### PR TITLE
feat: per-site browser environments + pinnable companion window (+ panel crash fix)

### DIFF
--- a/agent-station-menu-bar-app-mac/AgentStationMenuBar.xcodeproj/project.pbxproj
+++ b/agent-station-menu-bar-app-mac/AgentStationMenuBar.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		03BD5C7FA0B15F77C932DE37 /* ApiTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33D7EC80FA5DF7CCDEEC7EE1 /* ApiTypes.swift */; };
 		0525A743E9AC784FDBB588A7 /* EnvironmentOfferView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 250D92F99A204A2083C12D24 /* EnvironmentOfferView.swift */; };
+		0A0B574B5D1329B7F84E21D0 /* SiteRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7C7467689A6968FCF1CD78 /* SiteRegistry.swift */; };
 		0B134C58418DD780F5A12153 /* ChatBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DA9F4DC6F40FA54C493ECBA /* ChatBlocks.swift */; };
 		148A0D946E42C6C58EF97504 /* ForegroundAppMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56E028A064E01DB239EF9BC8 /* ForegroundAppMonitor.swift */; };
 		22D62BE8921A8A1065BB3036 /* InputSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58D3F218942BD019D3DDA6CB /* InputSynthesizer.swift */; };
@@ -40,6 +41,7 @@
 		56E028A064E01DB239EF9BC8 /* ForegroundAppMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForegroundAppMonitor.swift; sourceTree = "<group>"; };
 		58D3F218942BD019D3DDA6CB /* InputSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSynthesizer.swift; sourceTree = "<group>"; };
 		666566F6A2304DA00C88DEB8 /* AXReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXReader.swift; sourceTree = "<group>"; };
+		7B7C7467689A6968FCF1CD78 /* SiteRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteRegistry.swift; sourceTree = "<group>"; };
 		8DA9F4DC6F40FA54C493ECBA /* ChatBlocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatBlocks.swift; sourceTree = "<group>"; };
 		8E81B5AF9FD7C49311CD9F8D /* PanelComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelComponents.swift; sourceTree = "<group>"; };
 		A069F1000D2ABAA2A0A5BB2A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -85,6 +87,7 @@
 				3F31550B0FC16B45A28AC6A8 /* ScreenCapturer.swift */,
 				12D6061688BD621BFB9EE467 /* ScreenOCR.swift */,
 				12CFA614EF2FB8F0294B9AA1 /* ServerController.swift */,
+				7B7C7467689A6968FCF1CD78 /* SiteRegistry.swift */,
 				F1E653A9EE4D362F78F1994C /* VoiceController.swift */,
 			);
 			path = Services;
@@ -153,9 +156,10 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = AA1E49DB37EE969F7ED96AF6 /* Build configuration list for PBXProject "AgentStationMenuBar" */;
-			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -165,6 +169,7 @@
 			mainGroup = 120304F0E89A7A3A55E77DC8;
 			minimizedProjectReferenceProxies = 1;
 			preferredProjectObjectVersion = 77;
+			productRefGroup = 6531BA041A16E45440F35492 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -197,6 +202,7 @@
 				84BE433C9AF6C6B230C57083 /* ScreenCapturer.swift in Sources */,
 				89F7CFCF7CC7ADB692165339 /* ScreenOCR.swift in Sources */,
 				A08FF032D5689105E28BC656 /* ServerController.swift in Sources */,
+				0A0B574B5D1329B7F84E21D0 /* SiteRegistry.swift in Sources */,
 				8238B67CD800928945EDBCAA /* VoiceController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/agent-station-menu-bar-app-mac/Sources/Models/AgentStationModel.swift
+++ b/agent-station-menu-bar-app-mac/Sources/Models/AgentStationModel.swift
@@ -62,6 +62,10 @@ final class AgentStationModel: ObservableObject {
 
     // Foreground-app environment provider + Mac bridge (Tier 1/2)
     @Published var foregroundEnvironmentId: String?
+    // Per-site environment when a browser is frontmost on a recognized site
+    // (e.g. web:wikipedia), tracked independently of the per-app environment so
+    // both can be active at once.
+    @Published var foregroundSiteEnvironmentId: String?
     @Published var foregroundAppName: String?
     @Published var foregroundWindowTitle: String?
     @Published var accessibilityTrusted = false
@@ -338,12 +342,12 @@ final class AgentStationModel: ObservableObject {
         bridge.stop()
         hotKey.stop()
         voice.stopSpeaking()
-        let environmentToRelease = foregroundEnvironmentId
+        let environmentsToRelease = [foregroundEnvironmentId, foregroundSiteEnvironmentId].compactMap { $0 }
         Task {
-            // Best-effort: end the foreground episode so the server doesn't
+            // Best-effort: end the foreground/site episodes so the server doesn't
             // keep a stale availability after we're gone.
-            if let environmentToRelease {
-                try? await api.markEnvironmentUnavailable(id: environmentToRelease)
+            for environmentId in environmentsToRelease {
+                try? await api.markEnvironmentUnavailable(id: environmentId)
             }
             if managedServerRunning {
                 serverController.stop()
@@ -818,6 +822,7 @@ final class AgentStationModel: ObservableObject {
         let environmentId = knownAppEnvironmentSlug(for: app).map { "app:\($0)" }
         providerLog("foreground: \(app.name) [\(app.bundleId)] title=\(title ?? "nil") -> \(environmentId ?? "no environment")")
         updateBridgeContext(app: app, title: title, environmentId: environmentId)
+        reconcileSiteEnvironment(for: app)
         guard environmentId != foregroundEnvironmentId else {
             return
         }
@@ -847,12 +852,61 @@ final class AgentStationModel: ObservableObject {
         }
     }
 
-    /// In-app context change (e.g. switching Slack channels) — refresh the
-    /// bridge's live /context without re-registering the environment.
+    /// In-app context change (e.g. switching Slack channels, or navigating to a
+    /// new page/tab in a browser) — refresh the bridge's live /context and, for
+    /// browsers, re-resolve the per-site environment.
     private func handleContextRefresh(app: ForegroundApp, title: String?) {
         foregroundAppName = app.name
         foregroundWindowTitle = title
         updateBridgeContext(app: app, title: title, environmentId: foregroundEnvironmentId)
+        reconcileSiteEnvironment(for: app)
+    }
+
+    // MARK: - Per-site environment provider
+
+    /// Browsers whose active-tab URL we resolve to a per-site environment.
+    private static let browserBundleIds: Set<String> = [
+        "com.google.Chrome", "com.google.Chrome.beta", "com.google.Chrome.canary", "com.google.Chrome.dev",
+        "com.apple.Safari", "com.apple.SafariTechnologyPreview",
+        "company.thebrowser.Browser",
+        "com.brave.Browser", "com.brave.Browser.beta", "com.brave.Browser.nightly",
+        "com.microsoft.edgemac", "com.microsoft.edgemac.Beta",
+        "com.vivaldi.Vivaldi", "com.operasoftware.Opera",
+    ]
+
+    /// When a browser is frontmost on a recognized site, register `web:<slug>`
+    /// alongside the per-app environment; clear it when leaving the site/browser.
+    private func reconcileSiteEnvironment(for app: ForegroundApp) {
+        var match: SiteRegistry.Match?
+        if Self.browserBundleIds.contains(app.bundleId),
+           let url = AXReader.activeTabURL(pid: app.pid) {
+            match = SiteRegistry.match(url: url, repoRoot: ServerController.repoRoot)
+        }
+        let newSiteEnv = match?.environmentId
+        guard newSiteEnv != foregroundSiteEnvironmentId else {
+            return
+        }
+        let previous = foregroundSiteEnvironmentId
+        foregroundSiteEnvironmentId = newSiteEnv
+        providerLog("site: \(app.bundleId) -> \(newSiteEnv ?? "no site environment")")
+        Task {
+            do {
+                if let previous {
+                    try await api.markEnvironmentUnavailable(id: previous)
+                    providerLog("site unavailable ok: \(previous)")
+                }
+                if let newSiteEnv, let match {
+                    try await api.registerEnvironment(
+                        id: newSiteEnv,
+                        sourceName: match.sourceName,
+                        metadata: ["bundleId": .string(app.bundleId)]
+                    )
+                    providerLog("site register ok: \(newSiteEnv)")
+                }
+            } catch {
+                providerLog("site provider error: \(error.localizedDescription)")
+            }
+        }
     }
 
     // MARK: - Mac bridge (Tier 2)
@@ -1140,16 +1194,26 @@ final class AgentStationModel: ObservableObject {
     /// Re-announce the current foreground environment after the server comes
     /// (back) up — registrations are in-memory server state and die with it.
     private func reannounceForegroundEnvironment() {
-        guard let environmentId = foregroundEnvironmentId,
-              let app = foregroundMonitor.current else {
+        guard let app = foregroundMonitor.current else {
             return
         }
+        let environmentId = foregroundEnvironmentId
+        let siteEnvironmentId = foregroundSiteEnvironmentId
         Task {
-            try? await api.registerEnvironment(
-                id: environmentId,
-                sourceName: app.name,
-                metadata: ["bundleId": .string(app.bundleId)]
-            )
+            if let environmentId {
+                try? await api.registerEnvironment(
+                    id: environmentId,
+                    sourceName: app.name,
+                    metadata: ["bundleId": .string(app.bundleId)]
+                )
+            }
+            if let siteEnvironmentId {
+                try? await api.registerEnvironment(
+                    id: siteEnvironmentId,
+                    sourceName: siteEnvironmentId,
+                    metadata: ["bundleId": .string(app.bundleId)]
+                )
+            }
         }
     }
 
@@ -1217,5 +1281,17 @@ final class AgentStationModel: ObservableObject {
         if panelMode == .environmentOffer {
             dismissOfferView()
         }
+    }
+}
+
+/// Forwards the companion panel's close (red button or unpin) back to the model
+/// so pin state stays in sync. A standalone NSObject because the model itself
+/// isn't NSObject-rooted and so can't be an NSWindowDelegate directly.
+@MainActor
+final class PanelWindowDelegate: NSObject, NSWindowDelegate {
+    var onClose: () -> Void = {}
+
+    func windowWillClose(_ notification: Notification) {
+        onClose()
     }
 }

--- a/agent-station-menu-bar-app-mac/Sources/Models/AgentStationModel.swift
+++ b/agent-station-menu-bar-app-mac/Sources/Models/AgentStationModel.swift
@@ -25,6 +25,12 @@ final class AgentStationModel: ObservableObject {
     // where the user left off after the MenuBarExtra window closes.
     @Published var panelMode: PanelMode = .home
 
+    // When pinned, the panel is detached into a floating companion window that
+    // stays over whatever app you're working in until you close it. The
+    // MenuBarExtra dropdown can't do that (AppKit dismisses it on focus loss),
+    // so "keep open" means promoting it to a real window.
+    @Published var windowIsPinned = false
+
     // Server / control plane
     @Published var serverState: ServerState = .unknown
     @Published var managedServerRunning = false
@@ -85,6 +91,7 @@ final class AgentStationModel: ObservableObject {
     private var autoResumeAttempted = false
     private var reconnectTask: Task<Void, Never>?
     private var panelWindow: NSWindow?
+    private let panelWindowDelegate = PanelWindowDelegate()
 
     init() {
         AgentStationModel.shared = self
@@ -275,24 +282,54 @@ final class AgentStationModel: ObservableObject {
         }
     }
 
+    /// Pin → detach the panel into a floating companion window; unpin → close it.
+    func togglePinnedWindow() {
+        if let panelWindow {
+            panelWindow.close()
+        } else {
+            openPanelWindow()
+        }
+    }
+
     func openPanelWindow() {
         if let panelWindow {
             panelWindow.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
+            windowIsPinned = true
             return
         }
         let controller = NSHostingController(rootView: AgentStationMenuView(model: self))
         controller.sizingOptions = [.preferredContentSize]
-        let window = NSWindow(contentViewController: controller)
-        window.title = "Agent Station"
-        window.titlebarAppearsTransparent = true
-        window.titleVisibility = .hidden
-        window.isMovableByWindowBackground = true
-        window.isReleasedWhenClosed = false
-        window.center()
-        window.makeKeyAndOrderFront(nil)
+        // A non-activating floating panel stays above other apps and is visible
+        // on every Space, so it can ride along as a companion while you work —
+        // and clicking into it (e.g. the chat composer) won't yank focus away
+        // from the app you're in.
+        let panel = NSPanel(contentViewController: controller)
+        panel.styleMask = [.titled, .closable, .fullSizeContentView, .nonactivatingPanel]
+        panel.isFloatingPanel = true
+        panel.level = .floating
+        // .canJoinAllSpaces and .moveToActiveSpace are mutually exclusive —
+        // setting both makes NSWindow throw in _validateCollectionBehavior:.
+        // A companion panel should be visible on every Space, so keep the former.
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        panel.hidesOnDeactivate = false
+        panel.title = "Agent Station"
+        panel.titlebarAppearsTransparent = true
+        panel.titleVisibility = .hidden
+        panel.isMovableByWindowBackground = true
+        panel.isReleasedWhenClosed = false
+        panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+        panel.standardWindowButton(.zoomButton)?.isHidden = true
+        panelWindowDelegate.onClose = { [weak self] in
+            self?.panelWindow = nil
+            self?.windowIsPinned = false
+        }
+        panel.delegate = panelWindowDelegate
+        panel.center()
+        panel.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
-        panelWindow = window
+        panelWindow = panel
+        windowIsPinned = true
     }
 
     func quitApp() {

--- a/agent-station-menu-bar-app-mac/Sources/Models/AgentStationModel.swift
+++ b/agent-station-menu-bar-app-mac/Sources/Models/AgentStationModel.swift
@@ -340,9 +340,7 @@ final class AgentStationModel: ObservableObject {
     func openAgentSessions(_ agentId: String) {
         sessions = []
         sessionsError = ""
-        withAnimation(.easeInOut(duration: 0.16)) {
-            panelMode = .sessions(agentId: agentId)
-        }
+        panelMode = .sessions(agentId: agentId)
         Task {
             await loadSessions(agentId: agentId)
         }
@@ -413,25 +411,19 @@ final class AgentStationModel: ObservableObject {
         }
         socket.connect(sessionId: session.id, webSocketURL: api.webSocketURL)
         if switchToChat {
-            withAnimation(.easeInOut(duration: 0.16)) {
-                panelMode = .chat
-            }
+            panelMode = .chat
         }
     }
 
     func goHome() {
-        withAnimation(.easeInOut(duration: 0.16)) {
-            panelMode = .home
-        }
+        panelMode = .home
     }
 
     func openChat() {
         guard currentSession != nil else {
             return
         }
-        withAnimation(.easeInOut(duration: 0.16)) {
-            panelMode = .chat
-        }
+        panelMode = .chat
     }
 
     // MARK: - Chat
@@ -1142,9 +1134,7 @@ final class AgentStationModel: ObservableObject {
             }
             offerLoading = false
         }
-        withAnimation(.easeInOut(duration: 0.16)) {
-            panelMode = .environmentOffer
-        }
+        panelMode = .environmentOffer
     }
 
     private func handleEnvironmentOfferResolved(_ environmentId: String) {
@@ -1158,9 +1148,7 @@ final class AgentStationModel: ObservableObject {
         guard pendingOffer != nil else {
             return
         }
-        withAnimation(.easeInOut(duration: 0.16)) {
-            panelMode = .environmentOffer
-        }
+        panelMode = .environmentOffer
     }
 
     func decideEnvironment(_ decision: String) {
@@ -1182,9 +1170,7 @@ final class AgentStationModel: ObservableObject {
     }
 
     func dismissOfferView() {
-        withAnimation(.easeInOut(duration: 0.16)) {
-            panelMode = currentSession != nil ? .chat : .home
-        }
+        panelMode = currentSession != nil ? .chat : .home
     }
 
     private func clearOfferAndReturn() {

--- a/agent-station-menu-bar-app-mac/Sources/Services/AXReader.swift
+++ b/agent-station-menu-bar-app-mac/Sources/Services/AXReader.swift
@@ -56,6 +56,55 @@ enum AXReader {
         return (title?.isEmpty == false) ? title : nil
     }
 
+    /// The active tab's URL for a Chromium/WebKit browser owning `pid`, read from
+    /// the focused window's AXWebArea (AXURL). Relies on the web-content tree, so
+    /// the browser should have been primed (it comes forward → primeAccessibility).
+    /// Returns nil for non-browsers or before the URL is exposed.
+    static func activeTabURL(pid: pid_t, maxNodes: Int = 600) -> String? {
+        guard isTrusted() else {
+            return nil
+        }
+        let appElement = AXUIElementCreateApplication(pid)
+        enableWebContentAccessibility(appElement)
+        var windowRef: AnyObject?
+        if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) != .success {
+            if AXUIElementCopyAttributeValue(appElement, kAXMainWindowAttribute as CFString, &windowRef) != .success {
+                return nil
+            }
+        }
+        guard let windowRef else {
+            return nil
+        }
+        // Breadth-first: the web area sits near the top of the window subtree.
+        var queue: [AXUIElement] = [windowRef as! AXUIElement]
+        var budget = maxNodes
+        while !queue.isEmpty, budget > 0 {
+            let element = queue.removeFirst()
+            budget -= 1
+            if stringAttribute(element, kAXRoleAttribute as String) == "AXWebArea",
+               let url = urlAttribute(element, "AXURL") {
+                return url
+            }
+            var childrenRef: AnyObject?
+            if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+               let children = childrenRef as? [AXUIElement] {
+                queue.append(contentsOf: children)
+            }
+        }
+        return nil
+    }
+
+    private static func urlAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success, let value else {
+            return nil
+        }
+        if let url = value as? NSURL {
+            return url.absoluteString
+        }
+        return value as? String
+    }
+
     /// Visible text of the focused window, extracted by walking the
     /// Accessibility tree (value/title/description of each element). Gives the
     /// agent on-screen *content* — editor text, chat messages, labels — for

--- a/agent-station-menu-bar-app-mac/Sources/Services/SiteRegistry.swift
+++ b/agent-station-menu-bar-app-mac/Sources/Services/SiteRegistry.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Resolves a browser URL to a per-site environment (`web:<slug>`) using the
+/// Chrome extension's `site-registry.json` as the shared source of truth, so a
+/// site recognized by the extension is recognized natively too. This is the
+/// per-site companion to the foreground provider's per-app resolution: on a
+/// recognized site the agent gets the app's generic web skills *and* the
+/// site-specific skill bundle.
+enum SiteRegistry {
+    struct Match {
+        let environmentId: String
+        let sourceName: String
+    }
+
+    private struct RegistryFile: Decodable {
+        let sites: [Site]?
+        struct Site: Decodable {
+            let id: String
+            let environmentId: String?
+            let sourceName: String?
+            let hostSuffixes: [String]?
+            let hostsExact: [String]?
+        }
+    }
+
+    /// Resolve `url` to a known site environment, or nil. Only returns a match
+    /// whose skill bundle exists on disk (`environment-repository/<kind>/<path>`),
+    /// mirroring the app provider's disk check so we never raise an empty offer.
+    static func match(url: String, repoRoot: URL) -> Match? {
+        guard let host = URLComponents(string: url)?.host?.lowercased() else {
+            return nil
+        }
+        let registryURL = repoRoot.appending(path: "agent-station-chrome-extension/site-registry.json")
+        guard let data = try? Data(contentsOf: registryURL),
+              let file = try? JSONDecoder().decode(RegistryFile.self, from: data),
+              let sites = file.sites else {
+            return nil
+        }
+        for site in sites {
+            let exact = site.hostsExact?.contains { $0.lowercased() == host } ?? false
+            let suffix = site.hostSuffixes?.contains { host.hasSuffix($0.lowercased()) } ?? false
+            guard exact || suffix else {
+                continue
+            }
+            let environmentId = site.environmentId ?? "web:\(site.id)"
+            let parts = environmentId.split(separator: ":", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else {
+                continue
+            }
+            let dir = repoRoot.appending(path: "environment-repository/\(parts[0])/\(parts[1])")
+            guard FileManager.default.fileExists(atPath: dir.path) else {
+                continue
+            }
+            return Match(environmentId: environmentId, sourceName: site.sourceName ?? site.id)
+        }
+        return nil
+    }
+}

--- a/agent-station-menu-bar-app-mac/Sources/Views/AgentStationMenuView.swift
+++ b/agent-station-menu-bar-app-mac/Sources/Views/AgentStationMenuView.swift
@@ -588,6 +588,12 @@ private struct HomeContent: View {
             FooterIconButton(title: "Refresh", systemImage: "arrow.clockwise") {
                 model.refreshNow()
             }
+            FooterIconButton(
+                title: model.windowIsPinned ? "Close Companion Window" : "Keep Open as Companion",
+                systemImage: model.windowIsPinned ? "pin.slash" : "pin"
+            ) {
+                model.togglePinnedWindow()
+            }
             Spacer(minLength: 0)
             FooterIconButton(title: "Quit", systemImage: "xmark.circle") {
                 model.quitApp()

--- a/agent-station-menu-bar-app-mac/Sources/Views/AgentStationMenuView.swift
+++ b/agent-station-menu-bar-app-mac/Sources/Views/AgentStationMenuView.swift
@@ -11,34 +11,30 @@ struct AgentStationMenuView: View {
             switch model.panelMode {
             case .home:
                 HomeContent(model: model)
-                    .transition(detailTransition(edge: .leading))
             case .sessions(let agentId):
                 SessionsDetail(model: model, agentId: agentId)
-                    .transition(detailTransition(edge: .trailing))
             case .chat:
                 ChatDetail(model: model)
-                    .transition(detailTransition(edge: .trailing))
             case .environmentOffer:
                 EnvironmentOfferDetail(model: model)
-                    .transition(detailTransition(edge: .trailing))
             }
         }
         .padding(12)
         .frame(width: panelWidth, alignment: .topLeading)
         .background(PanelBackground())
         .environment(\.colorScheme, .dark)
-        .animation(.easeInOut(duration: 0.18), value: model.panelMode)
         .onAppear {
             model.refreshNow()
         }
     }
 
+    // Panel size is applied WITHOUT animation. Animating the hosting view's
+    // content size (here, the 372↔460 width on mode switches) makes AppKit
+    // resize the window mid–constraint-pass and trap inside
+    // NSHostingView.updateWindowContentSizeExtremaIfNecessary — crashing the
+    // app, including on launch when hosted in the companion NSPanel.
     private var panelWidth: CGFloat {
         model.panelMode == .home ? homePanelWidth : detailPanelWidth
-    }
-
-    private func detailTransition(edge: Edge) -> AnyTransition {
-        .move(edge: edge).combined(with: .opacity)
     }
 }
 


### PR DESCRIPTION
## Summary
Builds on main's foreground-app context provider with **per-site (browser-tab) environments**, a **pinnable companion window**, and a **panel crash fix**. Three focused commits:

1. **fix: stop animating the menu bar panel size** — animating the panel's content size on mode switches (the 372↔460 width change, via the view's `.animation`/`.transition` and the model's `withAnimation` wrappers) makes AppKit resize the hosting window mid–constraint-pass and trap in `NSHostingView.updateWindowContentSizeExtremaIfNecessary`. Crashed on the Back button and on companion-window launch. Mode switches now resize instantly.
2. **feat: pinnable floating companion window** — "Keep Open as Companion" detaches the panel into a non-activating floating `NSPanel` (all Spaces, stays above other apps), surviving focus loss unlike the MenuBarExtra dropdown. Also covers the hidden-menu-bar-icon case on notch Macs.
3. **feat: per-site environments from the active browser tab** — when a browser is frontmost, `AXReader.activeTabURL` reads the active tab URL (`AXWebArea` `AXURL`) and `SiteRegistry` resolves it against the Chrome extension's `site-registry.json` to a `web:<slug>` environment, registered **alongside** the per-app environment. So on a known site the agent gets the app's generic web skills *and* the site-specific skill. Registers only when the skill bundle exists on disk, mirroring the app provider.

## Verification
- Per-app provider (Slack, Chrome) and the per-site path (a `web:<slug>` registering alongside `app:google-chrome`) confirmed live via the provider log.
- Back button and companion window no longer crash.
- App + server build clean (`xcodebuild`, `tsc --noEmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)