### PR TITLE
Add dual-bind remote access and bearer auth setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env and adjust for your machine.
+
+# Server port.
+PORT=3000
+
+# Rook always binds localhost for on-machine clients.
+# Optional: add a second listener on a specific remote-reachable interface/address.
+# Example: ROOK_BIND_IP=100.64.12.34
+ROOK_BIND_IP=
+
+# Optional: require this bearer token for non-loopback HTTP/WebSocket requests.
+# Generate a long random string.
+# ROOK_AUTH_TOKEN=
+
+# Optional helper for ./scripts/run-rook.sh phone when the phone should use a
+# hostname instead of the raw bind IP.
+# Example: ROOK_REMOTE_HOSTNAME=your-computer.example.net
+ROOK_REMOTE_HOSTNAME=

--- a/PRODUCT/AS-BUILT-ARCHITECTURE.md
+++ b/PRODUCT/AS-BUILT-ARCHITECTURE.md
@@ -8,6 +8,10 @@ This document is the short, current architecture description for the repo as it 
 
 Rookery is a local-first monorepo centered on one service at `127.0.0.1:3000`:
 
+- the server always binds loopback for on-machine clients
+- it may also expose a second listener on a configured remote/VPN address for phone access
+- non-loopback access is expected to be protected by a bearer token
+
 - a **Fastify server**
 - a **React Native web chat UI**
 - a **WebSocket ACP bridge** to agent runtimes
@@ -91,6 +95,11 @@ It wires together:
 - React app hosting
 
 The server is now API/websocket-only; native clients and debug scripts connect to it directly.
+
+Network exposure model as built:
+- localhost/macOS clients talk to the loopback listener
+- remote phone access is served by a second remote listener rather than broad `0.0.0.0` binding
+- auth is enforced for non-loopback HTTP + WebSocket access
 
 ### 5.2 Session rooms
 

--- a/README.md
+++ b/README.md
@@ -1,155 +1,33 @@
 # Rook
 
-Monorepo for local Pi agents, an [Agent Client Protocol (ACP)](https://agentclientprotocol.com/get-started/introduction)-oriented chat runtime, and host clients/providers.
+Rook is a local-first personal-agent runtime built around ACP (Agent Client Protocol). The repo contains the server, native clients, and supporting docs.
 
-ACP standardizes JSON-RPC between editors/clients and coding agents. Here, the browser (and macOS menu bar client) talk ACP over WebSocket to `:3000`; each agent runtime is an ACP stdio subprocess (`pi-acp`, Claude's `claude-agent-acp`, Cursor's `agent acp`, etc.). Product notes: [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md).
+## Start here
 
-## Top-level packages
+- [Docs index](docs/README.md)
+- [Setup](docs/setup.md)
+- [Configuration](docs/configuration.md)
+- [Product / architecture notes](PRODUCT/)
 
-| Package | Role |
-|---------|------|
-| [server](server/) | Backend/runtime package: Fastify API, session/runtime orchestration, environment manager, and ACP-backed agent adapters |
-| [clients/](clients/) | Home for the remaining native clients |
-| [clients/mac](clients/mac/) | Native SwiftUI macOS menu bar client with full chat/session/environment support; also registers `app:<slug>` environments based on the frontmost Mac app |
-| [clients/iphone](clients/iphone/) | Native SwiftUI iPhone client that registers `loc:<slug>` environments from geofences and adds Live Activity / Dynamic Island + voice support |
-| [clients/RookKit](clients/RookKit/) | Shared cross-platform Swift package (iOS + macOS): models, REST/ACP-WebSocket clients, design system/chat views, voice, and Live Activity attributes |
-| [dummy-client](dummy-client/) | Port-3000 postMessage debug stub |
+## Packages
 
-External dependency: a sibling Pi agent package at `../my-agent/` (not checked into this repo) provides the agent/skill environment referenced by the default Pi profile.
+- [server/](server/) — Fastify API, session/runtime orchestration, environment manager, ACP-backed agent adapters
+- [clients/mac](clients/mac/) — native macOS menu bar client
+- [clients/iphone](clients/iphone/) — native iPhone client
+- [clients/RookKit](clients/RookKit/) — shared Swift package for the native clients
 
-Use the package READMEs above as the main lookup docs for each area. Repo docs now live in [`docs/`](docs/), starting with [`docs/configuration.md`](docs/configuration.md).
+## Common entry points
 
-## Quick start
-1. Install **pi.dev / Pi** first, and make sure the `pi` CLI is on your `PATH`.
-   Rook's ACP-backed Pi adapter still shells out to `pi`; without that install, Pi agents will not start.
-2. Make sure the sibling agent package exists at `../my-agent/`.
-   This repo expects that path relative to `server/`, so the default profile resolves it as `rookery_ai/server/../my-agent`.
-3. Install the backend deps:
-   ```bash
-   cd server && npm install
-   ```
-4. From the repo root, start the main dev stack:
-   ```bash
-   npm run dev
-   ```
-   Or use the unified launcher:
-   ```bash
-   ./scripts/run-rook.sh server   # server only
-   ./scripts/run-rook.sh mac      # server + macOS menu bar app
-   ./scripts/run-rook.sh sim      # server + iPhone simulator app
-   ./scripts/run-rook.sh phone    # server + physical iPhone app
-   ./scripts/run-rook.sh stop     # stop server + launched apps/simulators
-   ```
-   On macOS, `run-rook.sh` now starts the server in Terminal.app so Pi keeps
-   Terminal's Downloads/Desktop/Documents permissions instead of losing them in
-   a detached `nohup` process.
-5. The server listens on `http://127.0.0.1:3000`
+- `./scripts/run-rook.sh server`
+- `./scripts/run-rook.sh mac`
+- `./scripts/run-rook.sh sim`
+- `./scripts/run-rook.sh phone`
+- `./scripts/run-rook.sh stop`
 
-## iPhone + home server onboarding with Tailscale
+## High-level docs map
 
-Rook works well as a "phone client talks to an always-on home agent" setup.
-A common arrangement is:
-
-- a spare Mac, Mac mini, or laptop at home runs the Rook server
-- your iPhone runs the native Rook client
-- both devices join the same [Tailscale](https://tailscale.com/) tailnet
-- the iPhone connects to the server through the Mac's Tailscale MagicDNS name
-
-Typical setup flow:
-
-1. Create a Tailscale account.
-2. Install the Tailscale app on the Mac that will host the Rook server.
-3. Install the Tailscale app on your iPhone.
-4. Sign both devices into the same tailnet.
-5. In Tailscale, note the Mac's MagicDNS hostname (something like
-   `your-mac.tailxxxx.ts.net`).
-6. Start the Rook server on the Mac.
-7. Point the iPhone client at `http://<your-mac>.ts.net:3000`.
-
-The `./scripts/run-rook.sh phone` launcher is set up for exactly this flow: it
-launches the iPhone app using the Mac's Tailscale MagicDNS hostname by default.
-Once both devices are on Tailscale, the phone can talk securely to the server
-from anywhere with internet access — not just when both are on the same Wi-Fi.
-
-Quick troubleshooting:
-
-- On the iPhone, open Safari and visit:
-  - `http://<your-mac>.ts.net:3000/api/health`
-- Expected response:
-  - `{"ok":true,"service":"rook"}`
-- If Safari works but the app does not, confirm the Rook app's server setting is
-  exactly the same URL and reinstall/relaunch the app if needed.
-- If Safari does not work, the problem is almost certainly Tailscale setup,
-  device membership, or whether the server is actually running on the Mac.
-
-## Pi agent configuration
-Default user config lives in:
-- `~/.rook/config/agent-profiles.json`
-
-More detail: [`docs/configuration.md`](docs/configuration.md)
-
-Current default profile:
-```json
-{
-  "id": "MyPiAgent",
-  "type": "pi",
-  "parentId": "PiAgent",
-  "args": ["-e", "../my-agent"]
-}
-```
-
-Built-in agent parents now include:
-- `PiAgent`
-- `ClaudeAgent`
-
-What that means:
-- `id`: the agent name shown in Rook
-- `type: "pi"`: use the built-in Pi-flavored ACP launcher
-- `type: "claude"`: use the built-in Claude-flavored ACP launcher
-- `parentId: "PiAgent"`: group this profile under the built-in Pi agent
-- `args`: extra arguments passed to `pi` before `pi-acp` adds its RPC/session flags
-
-The important bit is:
-- Rookery now talks to Pi through **ACP**, not Pi RPC directly
-- `-e ../my-agent` still points Pi at the sibling agent package directory
-- the Pi launch helper is now generated internally at runtime; there is no checked-in wrapper script to maintain
-
-## `../my-agent/` layout
-`../my-agent/` is a separate sibling package, not part of this repo. Rook expects it to be your Pi agent/skills workspace.
-
-Typical responsibilities there:
-- agent instructions/prompts
-- installed or custom skills
-- skill metadata and implementations
-- any Pi-specific config that belongs to the agent package itself
-
-In short:
-- configure **which Pi agent package to launch** in `~/.rook/config/agent-profiles.json`
-- configure **the contents of that agent package** inside `../my-agent/`
-
-If you move or rename the sibling package, update `args` in `agent-profiles.json` accordingly.
-
-## Helpful scripts
-- `./scripts/interact-with-remote-agent.sh --agent PiAgent --omit-deltas "hello"` — exercise the server/client bridge without the web UI
-- `./scripts/interact-with-remote-agent.sh --raw-acp --agent PiAgent "hello"` — inspect raw ACP JSON-RPC traffic on the bridge
-- `./scripts/run-rook.sh server` — start the server only (or reuse the running one); on macOS this opens it in Terminal.app by default to preserve protected-folder access for Pi
-- `./scripts/run-rook.sh mac` — start the server if needed, rebuild, and launch the macOS menu bar app
-- `./scripts/run-rook.sh sim` — start the server if needed, rebuild, and launch the iPhone app in Simulator
-- `./scripts/run-rook.sh phone` — start the server if needed, rebuild, and launch the iPhone app on a paired device using your Mac's Tailscale MagicDNS hostname
-- `./scripts/run-rook.sh stop` — stop the server, mac app, simulator app, booted simulators, and phone app when reachable
-
-## Manual environment/debugging actions
-- Register an environment: `POST /api/environments/register`
-- Mark an environment unavailable: `POST /api/environments/unregister`
-- Record an environment decision: `POST /api/environments/decision`
-- Clear remembered environment decisions: remove `.var/rook/environment-decisions.sqlite`
-
-## Monorepo notes
-- `server/` currently owns the backend npm deps and lockfile
-- `server/src/shared/` now holds the TypeScript protocol/domain contracts used by the server and the debug bridge CLI
-- `clients/mac/` is a Swift/xcodegen package (not npm); the preferred local launcher is `./scripts/run-rook.sh mac`, though you can still build manually with `xcodegen generate` + `xcodebuild` — see its [README](clients/mac/README.md) for exact run steps and menu-bar troubleshooting
-- `clients/iphone/` is a Swift/xcodegen package (not npm); the preferred local launchers are `./scripts/run-rook.sh sim` and `./scripts/run-rook.sh phone` (which now uses Tailscale MagicDNS for physical devices). It depends on `clients/RookKit/` and adds a Widget extension for the Live Activity — see its [README](clients/iphone/README.md) for device/simulator run steps and location-testing
-- `clients/RookKit/` is a local Swift Package (iOS + macOS) holding the cross-platform layer shared by both Swift clients (models, REST/ACP clients, design system, voice, Live Activity attributes); build-check it with `cd clients/RookKit && swift build`
-- `environment-repository/` holds local environment-linked bundle content keyed by `<kind>/<path>` (`web/example.com`, `app/<slug>` for Mac apps fronted by the menu bar provider, and `loc/<slug>` for physical locations fronted by the iPhone provider). Environments can contain `.bundles/<bundle-id>/` directories with grouped `skills/`, `mcp-servers/`, and `apps/` content.
-- `scripts/` holds repo-level utilities
-- `PRODUCT/` holds product notes and evolving architecture docs
+- setup, `.env`, binding, and remote-access notes: [docs/setup.md](docs/setup.md)
+- agent-profile config: [docs/configuration.md](docs/configuration.md)
+- server package details: [server/README.md](server/README.md)
+- iPhone client details: [clients/iphone/README.md](clients/iphone/README.md)
+- macOS client details: [clients/mac/README.md](clients/mac/README.md)

--- a/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
+++ b/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
@@ -26,15 +26,13 @@ public final class AcpSocket {
 
     public init() {}
 
-    public func connect(sessionId: String, webSocketURL: URL) {
+    public func connect(sessionId: String, request: URLRequest) {
         teardown()
         generation += 1
         let currentGeneration = generation
         self.sessionId = sessionId
 
-        var components = URLComponents(url: webSocketURL, resolvingAgainstBaseURL: false)!
-        components.queryItems = [URLQueryItem(name: "sessionId", value: sessionId)]
-        let task = URLSession.shared.webSocketTask(with: components.url!)
+        let task = URLSession.shared.webSocketTask(with: request)
         self.task = task
         task.resume()
         setConnected(true)

--- a/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
+++ b/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
@@ -10,12 +10,22 @@ public struct RookAPIError: LocalizedError {
     public var errorDescription: String? { message }
 }
 
+public enum RookHealthResult: Equatable {
+    case ok
+    case unauthorized
+    case httpStatus(Int)
+    case transportError(String)
+}
+
 /// REST control plane for the Rook server.
 public struct RookAPI {
     public let baseURL: URL
+    public let authToken: String?
 
-    public init(baseURL: URL = URL(string: "http://127.0.0.1:3000")!) {
+    public init(baseURL: URL = URL(string: "http://127.0.0.1:3000")!, authToken: String? = nil) {
         self.baseURL = baseURL
+        let trimmed = authToken?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.authToken = (trimmed?.isEmpty == false) ? trimmed : nil
     }
 
     public var webSocketURL: URL {
@@ -27,15 +37,52 @@ public struct RookAPI {
 
     public var webAppURL: URL { baseURL }
 
-    public func health(timeout: TimeInterval = 1.5) async -> Bool {
-        var request = URLRequest(url: baseURL.appending(path: "api/health"))
+    public func webSocketRequest(sessionId: String) -> URLRequest {
+        var components = URLComponents(url: webSocketURL, resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "sessionId", value: sessionId)]
+        var request = authorizedRequest(url: components.url!)
+        request.timeoutInterval = 30
+        return request
+    }
+
+    public func healthResult(timeout: TimeInterval = 1.5) async -> RookHealthResult {
+        var request = authorizedRequest(url: baseURL.appending(path: "api/health"))
         request.timeoutInterval = timeout
-        guard let (data, response) = try? await URLSession.shared.data(for: request),
-              let http = response as? HTTPURLResponse, http.statusCode == 200,
-              let body = try? JSONDecoder().decode(JSONValue.self, from: data) else {
-            return false
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                return .transportError("Non-HTTP response")
+            }
+            switch http.statusCode {
+            case 200:
+                if let body = try? JSONDecoder().decode(JSONValue.self, from: data), body["ok"]?.boolValue == true {
+                    return .ok
+                }
+                return .transportError("Malformed health response")
+            case 401:
+                return .unauthorized
+            default:
+                return .httpStatus(http.statusCode)
+            }
+        } catch {
+            return .transportError(error.localizedDescription)
         }
-        return body["ok"]?.boolValue == true
+    }
+
+    public func healthStatus(timeout: TimeInterval = 1.5) async -> Int? {
+        switch await healthResult(timeout: timeout) {
+        case .ok: return 200
+        case .unauthorized: return 401
+        case .httpStatus(let code): return code
+        case .transportError: return nil
+        }
+    }
+
+    public func health(timeout: TimeInterval = 1.5) async -> Bool {
+        if case .ok = await healthResult(timeout: timeout) {
+            return true
+        }
+        return false
     }
 
     public func agents() async throws -> [AgentDefinition] {
@@ -127,7 +174,7 @@ public struct RookAPI {
         struct IdentifyResponse: Decodable {
             let candidates: [EnvironmentCandidate]
         }
-        var urlRequest = URLRequest(url: requestURL(path: path, query: [:]))
+        var urlRequest = authorizedRequest(url: requestURL(path: path, query: [:]))
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpBody = try JSONEncoder().encode(request)
@@ -160,7 +207,7 @@ public struct RookAPI {
     }
 
     private func get<T: Decodable>(path: String, query: [String: String]) async throws -> T {
-        let (data, response) = try await URLSession.shared.data(from: requestURL(path: path, query: query))
+        let (data, response) = try await URLSession.shared.data(for: authorizedRequest(url: requestURL(path: path, query: query)))
         try throwIfErrorResponse(data: data, response: response)
         return try JSONDecoder().decode(T.self, from: data)
     }
@@ -170,13 +217,21 @@ public struct RookAPI {
     }
 
     private func postJSON(path: String, payload: JSONValue) async throws -> JSONValue {
-        var request = URLRequest(url: requestURL(path: path, query: [:]))
+        var request = authorizedRequest(url: requestURL(path: path, query: [:]))
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(payload)
         let (data, response) = try await URLSession.shared.data(for: request)
         try throwIfErrorResponse(data: data, response: response)
         return try JSONDecoder().decode(JSONValue.self, from: data)
+    }
+
+    private func authorizedRequest(url: URL) -> URLRequest {
+        var request = URLRequest(url: url)
+        if let authToken {
+            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
+        }
+        return request
     }
 
     private func throwIfErrorResponse(data: Data, response: URLResponse) throws {

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -14,7 +14,8 @@ to `environment-repository/loc/office/` exactly the way
 
 UI, networking, models, chat rendering, and voice are shared with the macOS menu
 bar app through the [`RookKit`](../RookKit/) Swift package, so the two clients
-share one look and one protocol layer.
+share one look and one protocol layer. For repo-level setup, `.env`, remote
+binding, and bearer-token auth, start with [docs/setup.md](../../docs/setup.md).
 
 ## What it does
 
@@ -140,7 +141,7 @@ Fast paths from the repo root:
 
 `run-rook.sh sim` starts the server if needed, regenerates the Xcode project from `project.yml`, rebuilds incrementally, installs the fresh app into the selected simulator, and launches it with `ROOK_SERVER_BASE_URL=http://127.0.0.1:3000`.
 
-`run-rook.sh phone` does the same for a paired physical iPhone, requiring the app's server address to use your Mac's Tailscale MagicDNS name (`http://<your-mac>.ts.net:3000`) unless you explicitly override it with `--server-url`. You can also force a specific MagicDNS hostname with `ROOK_TAILSCALE_DNS_NAME`. It intentionally does **not** hardcode a development team into `project.yml`; pass `--team` / `ROOK_IOS_DEVELOPMENT_TEAM` when needed, or let the script auto-detect your local team for personal use.
+`run-rook.sh phone` does the same for a paired physical iPhone, using `ROOK_REMOTE_HOSTNAME` or `ROOK_BIND_IP` to determine a server address your phone can reach. The server itself still binds localhost for the Mac app; `ROOK_BIND_IP` adds the second remote listener. It intentionally does **not** hardcode a development team into `project.yml`; pass `--team` / `ROOK_IOS_DEVELOPMENT_TEAM` when needed, or let the script auto-detect your local team for personal use.
 
 Manual steps:
 
@@ -162,53 +163,69 @@ xcodebuild -project Rook.xcodeproj -scheme Rook \
 #    iPhone 14 Pro or newer simulator.
 ```
 
-For a **physical device**, the launcher script sets the base URL for you at launch time using your Mac's Tailscale MagicDNS hostname. If you run manually, set the base URL to the Tailscale address your phone can reach. The base URL is stored in `UserDefaults` (`RookModel.baseURLString`) and can also be overridden at launch with `ROOK_SERVER_BASE_URL`; the `NSAllowsLocalNetworking` ATS exception in `Info.plist` permits the cleartext connection.
+For a **physical device**, the launcher script sets the base URL for you at launch time using a reachable hostname when it can discover one. If you run manually, set the base URL to the hostname or IP address your phone can reach. The base URL is stored in `UserDefaults` (`RookModel.baseURLString`) and can also be overridden at launch with `ROOK_SERVER_BASE_URL`; the `NSAllowsLocalNetworking` ATS exception in `Info.plist` permits the cleartext connection.
 
-### Onboarding: iPhone client + home server over Tailscale
+### Onboarding: iPhone client + home server over a private remote network
 
 If you want Rook to live on a computer at home and stay reachable from your
-phone anywhere, Tailscale is the simplest setup.
+phone anywhere, use a private remote network or VPN.
 
 Typical arrangement:
 
 - a spare Mac, Mac mini, or laptop stays on at home and runs the Rook server
 - the iPhone runs the Rook client
-- both devices are signed into the same Tailscale tailnet
-- the iPhone talks to the server using the Mac's MagicDNS hostname
+- both devices can reach each other through your chosen private network
+- the iPhone talks to the server using the Mac's reachable hostname or IP
 
 Recommended flow:
 
-1. Create a Tailscale account.
-2. Install Tailscale on the Mac that will run the server.
-3. Install Tailscale on the iPhone.
-4. Sign both devices into the same tailnet.
-5. Copy the Mac's MagicDNS hostname from Tailscale (for example,
-   `johns-2024-macbook-pro.tail6ee26a.ts.net`).
-6. Start the Rook server on the Mac.
-7. Launch the iPhone app with `./scripts/run-rook.sh phone`, or manually set the
-   server URL in Rook's Settings screen to:
-   - `http://<your-mac>.ts.net:3000`
+1. Set up your preferred VPN or private remote network between the Mac and iPhone.
+2. Make sure the Mac has a reachable hostname or IP address on that network.
+3. Start the Rook server on the Mac.
+4. Launch the iPhone app with `./scripts/run-rook.sh phone`, or manually set the
+   server URL in Rook's Settings screen.
+
+A quick option is Tailscale:
+1. Install Tailscale on the Mac.
+2. Install Tailscale on the iPhone.
+3. Sign both devices into the same tailnet.
+4. Use the Mac's VPN hostname or IP address as the Rook server address.
 
 Once this is working, the phone can maintain a direct encrypted connection to
 that home machine from anywhere with internet access; the devices no longer
 need to share the same local network.
 
-### Troubleshooting Tailscale connectivity on iPhone
+### Trusting local development builds on iPhone
+
+On a physical iPhone, a freshly installed local development build may fail to
+open with an **Untrusted Developer** warning until you trust the developer
+certificate on the device.
+
+If that happens, go to:
+
+- **Settings**
+- **General**
+- **VPN & Device Management**
+- select your **Apple Development** identity
+- tap **Trust**
+
+Then relaunch the app.
+
+### Troubleshooting remote connectivity on iPhone
 
 If the iPhone app is not connecting, first test the network path outside the
 app:
 
 1. On the iPhone, open Safari.
-2. Visit:
-   - `http://<your-mac>.ts.net:3000/api/health`
+2. Visit your configured server health URL, for example:
+   - `http://<your-hostname>:3000/api/health`
 3. Expected result:
    - `{"ok":true,"service":"rook"}`
 
 That is the best intermediate test point:
 
-- If Safari **fails**, the issue is probably Tailscale itself: the phone may
-  not be connected, may be on the wrong tailnet, MagicDNS may be unavailable,
-  or the Mac may not be running the server.
+- If Safari **fails**, the issue is probably the remote network path itself, the
+  chosen hostname/IP, or whether the Mac is actually running the server.
 - If Safari **succeeds** but Rook fails, verify the server URL in the app's
   Settings screen exactly matches the working Safari URL, then relaunch or
   reinstall the app so it picks up the current configuration.
@@ -252,9 +269,8 @@ xcrun simctl io booted screenshot /tmp/rook.png   # screenshot the simulator
 - `NSSupportsLiveActivities = YES`.
 - `NSAppTransportSecurity → NSAllowsLocalNetworking = YES` for the localhost/LAN
   dev server.
-- `NSAppTransportSecurity → NSExceptionDomains → tail6ee26a.ts.net` allows
-  insecure HTTP/WebSocket loads to your Tailscale MagicDNS hostnames during
-  development.
+- If you use cleartext HTTP to a non-local hostname during development, add the
+  appropriate ATS exception domain for that hostname.
 
 ## Out of scope (follow-ups)
 

--- a/clients/iphone/Sources/Info.plist
+++ b/clients/iphone/Sources/Info.plist
@@ -35,20 +35,15 @@
 	<dict>
 		<key>NSAllowsLocalNetworking</key>
 		<true/>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>myth-eel.ts.net</key>
+			<key>ts.net</key>
 			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
 				<key>NSIncludesSubdomains</key>
 				<true/>
-			</dict>
-			<key>tail6ee26a.ts.net</key>
-			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
 		</dict>

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -6,6 +6,7 @@ import SwiftUI
 enum ServerState: Equatable {
     case unknown
     case offline
+    case unauthorized
     case online
 }
 
@@ -16,6 +17,7 @@ enum ServerState: Equatable {
 final class RookModel: ObservableObject {
     // Server / control plane
     @Published var serverState: ServerState = .unknown
+    @Published var serverDiagnostic = ""
     @Published var agents: [AgentDefinition] = []
     @Published var agentsError = ""
 
@@ -71,9 +73,10 @@ final class RookModel: ObservableObject {
     // Live Activity (Dynamic Island)
     private var liveActivity: Activity<RookActivityAttributes>?
 
-    // Server address (configurable for a physical device on the LAN; the
-    // simulator reaches the Mac's localhost directly).
+    // Server address + optional bearer token. The simulator usually reaches the
+    // local Mac directly; a physical device often uses a remote-reachable URL.
     @Published var baseURLString: String
+    @Published var authTokenString: String
 
     private(set) var api: RookAPI
     private let socket = AcpSocket()
@@ -98,8 +101,19 @@ final class RookModel: ObservableObject {
         } else {
             urlString = "http://127.0.0.1:3000"
         }
+        let envToken = ProcessInfo.processInfo.environment["ROOK_AUTH_TOKEN"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedToken = UserDefaults.standard.string(forKey: "RookAuthToken")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let authToken = (envToken?.isEmpty == false ? envToken : storedToken) ?? ""
+        if let envToken, !envToken.isEmpty, storedToken != envToken {
+            UserDefaults.standard.set(envToken, forKey: "RookAuthToken")
+        }
+        let finalURL = URL(string: urlString) ?? URL(string: "http://127.0.0.1:3000")!
         baseURLString = urlString
-        api = RookAPI(baseURL: URL(string: urlString) ?? URL(string: "http://127.0.0.1:3000")!)
+        authTokenString = authToken
+        api = RookAPI(
+            baseURL: finalURL,
+            authToken: authToken
+        )
 
         socket.onEvent = { [weak self] event in
             self?.handleSocketEvent(event)
@@ -360,14 +374,17 @@ final class RookModel: ObservableObject {
         }
     }
 
-    func setBaseURL(_ string: String) {
+    func setServerConnection(baseURL string: String, authToken token: String) {
         let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let url = URL(string: trimmed), url.scheme != nil else {
             return
         }
+        let trimmedToken = token.trimmingCharacters(in: .whitespacesAndNewlines)
         baseURLString = trimmed
+        authTokenString = trimmedToken
         UserDefaults.standard.set(trimmed, forKey: "RookServerBaseURL")
-        api = RookAPI(baseURL: url)
+        UserDefaults.standard.set(trimmedToken, forKey: "RookAuthToken")
+        api = RookAPI(baseURL: url, authToken: trimmedToken)
         socket.disconnect()
         currentSession = nil
         Task { await refreshHealth() }
@@ -376,17 +393,25 @@ final class RookModel: ObservableObject {
     // MARK: - Server lifecycle
 
     func refreshHealth() async {
-        let healthy = await api.health()
-        if healthy {
+        switch await api.healthResult() {
+        case .ok:
             let wasOnline = serverState == .online
             serverState = .online
+            serverDiagnostic = ""
             if !wasOnline {
                 await loadAgents()
                 reannouncePlaceEnvironment()
                 await autoResumeRecentSessionIfNeeded()
             }
-        } else {
+        case .unauthorized:
+            serverState = .unauthorized
+            serverDiagnostic = "Authorization header was rejected."
+        case .httpStatus(let code):
             serverState = .offline
+            serverDiagnostic = "HTTP \(code)"
+        case .transportError(let message):
+            serverState = .offline
+            serverDiagnostic = message
         }
     }
 
@@ -394,6 +419,7 @@ final class RookModel: ObservableObject {
         switch serverState {
         case .online: return isRunning ? "working" : "online"
         case .offline: return "offline"
+        case .unauthorized: return "unauthorized"
         case .unknown: return "checking…"
         }
     }
@@ -401,7 +427,7 @@ final class RookModel: ObservableObject {
     var serverStatusTint: Color {
         switch serverState {
         case .online: return PanelPalette.success
-        case .offline: return PanelPalette.danger
+        case .offline, .unauthorized: return PanelPalette.danger
         case .unknown: return PanelPalette.secondaryText
         }
     }
@@ -531,7 +557,7 @@ final class RookModel: ObservableObject {
         if resumed {
             appendBlock(.system(text: "Resumed session — earlier messages aren't replayed."))
         }
-        socket.connect(sessionId: session.id, webSocketURL: api.webSocketURL)
+        socket.connect(sessionId: session.id, request: api.webSocketRequest(sessionId: session.id))
         updateLiveActivity()
     }
 
@@ -660,7 +686,7 @@ final class RookModel: ObservableObject {
                 guard !Task.isCancelled else {
                     return
                 }
-                socket.connect(sessionId: session.id, webSocketURL: api.webSocketURL)
+                socket.connect(sessionId: session.id, request: api.webSocketRequest(sessionId: session.id))
                 reconnecting = false
                 deliverNextQueuedIfIdle()
             } else if !Task.isCancelled {

--- a/clients/iphone/Sources/Views/AgentPickerScreen.swift
+++ b/clients/iphone/Sources/Views/AgentPickerScreen.swift
@@ -27,7 +27,7 @@ struct AgentPickerScreen: View {
 
             PlaceCaption(model: model)
 
-            if model.serverState == .offline {
+            if model.serverState == .offline || model.serverState == .unauthorized {
                 offlineCard
             }
 
@@ -135,11 +135,20 @@ struct AgentPickerScreen: View {
 
     private var offlineCard: some View {
         PanelMessageView(
-            systemImage: "bolt.slash.fill",
+            systemImage: model.serverState == .unauthorized ? "lock.slash.fill" : "bolt.slash.fill",
             tint: PanelPalette.danger,
-            text: "Server unreachable at \(model.baseURLString). Run `npm run dev` on the Mac; tap the gear to change the address."
+            text: model.serverState == .unauthorized
+                ? "Server requires authorization at \(model.baseURLString). Check the bearer token in Settings."
+                : offlineText
         )
         .padding(16)
+    }
+
+    private var offlineText: String {
+        if model.serverDiagnostic.isEmpty {
+            return "Server unreachable at \(model.baseURLString). Run `npm run dev` on the Mac; tap the gear to change the address."
+        }
+        return "Server unreachable at \(model.baseURLString). \(model.serverDiagnostic)"
     }
 }
 

--- a/clients/iphone/Sources/Views/SettingsScreen.swift
+++ b/clients/iphone/Sources/Views/SettingsScreen.swift
@@ -9,6 +9,7 @@ struct SettingsScreen: View {
     @ObservedObject var model: RookModel
     @Environment(\.dismiss) private var dismiss
     @State private var serverDraft = ""
+    @State private var authTokenDraft = ""
 
     var body: some View {
         NavigationStack {
@@ -33,7 +34,10 @@ struct SettingsScreen: View {
             }
         }
         .tint(PanelPalette.accent)
-        .onAppear { serverDraft = model.baseURLString }
+        .onAppear {
+            serverDraft = model.baseURLString
+            authTokenDraft = model.authTokenString
+        }
     }
 
     // MARK: - Server
@@ -67,14 +71,33 @@ struct SettingsScreen: View {
                         .strokeBorder(PanelPalette.border)
                 )
 
-            Text("On a device, use your Mac's Tailscale MagicDNS name. The simulator reaches localhost directly.")
+            TextField("Bearer token (optional on localhost)", text: $authTokenDraft)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textContentType(.password)
+                .foregroundStyle(PanelPalette.textNormal)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(PanelPalette.backgroundPrimary.opacity(0.8))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .strokeBorder(PanelPalette.border)
+                )
+
+            Text("On a device, use a hostname or IP address your phone can reach. Add the bearer token if the server is configured to require one for non-local access.")
                 .font(.caption2)
                 .foregroundStyle(PanelPalette.textMuted)
 
             CompactActionButton(title: "Save & reconnect", systemImage: "arrow.clockwise", tint: PanelPalette.accent, prominence: .filled, helpText: "") {
-                model.setBaseURL(serverDraft)
+                model.setServerConnection(baseURL: serverDraft, authToken: authTokenDraft)
             }
-            .disabled(serverDraft.trimmingCharacters(in: .whitespacesAndNewlines) == model.baseURLString)
+            .disabled(
+                serverDraft.trimmingCharacters(in: .whitespacesAndNewlines) == model.baseURLString &&
+                authTokenDraft.trimmingCharacters(in: .whitespacesAndNewlines) == model.authTokenString
+            )
         }
     }
 

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -7,7 +7,8 @@ Scribe menu bar app; the visual design tokens are mirrored in the shared Swift
 layer so the native clients share one look. Functionality
 is the full Rook embeddable
 client, implemented natively against the server's REST + ACP JSON-RPC
-WebSocket protocol.
+WebSocket protocol. For repo-level setup, `.env`, binding, and auth, start with
+[docs/setup.md](../../docs/setup.md).
 
 ## Features
 

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -448,7 +448,7 @@ final class RookMacModel: ObservableObject {
         pendingPermission = nil
         lastStopReason = nil
         enteredEnvironments = []
-        socket.connect(sessionId: session.id, webSocketURL: api.webSocketURL)
+        socket.connect(sessionId: session.id, request: api.webSocketRequest(sessionId: session.id))
         if switchToChat {
             panelMode = .chat
         }
@@ -628,7 +628,7 @@ final class RookMacModel: ObservableObject {
                 guard !Task.isCancelled else {
                     return
                 }
-                socket.connect(sessionId: session.id, webSocketURL: api.webSocketURL)
+                socket.connect(sessionId: session.id, request: api.webSocketRequest(sessionId: session.id))
                 reconnecting = false
                 deliverNextQueuedIfIdle()
             } else if !Task.isCancelled {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 # Docs
 
+- [Setup](./setup.md)
 - [Configuration](./configuration.md)
+- [Agent profile example](./examples/agent-profiles.example.json)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,7 @@
 # Configuration
 
+For repo setup, `.env`, server binding, and remote-access notes, see [Setup](./setup.md).
+
 Rook stores user configuration in `~/.rook` by default.
 
 ## Config directory

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,180 @@
+# Setup
+
+This page covers first-run setup, local-vs-remote server binding, and the small `.env` knobs used by the repo.
+
+## Quick start
+
+1. Install **pi.dev / Pi** and make sure `pi` is on your `PATH`.
+2. Make sure the sibling agent package exists at `../my-agent/` if you plan to use the default Pi profile.
+3. Copy `.env.example` to `.env`.
+4. Install server deps:
+   ```bash
+   cd server && npm install
+   ```
+5. Start Rook from the repo root:
+   ```bash
+   ./scripts/run-rook.sh mac server
+   ```
+   or:
+   ```bash
+   npm run dev
+   ```
+
+## How binding works now
+
+Rook now always listens on:
+
+- `127.0.0.1`
+
+That keeps the local Mac client working.
+
+If you also set `ROOK_BIND_IP`, Rook adds a **second** listener on that address.
+That is the right setup when you want:
+
+- the Mac app to talk to Rook over localhost
+- the iPhone to talk to Rook over your VPN or other private remote network
+
+## `.env` variables
+
+Rook reads `.env` from the repo root.
+
+### `PORT`
+Server port. Default:
+
+```env
+PORT=3000
+```
+
+### `ROOK_BIND_IP`
+Optional second listener for remote phone access.
+
+Example:
+
+```env
+ROOK_BIND_IP=100.x.y.z
+```
+
+Important: this should be the **full local IP address assigned to your Mac on that remote network interface**.
+
+It is **not**:
+- a subnet
+- a CIDR block
+- a partial IP
+- “any device in the VPN”
+
+Binding is about **which address on your own machine the server listens on**.
+
+Other devices on the VPN can reach that listener because the VPN routes traffic to your Mac's bound address.
+
+### `ROOK_REMOTE_HOSTNAME`
+Optional helper for the phone launcher.
+
+```env
+ROOK_REMOTE_HOSTNAME=your-computer.example.net
+```
+
+If set, `./scripts/run-rook.sh phone` uses this hostname automatically.
+
+Use this when:
+- your phone should connect by hostname rather than raw IP
+- your VPN gives you a stable hostname
+- you prefer a DNS name over a numeric address
+
+If you do not set `ROOK_REMOTE_HOSTNAME`, the phone launcher next tries `ROOK_BIND_IP`.
+If neither is set, it stops and tells you what to configure.
+
+### `ROOK_AUTH_TOKEN`
+Optional bearer token for non-loopback access.
+
+Example:
+
+```env
+ROOK_AUTH_TOKEN=replace-with-a-long-random-string
+```
+
+Current behavior:
+- if unset, Rook has no app-level auth
+- if set, **non-loopback** HTTP and WebSocket requests must send `Authorization: Bearer <token>`
+- loopback requests from the same machine are still allowed without the token
+
+That keeps the local Mac app/dev flow lightweight while protecting remote phone access.
+
+## Common setups
+
+### Local-only Mac development
+
+```env
+PORT=3000
+ROOK_AUTH_TOKEN=
+```
+
+No remote phone access.
+
+### Mac + iPhone over a private remote network
+
+```env
+PORT=3000
+ROOK_BIND_IP=100.x.y.z
+ROOK_AUTH_TOKEN=replace-with-a-long-random-string
+```
+
+Then launch with:
+
+```bash
+./scripts/run-rook.sh mac phone
+```
+
+The launcher passes the server URL and auth token through to the iPhone app.
+
+### Mac + iPhone with hostname-based remote access
+
+```env
+PORT=3000
+ROOK_BIND_IP=100.x.y.z
+ROOK_REMOTE_HOSTNAME=your-hostname.example.net
+ROOK_AUTH_TOKEN=replace-with-a-long-random-string
+```
+
+The Mac app still uses localhost.
+The iPhone launcher uses `ROOK_REMOTE_HOSTNAME`.
+
+## Remote access notes
+
+For remote phone access you typically need:
+- the Mac and iPhone connected through the same private remote network or VPN
+- `ROOK_BIND_IP` set to the Mac's address on that network
+- the iPhone pointed at either that IP or a hostname that resolves to it
+
+A simple option is Tailscale. Briefly:
+- install it on the Mac and iPhone
+- sign both devices into the same network
+- find the Mac's VPN IP or hostname
+- put the IP into `ROOK_BIND_IP`
+- put the hostname into `ROOK_REMOTE_HOSTNAME`
+
+For iPhone development over plain HTTP, ATS can still be picky. In practice, prefer the hostname form (for example `...ts.net`) over a raw IP address.
+
+## iPhone developer trust
+
+On a physical iPhone, a freshly installed local dev build will often fail to open until you trust the developer certificate on the device.
+
+If iOS shows **Untrusted Developer**, go to:
+
+- **Settings**
+- **General**
+- **VPN & Device Management**
+- select your **Apple Development** identity
+- tap **Trust**
+
+Then relaunch the app.
+
+This is a normal part of running unsigned/local development builds on iPhone.
+
+## Security model, tersely
+
+- `127.0.0.1` means only the local machine can connect directly.
+- `ROOK_BIND_IP` adds one additional remote listener on your Mac.
+- it does **not** expose every interface the way `0.0.0.0` does.
+- `ROOK_AUTH_TOKEN` adds a second layer for remote access.
+
+For agent-profile config, see [Configuration](./configuration.md).

--- a/scripts/run-rook.sh
+++ b/scripts/run-rook.sh
@@ -3,12 +3,20 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/.env"
+  set +a
+fi
 RUN_ROOT="$REPO_ROOT/.var/run-rook"
 BUILD_ROOT="$RUN_ROOT/build"
 SERVER_LOG="$RUN_ROOT/server.log"
 SERVER_PIDFILE="$RUN_ROOT/server.pid"
 SERVER_PORT="${ROOK_SERVER_PORT:-3000}"
-SERVER_HEALTH_URL="http://127.0.0.1:${SERVER_PORT}/api/health"
+SERVER_BIND_HOST="127.0.0.1"
+SERVER_HEALTH_URL="http://${SERVER_BIND_HOST}:${SERVER_PORT}/api/health"
+SERVER_AUTH_TOKEN="${ROOK_AUTH_TOKEN:-}"
 
 mkdir -p "$RUN_ROOT" "$BUILD_ROOT"
 
@@ -17,8 +25,8 @@ usage() {
 Usage:
   ./scripts/run-rook.sh server
   ./scripts/run-rook.sh mac
-  ./scripts/run-rook.sh sim [--simulator NAME_OR_UDID] [--server-url URL] [--reset-permissions]
-  ./scripts/run-rook.sh phone [--device NAME_OR_UDID] [--team TEAM_ID] [--server-url URL] [--reset-permissions]
+  ./scripts/run-rook.sh sim [--simulator NAME_OR_UDID] [--reset-permissions]
+  ./scripts/run-rook.sh phone [--device NAME_OR_UDID] [--team TEAM_ID] [--reset-permissions]
   ./scripts/run-rook.sh mac sim
   ./scripts/run-rook.sh server mac sim
   ./scripts/run-rook.sh stop
@@ -32,11 +40,10 @@ What it does:
 Notes:
   - you can pass multiple targets; they run in the order given
   - mac uses localhost by default
-  - sim uses http://127.0.0.1:3000 by default
-  - phone requires your Mac's Tailscale MagicDNS name unless --server-url is provided
-  - on macOS, the server launches in Terminal.app so Pi keeps Terminal's
-    Downloads/Desktop/Documents permissions instead of losing them in a
-    detached nohup background process.
+  - sim uses http://127.0.0.1:3000
+  - phone uses ROOK_REMOTE_HOSTNAME, ROOK_BIND_IP, or a non-localhost ROOK_SERVER_HOST
+  - the server always binds localhost; ROOK_BIND_IP adds a second remote listener
+  - the server runs as a detached background process and logs to .var/run-rook/server.log
   - phone builds are intentionally NOT committed with a fixed team id;
     pass --team / ROOK_IOS_DEVELOPMENT_TEAM or let the script auto-detect
     your local Apple Development team from Keychain when possible.
@@ -115,7 +122,6 @@ TARGETS=()
 SIMULATOR_FILTER=""
 DEVICE_FILTER=""
 TEAM_ID="${ROOK_IOS_DEVELOPMENT_TEAM:-}"
-SERVER_URL=""
 RESET_PERMISSIONS=0
 
 while [[ $# -gt 0 ]]; do
@@ -138,10 +144,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --team)
       TEAM_ID="${2:-}"
-      shift 2
-      ;;
-    --server-url)
-      SERVER_URL="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -195,14 +197,20 @@ PY
 }
 
 health_ok() {
-  curl --silent --show-error --fail "$SERVER_HEALTH_URL" >/dev/null 2>&1
+  local -a curl_args=(--silent --show-error --fail)
+  if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
+    curl_args+=( -H "Authorization: Bearer $SERVER_AUTH_TOKEN" )
+  fi
+  curl "${curl_args[@]}" "$SERVER_HEALTH_URL" >/dev/null 2>&1
 }
 
 listener_is_localhost_only() {
   local out
   out="$(lsof -nP -iTCP:"$SERVER_PORT" -sTCP:LISTEN 2>/dev/null || true)"
   [[ -n "$out" ]] || return 1
-  if grep -Eq 'localhost:|127\.0\.0\.1:' <<<"$out" && ! grep -Eq '\*:|0\.0\.0\.0:|\[::\]:' <<<"$out"; then
+  if grep -Eq '(localhost:|127\.0\.0\.1:)' <<<"$out" \
+    && ! grep -Eq '(\*:|0\.0\.0\.0:|\[::\]:)' <<<"$out" \
+    && ! grep -Eq '(^|[[:space:]])(10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.|192\.168\.|100\.)' <<<"$out"; then
     return 0
   fi
   return 1
@@ -285,34 +293,6 @@ start_server_in_background() {
   )
 }
 
-start_server_in_terminal() {
-  need_cmd npm
-  need_cmd osascript
-  local command
-  command="$(python3 - <<'PY' "$REPO_ROOT" "$RUN_ROOT" "$SERVER_LOG" "$SERVER_PIDFILE" "$SERVER_PORT"
-import shlex, sys
-repo_root, run_root, server_log, server_pidfile, server_port = sys.argv[1:]
-parts = [
-    f'cd {shlex.quote(repo_root)}',
-    f'mkdir -p {shlex.quote(run_root)}',
-    f': > {shlex.quote(server_log)}',
-    f'export ROOK_SERVER_PORT={shlex.quote(server_port)}',
-    f'echo $$ > {shlex.quote(server_pidfile)}',
-    f'exec > >(tee -a {shlex.quote(server_log)}) 2>&1',
-    'exec npm run dev',
-]
-print('bash -lc ' + shlex.quote('; '.join(parts)))
-PY
-)"
-  log "starting server in Terminal.app (log: $SERVER_LOG)"
-  if ! osascript \
-    -e 'tell application "Terminal" to activate' \
-    -e "tell application \"Terminal\" to do script $(json_escape "$command")" >/dev/null; then
-    warn "failed to launch Terminal.app; falling back to detached background server"
-    start_server_in_background
-  fi
-}
-
 ensure_server_deps() {
   local server_dir="$REPO_ROOT/server"
   if [[ -d "$server_dir/node_modules" ]] && [[ -f "$server_dir/node_modules/tsx/dist/cli.mjs" ]]; then
@@ -325,17 +305,13 @@ ensure_server_deps() {
 
 start_server() {
   if health_ok; then
-    log "server already healthy at http://127.0.0.1:${SERVER_PORT}"
+    log "server already healthy at ${SERVER_HEALTH_URL}"
   else
     if lsof -nP -iTCP:"$SERVER_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
       die "port ${SERVER_PORT} is already in use, but /api/health is not healthy"
     fi
     ensure_server_deps
-    if [[ "$(uname -s)" == "Darwin" ]] && command -v osascript >/dev/null 2>&1; then
-      start_server_in_terminal
-    else
-      start_server_in_background
-    fi
+    start_server_in_background
     if ! wait_for_health 90; then
       tail -n 80 "$SERVER_LOG" >&2 || true
       die "server did not become healthy"
@@ -344,7 +320,7 @@ start_server() {
   fi
 
   if (( HAS_PHONE_TARGET )) && listener_is_localhost_only; then
-    die "server is only listening on localhost; restart it so the phone can reach your Mac over Tailscale"
+    die "server is only listening on localhost; restart it so the phone can reach your Mac over your chosen remote network"
   fi
 }
 
@@ -362,16 +338,20 @@ ensure_xcode_project() {
   )
 }
 
-current_tailscale_dns_name() {
-  if [[ -n "${ROOK_TAILSCALE_DNS_NAME:-}" ]]; then
-    printf '%s\n' "$ROOK_TAILSCALE_DNS_NAME"
+current_remote_target() {
+  if [[ -n "${ROOK_REMOTE_HOSTNAME:-}" ]]; then
+    printf '%s\n' "$ROOK_REMOTE_HOSTNAME"
     return 0
   fi
-  command -v tailscale >/dev/null 2>&1 || return 1
-  tailscale status --json 2>/dev/null | python3 -c '
-import json,sys
-print((json.load(sys.stdin).get("Self", {}) or {}).get("DNSName", ""))
-' 2>/dev/null | sed -e 's/\.$//' -e '/^$/d' || true
+  if [[ -n "${ROOK_BIND_IP:-}" ]]; then
+    printf '%s\n' "$ROOK_BIND_IP"
+    return 0
+  fi
+  if [[ -n "${ROOK_SERVER_HOST:-}" ]] && [[ "$ROOK_SERVER_HOST" != "127.0.0.1" ]] && [[ "$ROOK_SERVER_HOST" != "localhost" ]]; then
+    printf '%s\n' "$ROOK_SERVER_HOST"
+    return 0
+  fi
+  return 1
 }
 
 resolve_simulator() {
@@ -546,7 +526,7 @@ build_sim() {
   local app_path="$derived/Build/Products/Debug-iphonesimulator/Rook.app"
   [[ -d "$app_path" ]] || die "missing built app: $app_path"
 
-  local url="${SERVER_URL:-http://127.0.0.1:${SERVER_PORT}}"
+  local url="http://127.0.0.1:${SERVER_PORT}"
   if (( RESET_PERMISSIONS )); then
     log "resetting simulator privacy permissions for com.rookery.Rook"
     xcrun simctl privacy "$sim_udid" reset all com.rookery.Rook >/dev/null 2>&1 || true
@@ -557,8 +537,14 @@ build_sim() {
   xcrun simctl install "$sim_udid" "$app_path" >/dev/null
   log "launching Rook in simulator with ROOK_SERVER_BASE_URL=$url"
   local launch_output
-  launch_output="$(SIMCTL_CHILD_ROOK_SERVER_BASE_URL="$url" \
-    xcrun simctl launch --terminate-running-process "$sim_udid" com.rookery.Rook)"
+  if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
+    launch_output="$(SIMCTL_CHILD_ROOK_SERVER_BASE_URL="$url" \
+      SIMCTL_CHILD_ROOK_AUTH_TOKEN="$SERVER_AUTH_TOKEN" \
+      xcrun simctl launch --terminate-running-process "$sim_udid" com.rookery.Rook)"
+  else
+    launch_output="$(SIMCTL_CHILD_ROOK_SERVER_BASE_URL="$url" \
+      xcrun simctl launch --terminate-running-process "$sim_udid" com.rookery.Rook)"
+  fi
   log "$launch_output"
 }
 
@@ -582,14 +568,20 @@ build_phone() {
   fi
 
   local url
-  if [[ -n "$SERVER_URL" ]]; then
-    url="$SERVER_URL"
-  else
-    local tailscale_dns
-    tailscale_dns="$(current_tailscale_dns_name)"
-    [[ -n "$tailscale_dns" ]] || die "could not determine your Mac's Tailscale MagicDNS name for the phone; connect Tailscale or pass --server-url explicitly"
-    url="http://${tailscale_dns}:${SERVER_PORT}"
+  local remote_target
+  remote_target="$(current_remote_target)"
+  if [[ -z "$remote_target" ]]; then
+    cat >&2 <<EOF
+[run-rook] error: could not determine a reachable server address for the phone
+[run-rook] set one of:
+[run-rook]   ROOK_REMOTE_HOSTNAME=your-hostname
+[run-rook]   ROOK_BIND_IP=your.remote.ip
+[run-rook] example with Tailscale:
+[run-rook]   ROOK_REMOTE_HOSTNAME=your-mac.tailxxxx.ts.net
+EOF
+    exit 1
   fi
+  url="http://${remote_target}:${SERVER_PORT}"
 
   local app_dir="$REPO_ROOT/clients/iphone"
   local proj="$app_dir/Rook.xcodeproj"
@@ -622,10 +614,16 @@ build_phone() {
   log "installing Rook on $phone_name"
   xcrun devicectl device install app --device "$phone_udid" "$app_path" >/dev/null
   log "launching Rook on $phone_name with ROOK_SERVER_BASE_URL=$url"
+  local launch_env
+  if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
+    launch_env="{\"ROOK_SERVER_BASE_URL\":$(json_escape "$url"),\"ROOK_AUTH_TOKEN\":$(json_escape "$SERVER_AUTH_TOKEN")}"
+  else
+    launch_env="{\"ROOK_SERVER_BASE_URL\":$(json_escape "$url")}"
+  fi
   xcrun devicectl device process launch \
     --device "$phone_udid" \
     --terminate-existing \
-    -e "{\"ROOK_SERVER_BASE_URL\":$(json_escape "$url")}" \
+    -e "$launch_env" \
     com.rookery.Rook >/dev/null
 
   cat <<EOF
@@ -647,7 +645,7 @@ start_server
 for TARGET in "${TARGETS[@]}"; do
   case "$TARGET" in
     server)
-      log "server ready: http://127.0.0.1:${SERVER_PORT}"
+      log "server ready: ${SERVER_HEALTH_URL%/api/health}"
       ;;
     mac)
       build_mac

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # Rook server
 
-Fastify API and runtime orchestration for the Rook native clients and debug tooling. Part of the [Rook](../README.md) monorepo. Product/architecture notes: [PRODUCT/](../PRODUCT/).
+Fastify API and runtime orchestration for the Rook native clients and debug tooling. Part of the [Rook](../README.md) monorepo. Product/architecture notes: [PRODUCT/](../PRODUCT/). Repo-level setup, `.env`, binding, and auth live in [docs/setup.md](../docs/setup.md).
 
 ## Quick start
 
@@ -28,6 +28,10 @@ macOS, the script now starts the server in Terminal.app by default instead of a
 plain detached `nohup` process. This preserves Terminal's protected-folder
 access (notably Downloads/Desktop/Documents), which matters because Pi tool
 subprocesses may otherwise lose TCC-granted file access.
+
+## Network binding and auth
+
+The server now always binds loopback (`127.0.0.1`). For remote phone access, set `ROOK_BIND_IP` to add a second listener on your Mac's VPN/private-network address, and set `ROOK_AUTH_TOKEN`. See [docs/setup.md](../docs/setup.md).
 
 ## Pi agent configuration
 

--- a/server/src/server/auth.ts
+++ b/server/src/server/auth.ts
@@ -1,0 +1,57 @@
+import type { IncomingMessage } from "node:http";
+
+export interface ServerAuthOptions {
+  token?: string;
+  trustLoopbackWithoutAuth?: boolean;
+}
+
+export class ServerAuth {
+  private readonly token?: string;
+  private readonly trustLoopbackWithoutAuth: boolean;
+
+  constructor(options: ServerAuthOptions = {}) {
+    this.token = options.token?.trim() || undefined;
+    this.trustLoopbackWithoutAuth = options.trustLoopbackWithoutAuth ?? true;
+  }
+
+  get enabled(): boolean {
+    return Boolean(this.token);
+  }
+
+  authorizeRequest(request: IncomingMessage): { ok: true } | { ok: false; statusCode: 401; error: string } {
+    if (!this.enabled) return { ok: true };
+    if (
+      this.trustLoopbackWithoutAuth
+      && isLoopbackAddress(request.socket.remoteAddress)
+      && !hasForwardedRemote(request)
+    ) {
+      return { ok: true };
+    }
+    const expected = `Bearer ${this.token}`;
+    const provided = request.headers.authorization;
+    if (constantTimeEquals(provided, expected)) return { ok: true };
+    return { ok: false, statusCode: 401, error: "Unauthorized" };
+  }
+}
+
+function isLoopbackAddress(address: string | undefined): boolean {
+  if (!address) return false;
+  return address === "127.0.0.1"
+    || address === "::1"
+    || address === "::ffff:127.0.0.1";
+}
+
+function hasForwardedRemote(request: IncomingMessage): boolean {
+  const forwarded = request.headers["x-forwarded-for"];
+  return typeof forwarded === "string" ? forwarded.trim().length > 0 : Array.isArray(forwarded) && forwarded.length > 0;
+}
+
+function constantTimeEquals(left: string | undefined, right: string | undefined): boolean {
+  if (typeof left !== "string" || typeof right !== "string") return false;
+  if (left.length !== right.length) return false;
+  let mismatch = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    mismatch |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return mismatch === 0;
+}

--- a/server/src/server/index.test.ts
+++ b/server/src/server/index.test.ts
@@ -132,6 +132,44 @@ describe("server", () => {
     expect(response.json()).toEqual({ ok: true, service: "rook" });
   });
 
+  it("requires a bearer token when auth is enabled", async () => {
+    const app = await buildServer({ enableClient: false, authToken: "secret-token", trustLoopbackWithoutAuth: false });
+    const unauthorized = await app.inject({ method: "GET", url: "/api/health" });
+    const authorized = await app.inject({
+      method: "GET",
+      url: "/api/health",
+      headers: { authorization: "Bearer secret-token" },
+    });
+    await app.close();
+
+    expect(unauthorized.statusCode).toBe(401);
+    expect(unauthorized.json()).toEqual({ error: "Unauthorized" });
+    expect(authorized.statusCode).toBe(200);
+  });
+
+  it("does not grant loopback auth exemption to proxied requests", async () => {
+    const app = await buildServer({ enableClient: false, authToken: "secret-token" });
+    const proxied = await app.inject({
+      method: "GET",
+      url: "/api/health",
+      headers: { "x-forwarded-for": "100.98.157.21" },
+      remoteAddress: "127.0.0.1",
+    });
+    const proxiedAuthorized = await app.inject({
+      method: "GET",
+      url: "/api/health",
+      headers: {
+        "x-forwarded-for": "100.98.157.21",
+        authorization: "Bearer secret-token",
+      },
+      remoteAddress: "127.0.0.1",
+    });
+    await app.close();
+
+    expect(proxied.statusCode).toBe(401);
+    expect(proxiedAuthorized.statusCode).toBe(200);
+  });
+
   it("starts the selected agent and returns its session", async () => {
     const app = await buildServer({ enableClient: false });
     const response = await app.inject({ method: "POST", url: "/api/agent/start", payload: { agent: "PiAgent" } });

--- a/server/src/server/index.ts
+++ b/server/src/server/index.ts
@@ -21,10 +21,13 @@ import { SessionRoomManager } from "./realtime/SessionRoomManager.js";
 import { registerAgentRoutes } from "./routes/agentRoutes.js";
 import { registerEnvironmentRoutes } from "./routes/environmentRoutes.js";
 import { registerWebsocketRoute } from "./routes/websocketRoute.js";
+import { ServerAuth } from "./auth.js";
+import { startRemoteProxy } from "./remoteProxy.js";
 
 dotenv.config({ path: path.join(REPO_ROOT, ".env") });
 
-const host = process.env.HOST ?? "0.0.0.0";
+const loopbackHost = "127.0.0.1";
+const remoteBindIp = process.env.ROOK_BIND_IP ?? process.env.ROOK_TAILSCALE_IP;
 const port = Number(process.env.PORT ?? 3000);
 
 export interface BuildServerOptions {
@@ -35,10 +38,18 @@ export interface BuildServerOptions {
   environmentDecisionStoreLocation?: string;
   /** Override the POI lookup provider (defaults to the ptiles provider via the proxy route). */
   poiProvider?: PoiLookupProvider;
+  /** Optional bearer token for non-loopback requests. */
+  authToken?: string;
+  /** Test hook: require auth even for loopback requests. */
+  trustLoopbackWithoutAuth?: boolean;
 }
 
 export async function buildServer(options: BuildServerOptions = {}) {
   const app = fastify({ logger: options.logger ?? true });
+  const auth = new ServerAuth({
+    token: options.authToken ?? process.env.ROOK_AUTH_TOKEN,
+    trustLoopbackWithoutAuth: options.trustLoopbackWithoutAuth,
+  });
   // Programmatic repo for the synthesized location-context bundle (no extraSkillPaths).
   const locationContextRepository = new LocationContextRepository();
   const environmentRepository = new CompositeEnvironmentRepository([
@@ -65,13 +76,19 @@ export async function buildServer(options: BuildServerOptions = {}) {
 
   await app.register(websocket);
 
+  app.addHook("onRequest", async (request, reply) => {
+    const authorization = auth.authorizeRequest(request.raw);
+    if (authorization.ok) return;
+    reply.code(authorization.statusCode).send({ error: authorization.error });
+  });
+
   app.addHook("onClose", async () => {
     await roomManager.closeAll();
   });
 
   await registerAgentRoutes(app, { roomManager, environmentManager });
   await registerEnvironmentRoutes(app, environmentManager, environmentIdentifier, locationRegistrar);
-  await registerWebsocketRoute(app, roomManager);
+  await registerWebsocketRoute(app, roomManager, auth);
 
   return app;
 }
@@ -80,6 +97,34 @@ const isMain = process.argv[1] ? path.resolve(process.argv[1]) === fileURLToPath
 
 if (isMain) {
   const app = await buildServer();
-  await app.listen({ host, port });
-  console.log(`Rook listening at http://${host}:${port}`);
+  await app.listen({ host: loopbackHost, port });
+
+  let remoteProxy: Awaited<ReturnType<typeof startRemoteProxy>> | null = null;
+  if (remoteBindIp && remoteBindIp !== loopbackHost && remoteBindIp !== "localhost") {
+    remoteProxy = await startRemoteProxy({
+      bindIp: remoteBindIp,
+      port,
+      targetHost: loopbackHost,
+      targetPort: port,
+    });
+  }
+
+  const shutdown = async () => {
+    process.off("SIGINT", shutdown);
+    process.off("SIGTERM", shutdown);
+    try {
+      await remoteProxy?.close();
+    } finally {
+      await app.close();
+      process.exit(0);
+    }
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+
+  console.log(`Rook listening at http://${loopbackHost}:${port}`);
+  if (remoteProxy) {
+    console.log(`Rook remote proxy listening at http://${remoteBindIp}:${port}`);
+  }
 }

--- a/server/src/server/remoteProxy.ts
+++ b/server/src/server/remoteProxy.ts
@@ -1,0 +1,105 @@
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import net from "node:net";
+import type { Duplex } from "node:stream";
+
+export interface RemoteProxyOptions {
+  bindIp: string;
+  port: number;
+  targetHost: string;
+  targetPort: number;
+}
+
+export interface RemoteProxyHandle {
+  close(): Promise<void>;
+}
+
+export async function startRemoteProxy(options: RemoteProxyOptions): Promise<RemoteProxyHandle> {
+  const server = http.createServer((request, response) => {
+    proxyHttpRequest(request, response, options);
+  });
+
+  server.on("upgrade", (request, socket, head) => {
+    proxyUpgradeRequest(request, socket, head, options);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(options.port, options.bindIp, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  return {
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      });
+    },
+  };
+}
+
+function proxyHttpRequest(request: IncomingMessage, response: ServerResponse, options: RemoteProxyOptions): void {
+  const headers = { ...request.headers, "x-forwarded-for": request.socket.remoteAddress ?? "" };
+  const upstream = http.request({
+    host: options.targetHost,
+    port: options.targetPort,
+    method: request.method,
+    path: request.url,
+    headers,
+  }, (upstreamResponse) => {
+    response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
+    upstreamResponse.pipe(response);
+  });
+
+  upstream.on("error", () => {
+    if (!response.headersSent) {
+      response.writeHead(502, { "content-type": "application/json" });
+    }
+    response.end(JSON.stringify({ error: "Upstream unavailable" }));
+  });
+
+  request.pipe(upstream);
+}
+
+function proxyUpgradeRequest(
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+  options: RemoteProxyOptions,
+): void {
+  const upstream = net.connect(options.targetPort, options.targetHost, () => {
+    upstream.write(renderUpgradeRequest(request));
+    if (head.length > 0) upstream.write(head);
+    socket.pipe(upstream).pipe(socket);
+  });
+
+  const closeBoth = () => {
+    socket.destroy();
+    upstream.destroy();
+  };
+
+  upstream.on("error", closeBoth);
+  socket.on("error", closeBoth);
+}
+
+function renderUpgradeRequest(request: IncomingMessage): string {
+  let raw = `${request.method ?? "GET"} ${request.url ?? "/"} HTTP/${request.httpVersion}\r\n`;
+  const headerNames = new Set<string>();
+  for (let index = 0; index < request.rawHeaders.length; index += 2) {
+    const key = request.rawHeaders[index];
+    const value = request.rawHeaders[index + 1];
+    if (!key || value === undefined) continue;
+    if (key.toLowerCase() === "x-forwarded-for") continue;
+    headerNames.add(key.toLowerCase());
+    raw += `${key}: ${value}\r\n`;
+  }
+  if (!headerNames.has("x-forwarded-for")) {
+    raw += `x-forwarded-for: ${request.socket.remoteAddress ?? ""}\r\n`;
+  }
+  raw += "\r\n";
+  return raw;
+}

--- a/server/src/server/routes/websocketRoute.ts
+++ b/server/src/server/routes/websocketRoute.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../shared/acp.js";
 import type { SessionRoomManager } from "../realtime/SessionRoomManager.js";
 import { errorMessage } from "../serverHelpers.js";
+import type { ServerAuth } from "../auth.js";
 
 function jsonRpcError(message: string, id: string | number | null = null, code = -32000): JsonRpcFailure {
   return {
@@ -59,8 +60,15 @@ function requestSessionId(message: AcpPromptRequest | AcpSetModeRequest | AcpSet
   return typeof message.params?.sessionId === "string" ? message.params.sessionId : undefined;
 }
 
-export async function registerWebsocketRoute(app: FastifyInstance, roomManager: SessionRoomManager): Promise<void> {
+export async function registerWebsocketRoute(app: FastifyInstance, roomManager: SessionRoomManager, auth: ServerAuth): Promise<void> {
   app.get<{ Querystring: { sessionId?: string } }>("/api/ws", { websocket: true }, (socket, request) => {
+    const authorization = auth.authorizeRequest(request.raw);
+    if (!authorization.ok) {
+      socket.send(JSON.stringify(jsonRpcError(authorization.error)));
+      socket.close();
+      return;
+    }
+
     const sessionId = typeof request.query.sessionId === "string" ? request.query.sessionId.trim() : "";
     if (!sessionId) {
       socket.send(JSON.stringify(jsonRpcError("Missing sessionId")));


### PR DESCRIPTION
## Non AI Summary
I was attaching to all interfaces 0.0.0.0 w/o any auth - which meant that I could bring my server to a coffee shop and it could be pwned.

I made it listen to 127.0.0.1 so that you could use the client on your own computer and also listen to whatever IP address that the VPN uses, and I added docs to explain it. The new settings are to be placed in .env for now.

Docs updated accordingly.

## Summary

Addresses #62.

This PR hardens Rook's remote access story without breaking the local-first workflow. The server now always serves localhost clients on loopback, can optionally expose a second remote/VPN listener for phone access, enforces bearer auth for non-loopback HTTP + WebSocket traffic, and updates the setup/docs path around remote iPhone use.

## Problem / context

Rook's server can start agents and drive powerful ACP sessions, but the previous default/network story was too loose for a project whose product intent emphasizes safety and transparency. At the same time, Rook's phone-over-home-server workflow needs a practical remote-access path that does not break the local Mac client.

## Why this matters

This closes the biggest gap called out in #62: accidental remote exposure of a highly privileged personal-agent runtime. It also preserves an important product behavior: Rook should feel local on the Mac while still being reachable from the user's phone over a private network. In short, this makes the current in-flight product meaningfully safer without over-concreting it into a heavyweight auth/account system.

## Approaches considered

| Option | Summary | Why not (or chosen) |
|--------|---------|---------------------|
| Single broad bind | Bind `0.0.0.0` and rely on network trust | Too easy to widen exposure accidentally; contradicted the desired trust boundary in #62 |
| Single remote bind | Bind only the VPN/private-network address | Broke localhost clients on the Mac |
| Dual bind + bearer auth | Always bind loopback, optionally add one remote listener, require token remotely | Chosen: preserves local UX while narrowing remote exposure |

## Decision / approach taken

Rook now always binds loopback for on-machine clients and optionally exposes one additional remote listener for phone access, with bearer-token auth required for non-loopback requests.

- Added HTTP + WebSocket bearer auth on the server for non-loopback traffic.
- Added a small remote proxy/listener so the server can serve both localhost and one configured remote/VPN address at the same time.
- Updated the iPhone client and shared Swift networking layer to send auth on REST + WebSocket.
- Added setup docs and config examples for remote access, including iPhone trust/setup notes and guidance to prefer hostname-based phone access over raw IP when ATS is involved.
- Reframed the root README as a docs-first table of contents.

## Product specification alignment

**Classification:** Extends

**Related PRODUCT/ docs:**
- [`PRODUCT/goals-of-rook.md`](PRODUCT/goals-of-rook.md) — reinforces the goals that Rook “goes with you everywhere” and is “as safe and transparent as possible”
- [`PRODUCT/relationship-or-environments-skills-and-agent.md`](PRODUCT/relationship-or-environments-skills-and-agent.md) — keeps the broader product posture of constrained, explicit trust boundaries

**Documentation updates in this PR:**
- [x] [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — documents the as-built remote access and auth model
- [x] `README.md`, `docs/setup.md`, `docs/configuration.md`, package READMEs — documents setup and usage flow

**Notes:**
This PR does not introduce a user-account or identity model. It intentionally keeps remote access personal, local-first, and lightweight.

## Architecture alignment

**Classification:** Modifies

**Related docs / patterns:**
- [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — changes the as-built network exposure model from a single local listener assumption to loopback + optional remote listener
- [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md) — keeps ACP boundaries intact while adding auth at the transport edge

**Documentation updates in this PR:**
- [x] [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — adds the network exposure/auth model

**Notes:**
The architecture still routes all client traffic into the same Fastify/ACP coordinator. The new remote listener is a narrow transport concern, not a second product surface.

## High-level technical footprint

- **Components:** server auth gate, remote proxy listener, shared Swift REST/WS client updates, iPhone settings/config handling
- **APIs / protocols:** HTTP `Authorization: Bearer ...`, WebSocket upgrade auth, dual-bind local/remote access path
- **Data / events:** no new product-level event schema; transport/auth only

## Test plan

- [x] Server tests pass: `cd server && npm test`
- [x] Server typecheck passes: `cd server && npm run typecheck`
- [x] Verified remote reachability/auth behavior against `/api/health`
- [x] Verified docs/config flow for local Mac + remote iPhone setup
