### PR TITLE
Require auth on localhost and store tokens securely

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ PORT=3000
 # Example: ROOK_BIND_IP=100.64.12.34
 ROOK_BIND_IP=
 
-# Optional: require this bearer token for non-loopback HTTP/WebSocket requests.
+# Optional: require this bearer token for all HTTP/WebSocket requests.
 # Generate a long random string.
 # ROOK_AUTH_TOKEN=
 

--- a/PRODUCT/AS-BUILT-ARCHITECTURE.md
+++ b/PRODUCT/AS-BUILT-ARCHITECTURE.md
@@ -10,7 +10,7 @@ Rookery is a local-first monorepo centered on one service at `127.0.0.1:3000`:
 
 - the server always binds loopback for on-machine clients
 - it may also expose a second listener on a configured remote/VPN address for phone access
-- non-loopback access is expected to be protected by a bearer token
+- when configured, bearer auth is required for all client access, including localhost
 
 - a **Fastify server**
 - a **React Native web chat UI**
@@ -99,7 +99,7 @@ The server is now API/websocket-only; native clients and debug scripts connect t
 Network exposure model as built:
 - localhost/macOS clients talk to the loopback listener
 - remote phone access is served by a second remote listener rather than broad `0.0.0.0` binding
-- auth is enforced for non-loopback HTTP + WebSocket access
+- auth is enforced for all HTTP + WebSocket access when configured
 
 ### 5.2 Session rooms
 

--- a/clients/RookKit/Sources/RookKit/KeychainStore.swift
+++ b/clients/RookKit/Sources/RookKit/KeychainStore.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Security
+
+public enum KeychainStore {
+    private static let service = "com.rookery.Rook"
+
+    public static func string(for account: String) -> String? {
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        #if os(iOS)
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        #endif
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value
+    }
+
+    @discardableResult
+    public static func setString(_ value: String, for account: String) -> Bool {
+        guard let data = value.data(using: .utf8) else {
+            return false
+        }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        let attributes: [String: Any] = {
+            var base: [String: Any] = [
+                kSecValueData as String: data,
+            ]
+            #if os(iOS)
+            base[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+            #endif
+            return base
+        }()
+
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess {
+            return true
+        }
+
+        var create = query
+        attributes.forEach { create[$0.key] = $0.value }
+        return SecItemAdd(create as CFDictionary, nil) == errSecSuccess
+    }
+
+    @discardableResult
+    public static func removeString(for account: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+}

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -163,7 +163,7 @@ xcodebuild -project Rook.xcodeproj -scheme Rook \
 #    iPhone 14 Pro or newer simulator.
 ```
 
-For a **physical device**, the launcher script sets the base URL for you at launch time using a reachable hostname when it can discover one. If you run manually, set the base URL to the hostname or IP address your phone can reach. The base URL is stored in `UserDefaults` (`RookModel.baseURLString`) and can also be overridden at launch with `ROOK_SERVER_BASE_URL`; the `NSAllowsLocalNetworking` ATS exception in `Info.plist` permits the cleartext connection.
+For a **physical device**, the launcher script sets the base URL for you at launch time using a reachable hostname when it can discover one. If you run manually, set the base URL to the hostname or IP address your phone can reach. The base URL is stored in `UserDefaults` (`RookModel.baseURLString`) and can also be overridden at launch with `ROOK_SERVER_BASE_URL`; the bearer token is stored in Keychain and can be overridden at launch with `ROOK_AUTH_TOKEN`; the `NSAllowsLocalNetworking` ATS exception in `Info.plist` permits the cleartext connection.
 
 ### Onboarding: iPhone client + home server over a private remote network
 
@@ -274,7 +274,7 @@ xcrun simctl io booted screenshot /tmp/rook.png   # screenshot the simulator
 
 ## Out of scope (follow-ups)
 
-The MVP targets the local Mac dev server, unauthenticated, on the LAN. True
+The MVP targets the local Mac dev server and private-network phone access. True
 away-from-home presence (push-to-start Live Activities and remote updates while
 the app is closed) needs a hosted server + APNs + Sign in with Apple — see
 [`PRODUCT_CHANGES/research/rook-on-iphone.md`](../../PRODUCT_CHANGES/research/rook-on-iphone.md)

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -102,10 +102,13 @@ final class RookModel: ObservableObject {
             urlString = "http://127.0.0.1:3000"
         }
         let envToken = ProcessInfo.processInfo.environment["ROOK_AUTH_TOKEN"]?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let storedToken = UserDefaults.standard.string(forKey: "RookAuthToken")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let legacyStoredToken = UserDefaults.standard.string(forKey: "RookAuthToken")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let keychainToken = KeychainStore.string(for: "RookAuthToken")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedToken = (keychainToken?.isEmpty == false ? keychainToken : legacyStoredToken)
         let authToken = (envToken?.isEmpty == false ? envToken : storedToken) ?? ""
-        if let envToken, !envToken.isEmpty, storedToken != envToken {
-            UserDefaults.standard.set(envToken, forKey: "RookAuthToken")
+        if let tokenToPersist = (envToken?.isEmpty == false ? envToken : storedToken), !tokenToPersist.isEmpty {
+            KeychainStore.setString(tokenToPersist, for: "RookAuthToken")
+            UserDefaults.standard.removeObject(forKey: "RookAuthToken")
         }
         let finalURL = URL(string: urlString) ?? URL(string: "http://127.0.0.1:3000")!
         baseURLString = urlString
@@ -383,7 +386,12 @@ final class RookModel: ObservableObject {
         baseURLString = trimmed
         authTokenString = trimmedToken
         UserDefaults.standard.set(trimmed, forKey: "RookServerBaseURL")
-        UserDefaults.standard.set(trimmedToken, forKey: "RookAuthToken")
+        UserDefaults.standard.removeObject(forKey: "RookAuthToken")
+        if trimmedToken.isEmpty {
+            KeychainStore.removeString(for: "RookAuthToken")
+        } else {
+            KeychainStore.setString(trimmedToken, for: "RookAuthToken")
+        }
         api = RookAPI(baseURL: url, authToken: trimmedToken)
         socket.disconnect()
         currentSession = nil

--- a/clients/iphone/Sources/Views/SettingsScreen.swift
+++ b/clients/iphone/Sources/Views/SettingsScreen.swift
@@ -71,7 +71,7 @@ struct SettingsScreen: View {
                         .strokeBorder(PanelPalette.border)
                 )
 
-            TextField("Bearer token (optional on localhost)", text: $authTokenDraft)
+            SecureField("Bearer token", text: $authTokenDraft)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .textContentType(.password)
@@ -87,7 +87,7 @@ struct SettingsScreen: View {
                         .strokeBorder(PanelPalette.border)
                 )
 
-            Text("On a device, use a hostname or IP address your phone can reach. Add the bearer token if the server is configured to require one for non-local access.")
+            Text("On a device, use a hostname or IP address your phone can reach. If the server is configured with a bearer token, every client request must send it.")
                 .font(.caption2)
                 .foregroundStyle(PanelPalette.textMuted)
 

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -100,6 +100,8 @@ final class RookMacModel: ObservableObject {
     @Published var screenRecordingTrusted = false
     @Published var computerControlEnabled = false
     @Published var bridgePort: UInt16 = 0
+    @Published var baseURLString: String
+    @Published var authTokenString: String
 
     // Voice
     @Published var voiceModeEnabled = false
@@ -108,7 +110,7 @@ final class RookMacModel: ObservableObject {
     @Published var voiceSpeaking = false
     @Published var voicePartial = ""
 
-    let api = RookAPI()
+    private(set) var api: RookAPI
     private let socket = AcpSocket()
     private let serverController = ServerController()
     private let foregroundMonitor = ForegroundAppMonitor()
@@ -141,6 +143,23 @@ final class RookMacModel: ObservableObject {
     private let environmentStaleAfter: TimeInterval = 5 * 60
 
     init() {
+        let envBaseURL = ProcessInfo.processInfo.environment["ROOK_SERVER_BASE_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedBaseURL = UserDefaults.standard.string(forKey: "RookServerBaseURL")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedBaseURL = (envBaseURL?.isEmpty == false ? envBaseURL : storedBaseURL) ?? "http://127.0.0.1:3000"
+        if let envBaseURL, !envBaseURL.isEmpty, storedBaseURL != envBaseURL {
+            UserDefaults.standard.set(envBaseURL, forKey: "RookServerBaseURL")
+        }
+
+        let envToken = ProcessInfo.processInfo.environment["ROOK_AUTH_TOKEN"]?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedToken = KeychainStore.string(for: "RookAuthToken")?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedToken = (envToken?.isEmpty == false ? envToken : storedToken) ?? ""
+        if let envToken, !envToken.isEmpty, storedToken != envToken {
+            KeychainStore.setString(envToken, for: "RookAuthToken")
+        }
+
+        baseURLString = resolvedBaseURL
+        authTokenString = resolvedToken
+        api = RookAPI(baseURL: URL(string: resolvedBaseURL) ?? URL(string: "http://127.0.0.1:3000")!, authToken: resolvedToken)
         RookMacModel.shared = self
         socket.onEvent = { [weak self] event in
             self?.handleSocketEvent(event)

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -84,7 +84,7 @@ If you do not set `ROOK_REMOTE_HOSTNAME`, the phone launcher next tries `ROOK_BI
 If neither is set, it stops and tells you what to configure.
 
 ### `ROOK_AUTH_TOKEN`
-Optional bearer token for non-loopback access.
+Optional bearer token for all client access.
 
 Example:
 
@@ -94,10 +94,10 @@ ROOK_AUTH_TOKEN=replace-with-a-long-random-string
 
 Current behavior:
 - if unset, Rook has no app-level auth
-- if set, **non-loopback** HTTP and WebSocket requests must send `Authorization: Bearer <token>`
-- loopback requests from the same machine are still allowed without the token
+- if set, **every** HTTP and WebSocket request must send `Authorization: Bearer <token>`
+- that includes localhost clients, the Mac app, the iPhone app, and debug scripts
 
-That keeps the local Mac app/dev flow lightweight while protecting remote phone access.
+This closes the browser/localhost gap where a hostile local webpage or process could otherwise talk to Rook without authenticating.
 
 ## Common setups
 
@@ -135,7 +135,7 @@ ROOK_REMOTE_HOSTNAME=your-hostname.example.net
 ROOK_AUTH_TOKEN=replace-with-a-long-random-string
 ```
 
-The Mac app still uses localhost.
+The Mac app still uses localhost, but now sends the bearer token too.
 The iPhone launcher uses `ROOK_REMOTE_HOSTNAME`.
 
 ## Remote access notes

--- a/scripts/run-rook.sh
+++ b/scripts/run-rook.sh
@@ -496,8 +496,13 @@ build_mac() {
   xcodebuild -project "$proj" -scheme Rook -configuration Debug -derivedDataPath "$derived" build >/dev/null
   local app_path="$derived/Build/Products/Debug/Rook.app"
   [[ -d "$app_path" ]] || die "missing built app: $app_path"
-  log "launching Rook"
-  open "$app_path"
+  local url="http://127.0.0.1:${SERVER_PORT}"
+  log "launching Rook with ROOK_SERVER_BASE_URL=$url"
+  if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
+    ROOK_SERVER_BASE_URL="$url" ROOK_AUTH_TOKEN="$SERVER_AUTH_TOKEN" "$app_path/Contents/MacOS/Rook" >/dev/null 2>&1 &
+  else
+    ROOK_SERVER_BASE_URL="$url" "$app_path/Contents/MacOS/Rook" >/dev/null 2>&1 &
+  fi
 }
 
 build_sim() {

--- a/server/README.md
+++ b/server/README.md
@@ -31,7 +31,7 @@ subprocesses may otherwise lose TCC-granted file access.
 
 ## Network binding and auth
 
-The server now always binds loopback (`127.0.0.1`). For remote phone access, set `ROOK_BIND_IP` to add a second listener on your Mac's VPN/private-network address, and set `ROOK_AUTH_TOKEN`. See [docs/setup.md](../docs/setup.md).
+The server now always binds loopback (`127.0.0.1`). For remote phone access, set `ROOK_BIND_IP` to add a second listener on your Mac's VPN/private-network address, and set `ROOK_AUTH_TOKEN`. When a token is configured, every HTTP + WebSocket client — including localhost clients — must send it. See [docs/setup.md](../docs/setup.md).
 
 ## Pi agent configuration
 

--- a/server/src/server/auth.ts
+++ b/server/src/server/auth.ts
@@ -2,16 +2,13 @@ import type { IncomingMessage } from "node:http";
 
 export interface ServerAuthOptions {
   token?: string;
-  trustLoopbackWithoutAuth?: boolean;
 }
 
 export class ServerAuth {
   private readonly token?: string;
-  private readonly trustLoopbackWithoutAuth: boolean;
 
   constructor(options: ServerAuthOptions = {}) {
     this.token = options.token?.trim() || undefined;
-    this.trustLoopbackWithoutAuth = options.trustLoopbackWithoutAuth ?? true;
   }
 
   get enabled(): boolean {
@@ -20,30 +17,11 @@ export class ServerAuth {
 
   authorizeRequest(request: IncomingMessage): { ok: true } | { ok: false; statusCode: 401; error: string } {
     if (!this.enabled) return { ok: true };
-    if (
-      this.trustLoopbackWithoutAuth
-      && isLoopbackAddress(request.socket.remoteAddress)
-      && !hasForwardedRemote(request)
-    ) {
-      return { ok: true };
-    }
     const expected = `Bearer ${this.token}`;
     const provided = request.headers.authorization;
     if (constantTimeEquals(provided, expected)) return { ok: true };
     return { ok: false, statusCode: 401, error: "Unauthorized" };
   }
-}
-
-function isLoopbackAddress(address: string | undefined): boolean {
-  if (!address) return false;
-  return address === "127.0.0.1"
-    || address === "::1"
-    || address === "::ffff:127.0.0.1";
-}
-
-function hasForwardedRemote(request: IncomingMessage): boolean {
-  const forwarded = request.headers["x-forwarded-for"];
-  return typeof forwarded === "string" ? forwarded.trim().length > 0 : Array.isArray(forwarded) && forwarded.length > 0;
 }
 
 function constantTimeEquals(left: string | undefined, right: string | undefined): boolean {

--- a/server/src/server/index.test.ts
+++ b/server/src/server/index.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+process.env.ROOK_AUTH_TOKEN = "";
+
 const mockSession = { id: "s-mock", agent: "PiAgent", createdAt: "now", restart: {} };
 const olderSession = { id: "s-old", agent: "PiAgent", createdAt: "2025-12-31T00:00:00.000Z", restart: {} };
 const myPiOpenAiSession = { id: "s1", agent: "MyPiOpenAiAgent", createdAt: "2026-01-01T00:00:00.000Z", restart: { sessionId: "abc" } };
@@ -113,6 +115,14 @@ async function delay(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function routeMethods(method: string | readonly string[]): string[] {
+  return Array.isArray(method) ? [...method] : [method as string];
+}
+
+function routeUrl(url: string): string {
+  return url.includes(":") ? url.replace(/:([A-Za-z0-9_]+)/g, "test") : url;
+}
+
 describe("server", () => {
   afterEach(async () => {
     agentDiscoveryMock.createAgentMock.mockClear();
@@ -132,9 +142,26 @@ describe("server", () => {
     expect(response.json()).toEqual({ ok: true, service: "rook" });
   });
 
-  it("requires a bearer token when auth is enabled", async () => {
-    const app = await buildServer({ enableClient: false, authToken: "secret-token", trustLoopbackWithoutAuth: false });
-    const unauthorized = await app.inject({ method: "GET", url: "/api/health" });
+  it("requires a bearer token on every HTTP endpoint when auth is enabled", async () => {
+    const routes: Array<{ method: any; url: string; websocket?: boolean }> = [];
+    const app = await buildServer({
+      enableClient: false,
+      authToken: "secret-token",
+      onRoute: (route) => routes.push(route),
+    });
+
+    const httpRoutes = routes.filter((route) => !route.websocket);
+    expect(httpRoutes.length).toBeGreaterThan(5);
+
+    for (const route of httpRoutes) {
+      for (const method of routeMethods(route.method)) {
+        if (method === "HEAD") continue;
+        const response = await app.inject({ method: method as any, url: routeUrl(route.url) });
+        expect(response.statusCode, `${method} ${route.url}`).toBe(401);
+        expect(response.json(), `${method} ${route.url}`).toEqual({ error: "Unauthorized" });
+      }
+    }
+
     const authorized = await app.inject({
       method: "GET",
       url: "/api/health",
@@ -142,32 +169,63 @@ describe("server", () => {
     });
     await app.close();
 
-    expect(unauthorized.statusCode).toBe(401);
-    expect(unauthorized.json()).toEqual({ error: "Unauthorized" });
     expect(authorized.statusCode).toBe(200);
   });
 
-  it("does not grant loopback auth exemption to proxied requests", async () => {
+  it("rejects websocket connections without a bearer token when auth is required", async () => {
     const app = await buildServer({ enableClient: false, authToken: "secret-token" });
-    const proxied = await app.inject({
+    const baseUrl = await listen(app);
+    await app.inject({
+      method: "POST",
+      url: "/api/agent/start",
+      payload: { agent: "PiAgent" },
+      headers: { authorization: "Bearer secret-token" },
+    });
+
+    const socket = new WebSocket(`${baseUrl.replace("http", "ws")}/api/ws?sessionId=${mockSession.id}`);
+    const outcome = await new Promise<"message" | "error">((resolve, reject) => {
+      const timeout = setTimeout(() => reject(new Error("Timed out waiting for websocket auth rejection.")), 3_000);
+      socket.addEventListener("message", (event) => {
+        clearTimeout(timeout);
+        const payload = JSON.parse(String(event.data));
+        expect(payload).toEqual({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32000, message: "Unauthorized" },
+        });
+        resolve("message");
+      }, { once: true });
+      socket.addEventListener("error", () => {
+        clearTimeout(timeout);
+        resolve("error");
+      }, { once: true });
+    });
+
+    if (socket.readyState !== socket.CLOSED) {
+      await new Promise<void>((resolve) => socket.addEventListener("close", () => resolve(), { once: true }));
+    }
+    await app.close();
+
+    expect(["message", "error"]).toContain(outcome);
+  });
+
+  it("requires a bearer token even for loopback requests when auth is enabled", async () => {
+    const app = await buildServer({ enableClient: false, authToken: "secret-token" });
+    const unauthorized = await app.inject({
       method: "GET",
       url: "/api/health",
-      headers: { "x-forwarded-for": "100.98.157.21" },
       remoteAddress: "127.0.0.1",
     });
-    const proxiedAuthorized = await app.inject({
+    const authorized = await app.inject({
       method: "GET",
       url: "/api/health",
-      headers: {
-        "x-forwarded-for": "100.98.157.21",
-        authorization: "Bearer secret-token",
-      },
+      headers: { authorization: "Bearer secret-token" },
       remoteAddress: "127.0.0.1",
     });
     await app.close();
 
-    expect(proxied.statusCode).toBe(401);
-    expect(proxiedAuthorized.statusCode).toBe(200);
+    expect(unauthorized.statusCode).toBe(401);
+    expect(authorized.statusCode).toBe(200);
   });
 
   it("starts the selected agent and returns its session", async () => {

--- a/server/src/server/index.ts
+++ b/server/src/server/index.ts
@@ -38,17 +38,25 @@ export interface BuildServerOptions {
   environmentDecisionStoreLocation?: string;
   /** Override the POI lookup provider (defaults to the ptiles provider via the proxy route). */
   poiProvider?: PoiLookupProvider;
-  /** Optional bearer token for non-loopback requests. */
+  /** Optional bearer token required by all HTTP + WebSocket requests. */
   authToken?: string;
-  /** Test hook: require auth even for loopback requests. */
-  trustLoopbackWithoutAuth?: boolean;
+  /** Test hook: observe registered routes. */
+  onRoute?: (route: { method: string | readonly string[]; url: string; websocket?: boolean }) => void;
 }
 
 export async function buildServer(options: BuildServerOptions = {}) {
   const app = fastify({ logger: options.logger ?? true });
+  if (options.onRoute) {
+    app.addHook("onRoute", (routeOptions) => {
+      options.onRoute?.({
+        method: routeOptions.method as string | readonly string[],
+        url: routeOptions.url,
+        websocket: (routeOptions as { websocket?: boolean }).websocket,
+      });
+    });
+  }
   const auth = new ServerAuth({
     token: options.authToken ?? process.env.ROOK_AUTH_TOKEN,
-    trustLoopbackWithoutAuth: options.trustLoopbackWithoutAuth,
   });
   // Programmatic repo for the synthesized location-context bundle (no extraSkillPaths).
   const locationContextRepository = new LocationContextRepository();


### PR DESCRIPTION
## Non-AI Summary

Dear human, please add your own comments here.

## Summary

Addresses #62.

This follow-up PR closes the localhost/browser gap left by the earlier remote-access hardening. When `ROOK_AUTH_TOKEN` is configured, the server now requires bearer auth for all HTTP and WebSocket access — including localhost clients — and the Apple clients persist that token in Keychain rather than plain app preferences.

## Problem / context

The earlier fix substantially improved remote exposure by adding dual bind and bearer auth for non-loopback traffic. But a localhost exemption still left Rook open to the modern class of attacks where a hostile webpage, browser extension, or other local software can talk to a loopback service. At the same time, once localhost also needs auth, the native clients need a safer persistence story than storing the token in plain `UserDefaults`.

## Why this matters

Issue #62 is not really about coffee-shop networking alone; it is about reducing accidental control of a privileged personal-agent runtime. Requiring auth on localhost materially improves the protection against browser-to-localhost abuse, which is a realistic threat model on modern machines. Moving the token into Keychain on Apple platforms also reduces the chance that app-local preferences become the weakest link.

## Approaches considered

| Option | Summary | Why not (or chosen) |
|--------|---------|---------------------|
| Keep localhost exempt | Preserve convenience for the Mac app and scripts | Too weak against browser / local-process access to loopback |
| Require auth everywhere | Make the bearer token the only transport gate when enabled | Chosen: simplest way to close the localhost gap |
| Keep app token in preferences | Persist auth in `UserDefaults` | Too weak once auth becomes mandatory for all clients |

## Decision / approach taken

When `ROOK_AUTH_TOKEN` is set, Rook now requires that bearer token for all HTTP and WebSocket requests, including localhost, and the Apple clients persist the token in Keychain.

- Removed the loopback auth exemption from the server.
- Kept the auth gate centralized so new routes stay covered automatically.
- Updated the Mac launcher path so the Mac app receives `ROOK_SERVER_BASE_URL` and `ROOK_AUTH_TOKEN` at launch.
- Added a shared Swift `KeychainStore` and migrated iPhone token persistence away from `UserDefaults`.
- Updated docs/examples to reflect that localhost clients also authenticate now.

## Product specification alignment

**Classification:** Extends

**Related PRODUCT/ docs:**
- [`PRODUCT/goals-of-rook.md`](PRODUCT/goals-of-rook.md) — directly supports “as safe and transparent as possible”
- [`PRODUCT/relationship-or-environments-skills-and-agent.md`](PRODUCT/relationship-or-environments-skills-and-agent.md) — reinforces the product intent of narrow, explicit trust boundaries around powerful agent behavior

**Documentation updates in this PR:**
- [x] [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — updates the as-built auth model from remote-only to all-client auth when configured
- [x] `docs/setup.md`, `server/README.md`, `clients/iphone/README.md`, `.env.example` — reflect localhost auth + Apple Keychain persistence

**Notes:**
This still deliberately avoids a heavyweight account/auth product. The model remains personal and local-first: one shared bearer token for your own clients.

## Architecture alignment

**Classification:** Modifies

**Related docs / patterns:**
- [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — the auth boundary now sits uniformly at the transport edge for all clients
- [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md) — ACP remains unchanged; only the transport gate and client credential persistence changed

**Documentation updates in this PR:**
- [x] [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — clarifies auth for all HTTP + WebSocket access when configured

**Notes:**
This PR does not add per-user auth, browser origin policies, or a broader cross-platform secret-storage abstraction. Apple clients now use Keychain; non-Apple platform strategy remains future work.

## High-level technical footprint

- **Components:** `ServerAuth`, Fastify on-request auth hook, websocket auth check, shared Swift `KeychainStore`, Mac/iPhone model token persistence
- **APIs / protocols:** unchanged bearer header shape; changed auth scope (all clients instead of remote-only)
- **Data / events:** no product-level schema changes

## Test plan

- [x] `cd server && npm test`
- [x] `cd server && npm run typecheck`
- [x] Verified auth-required matrix across all registered HTTP endpoints when enabled
- [x] Verified websocket auth rejection when enabled
