### PR TITLE
Improve session stop hygiene

### DIFF
--- a/server/src/server/agents/BaseAgent.test.ts
+++ b/server/src/server/agents/BaseAgent.test.ts
@@ -1,11 +1,15 @@
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AcpSessionUpdateNotification } from "../../shared/acp";
 import { BaseAgent } from "./BaseAgent";
 
 class InspectableBaseAgent extends BaseAgent {
   inspectHandleStdoutLine(line: string): void {
     this.handleStdoutLine(line);
+  }
+
+  inspectSendRequest(method: string, params?: unknown): Promise<unknown> {
+    return this.sendRequest(method, params);
   }
 }
 
@@ -267,5 +271,36 @@ describe("BaseAgent", () => {
         }),
       }),
     );
+  });
+
+  it("rejects pending ACP requests when stopped", async () => {
+    const agent = new InspectableBaseAgent({
+      command: "node",
+      args: [FIXTURE],
+      cwd: path.resolve("."),
+      sessionCwd: path.resolve("."),
+      agentName: "TestAcpAgent",
+    });
+
+    const kill = vi.fn();
+    const write = vi.fn(() => true);
+    (agent as any).process = {
+      kill,
+      stdin: {
+        writable: true,
+        destroyed: false,
+        writableEnded: false,
+        write,
+      },
+    };
+    (agent as any).sessionIdValue = "session-1";
+
+    const pending = agent.inspectSendRequest("session/test", { hello: "world" });
+    await agent.stop();
+
+    await expect(pending).rejects.toThrow("TestAcpAgent stopped.");
+    expect(kill).toHaveBeenCalledWith("SIGTERM");
+    expect(write).toHaveBeenCalledWith(`${JSON.stringify({ jsonrpc: "2.0", id: "acp-1", method: "session/test", params: { hello: "world" } })}\n`);
+    expect(write).toHaveBeenCalledWith(`${JSON.stringify({ jsonrpc: "2.0", method: "session/cancel", params: { sessionId: "session-1" } })}\n`);
   });
 });

--- a/server/src/server/agents/BaseAgent.ts
+++ b/server/src/server/agents/BaseAgent.ts
@@ -184,7 +184,7 @@ export class BaseAgent {
     this.activeRunReject?.(error);
     this.activeRunReject = undefined;
     this.rejectPendingSteeringMessages(error);
-    await this.stopImpl();
+    await this.stopImpl(error);
   }
 
   /**
@@ -354,9 +354,15 @@ export class BaseAgent {
     this.emitAcpUpdate({ sessionUpdate: "user_message_chunk", content: { type: "text", text: userMessage } });
   }
 
-  protected async stopImpl(): Promise<void> {
-    if (!this.process) return;
+  protected async stopImpl(reason: Error = new Error(`${this.agentName} stopped.`)): Promise<void> {
     this.stopping = true;
+    this.pendingPermissionRequestIds.clear();
+    this.rejectPendingRequests(reason);
+
+    if (!this.process) {
+      this.startPromise = null;
+      return;
+    }
 
     if (this.sessionIdValue) {
       try {
@@ -369,7 +375,6 @@ export class BaseAgent {
     this.process.kill("SIGTERM");
     this.process = null;
     this.startPromise = null;
-    this.pendingRequests.clear();
   }
 
   protected rejectPendingSteeringMessages(error: unknown): void {
@@ -377,6 +382,12 @@ export class BaseAgent {
     while (this.pendingSteeringMessages.length > 0) {
       this.pendingSteeringMessages.shift()?.reject(normalized);
     }
+  }
+
+  protected rejectPendingRequests(error: unknown): void {
+    const normalized = error instanceof Error ? error : new Error(String(error));
+    for (const pending of this.pendingRequests.values()) pending.reject(normalized);
+    this.pendingRequests.clear();
   }
 
   protected getSessionCwd(): string {
@@ -407,8 +418,7 @@ export class BaseAgent {
       child.on("exit", (code, signal) => {
         if (this.stopping) return;
         const message = `ACP agent process exited${code === null ? "" : ` with code ${code}`}${signal ? ` (${signal})` : ""}.`;
-        for (const pending of this.pendingRequests.values()) pending.reject(new Error(message));
-        this.pendingRequests.clear();
+        this.rejectPendingRequests(new Error(message));
         this.emitAcpUpdate({ sessionUpdate: "_rookery_connection_error", error: message });
       });
     });

--- a/server/src/server/realtime/SessionRoom.test.ts
+++ b/server/src/server/realtime/SessionRoom.test.ts
@@ -182,4 +182,17 @@ describe("SessionRoom", () => {
 
     expect(agent.cancelled).toBe(1);
   });
+
+  it("rejects new work after the room is stopped", async () => {
+    const room = createRoom(new TestAgent());
+
+    await room.stop();
+
+    await expect(room.ensureStarted()).rejects.toThrow("Session room stopped.");
+    await expect(room.sendSteeringMessage("Keep going")).rejects.toThrow("Session room stopped.");
+    await expect(room.setMode("ask")).rejects.toThrow("Session room stopped.");
+    await expect(room.setConfigOption("verbosity", "high")).rejects.toThrow("Session room stopped.");
+    await expect(room.cancel()).rejects.toThrow("Session room stopped.");
+    await expect(room.run("hello")).resolves.toEqual({ ok: false, error: "Session room stopped." });
+  });
 });

--- a/server/src/server/realtime/SessionRoom.ts
+++ b/server/src/server/realtime/SessionRoom.ts
@@ -29,6 +29,10 @@ function logEnvironmentEvent(sessionId: string, event: string, environmentId: st
   console.log(`[environment] session=${sessionId} event=${event} environment=${environmentId}${Object.keys(extra).length > 0 ? ` ${JSON.stringify(extra)}` : ""}`);
 }
 
+function stoppedError(): Error {
+  return new Error("Session room stopped.");
+}
+
 export class SessionRoom implements EnvironmentEventListener {
   private readonly events: RoomEventStream;
   private readonly environmentState = new EnvironmentSessionState();
@@ -155,10 +159,12 @@ export class SessionRoom implements EnvironmentEventListener {
   }
 
   async ensureStarted(): Promise<void> {
+    if (this.stopped) throw stoppedError();
     if (this.started) return;
     if (!this.startPromise) {
       this.startPromise = this.currentRuntime.agent.ensureStarted()
         .then(() => {
+          if (this.stopped) throw stoppedError();
           this.started = true;
         })
         .finally(() => {
@@ -171,7 +177,9 @@ export class SessionRoom implements EnvironmentEventListener {
   async run(message: string): Promise<{ ok: true; stopReason: string } | { ok: false; error: string }> {
     const run = async () => {
       try {
+        if (this.stopped) throw stoppedError();
         await this.ensureStarted();
+        if (this.stopped) throw stoppedError();
         await this.currentRuntime.agent.run(message);
         return { ok: true, stopReason: this.currentRuntime.agent.lastStopReason ?? "end_turn" } as const;
       } catch (error) {
@@ -199,25 +207,30 @@ export class SessionRoom implements EnvironmentEventListener {
   }
 
   async cancel(): Promise<void> {
+    if (this.stopped) throw stoppedError();
     await this.currentRuntime.agent.cancel();
   }
 
   async sendSteeringMessage(message: string): Promise<void> {
+    if (this.stopped) throw stoppedError();
     await this.ensureStarted();
     await this.currentRuntime.agent.sendSteeringMessage(message);
   }
 
   async setMode(modeId: string): Promise<unknown> {
+    if (this.stopped) throw stoppedError();
     await this.ensureStarted();
     return await this.currentRuntime.agent.setMode(modeId);
   }
 
   async setConfigOption(configId: string, value: string): Promise<unknown> {
+    if (this.stopped) throw stoppedError();
     await this.ensureStarted();
     return await this.currentRuntime.agent.setConfigOption(configId, value);
   }
 
   respondToPermissionRequest(message: JsonRpcSuccess | JsonRpcFailure): void {
+    if (this.stopped) return;
     this.currentRuntime.agent.respondToPermissionRequest(message);
   }
 


### PR DESCRIPTION
## Summary
Improve server-side stop hygiene for live agent sessions so stopping a room or agent fails in-flight work cleanly instead of leaving requests hanging. This addresses the reliability half of issue #62's “timeout / stop hygiene” concern without yet adding new timeout behavior.

## Problem / context
Issue #62’s security/reliability review called out that the realtime seam was not shutting down cleanly. In particular, `BaseAgent.stopImpl` cleared pending ACP requests without rejecting them, and `SessionRoom` could still accept new work after it had been stopped. That left callers waiting forever on work that could never complete and made the stop button less trustworthy.

## Why this matters
Rook’s safety model depends on the user being able to halt agent activity predictably. If stop tears down the subprocess but leaves pending requests unresolved or still accepts new room work, the UI can look idle while promises remain hung behind the scenes. Tightening stop behavior makes “stop” a real control surface, which is especially important while issue #62’s larger security hardening is still in progress.

## Approaches considered
| Option | Summary | Why not (or chosen) |
|--------|---------|---------------------|
| Minimal process kill | Keep current behavior and only SIGTERM the child | Leaves ACP callers hanging and permits post-stop work to sneak in |
| Explicit shutdown rejection | Reject pending ACP work and guard room APIs once stopped | Chosen: smallest change that fixes the broken shutdown contract without changing prompt timing yet |

## Decision / approach taken
Tighten stop handling at the agent and room layers.

- `BaseAgent.stop()` now rejects all pending ACP requests before tearing down the subprocess.
- stop also clears pending permission-request ids so stale approvals cannot be replayed after shutdown.
- `SessionRoom` now rejects or ignores new work once the room has entered a stopped state.
- add regression tests covering pending-request rejection and post-stop room behavior.
- intentionally defer timeout/watchdog work to a follow-up so this PR stays focused on stop hygiene only.

## Product specification alignment
**Classification:** Extends

**Related PRODUCT/ docs:**
- [`PRODUCT/goals-of-rook.md`](PRODUCT/goals-of-rook.md) — supports the “as safe and transparent as possible” goal by making stop behavior more reliable
- [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — tightens the existing room/runtime lifecycle contract without changing the product model

**Documentation updates in this PR:**
- No PRODUCT/ updates — this is runtime hardening of an existing stop contract, not a product or architecture concept change.

**Notes:** This is one slice of issue #62 only: stop hygiene, not timeout hygiene.

## Architecture alignment
**Classification:** Extends

**Related docs / patterns:**
- [`PRODUCT/AS-BUILT-ARCHITECTURE.md`](PRODUCT/AS-BUILT-ARCHITECTURE.md) — `SessionRoom` owns room lifecycle and `BaseAgent` owns ACP subprocess lifecycle

**Documentation updates in this PR:**
- No architecture doc updates — component boundaries stay the same.

**Notes:** The change strengthens the existing shutdown semantics at the room/runtime seam without introducing new services, protocols, or persistence.

## High-level technical footprint
- **Components:** `SessionRoom`, `BaseAgent`
- **APIs / protocols:** ACP request lifecycle during stop
- **Data / events:** pending ACP requests now reject on shutdown instead of hanging indefinitely

## Test plan
- [x] `cd server && npm test -- --run src/server/agents/BaseAgent.test.ts src/server/realtime/SessionRoom.test.ts src/server/index.test.ts`
- [x] `cd server && npm run typecheck`
- [x] Manual sanity check: stop button now halts active work cleanly in local use
