### PR TITLE
issue-77: per-session environment offers and decisions

### DIFF
--- a/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
+++ b/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
@@ -176,13 +176,14 @@ public struct RookAPI {
         return try JSONDecoder().decode(IdentifyResponse.self, from: data).candidates
     }
 
-    public func decideEnvironment(environmentId: String, bundleHash: String, decision: String) async throws {
+    public func decideEnvironment(environmentId: String, bundleHash: String, decision: String, sessionId: String) async throws {
         _ = try await postJSON(
             path: "api/environments/decision",
             payload: .object([
                 "environmentId": .string(environmentId),
                 "bundleHash": .string(bundleHash),
                 "decision": .string(decision),
+                "sessionId": .string(sessionId),
             ])
         )
     }

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -1721,12 +1721,12 @@ final class RookMacModel: ObservableObject {
     }
 
     func decideEnvironment(_ decision: String) {
-        guard let offer = pendingOffer else {
+        guard let offer = pendingOffer, let session = currentSession else {
             return
         }
         Task {
             do {
-                try await api.decideEnvironment(environmentId: offer.environmentId, bundleHash: offer.bundleHash, decision: decision)
+                try await api.decideEnvironment(environmentId: offer.environmentId, bundleHash: offer.bundleHash, decision: decision, sessionId: session.id)
                 if decision == "accept" || decision == "approve" {
                     appendBlock(.system(text: "Bundle \(offer.bundleId) allowed for \(offer.environmentId)."))
                 }

--- a/server/src/server/environment/EnvironmentDecisionStore.ts
+++ b/server/src/server/environment/EnvironmentDecisionStore.ts
@@ -1,7 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { mkdirSync } from "node:fs";
 import path from "node:path";
-import type { PersistentDecision } from "./types.js";
+import type { PermanentDecision } from "./types.js";
 import { REPO_ROOT } from "../paths.js";
 
 /**
@@ -36,14 +36,14 @@ export class EnvironmentDecisionStore {
     `);
   }
 
-  getDecision(bundleHash: string): PersistentDecision | null {
+  getDecision(bundleHash: string): PermanentDecision | null {
     const row = this.db
       .prepare("SELECT decision FROM environment_decisions WHERE bundle_hash = ?")
-      .get(bundleHash) as { decision: PersistentDecision } | undefined;
+      .get(bundleHash) as { decision: PermanentDecision } | undefined;
     return row?.decision ?? null;
   }
 
-  setDecision(bundleHash: string, environmentId: string, bundleId: string | null, decision: PersistentDecision): void {
+  setDecision(bundleHash: string, environmentId: string, bundleId: string | null, decision: PermanentDecision): void {
     this.db
       .prepare(`
         INSERT INTO environment_decisions (bundle_hash, environment_id, bundle_id, decision, updated_at)

--- a/server/src/server/environment/EnvironmentManager.test.ts
+++ b/server/src/server/environment/EnvironmentManager.test.ts
@@ -128,14 +128,18 @@ describe("EnvironmentManager", () => {
     expect(second.lastTouchedAt).toBe(second.registeredAt);
   });
 
-  it("retains persistent decisions and ephemeral visit decisions", () => {
+  it("retains permanent decisions and session-scoped decisions", () => {
     const manager = newManager();
 
+    // Permanent approve: no sessionId needed, stored in DB.
     manager.decideEnvironment("web:example.com", "approve");
     expect(manager.effectiveDecision("web:example.com")).toBe("approve");
 
-    manager.decideEnvironment("web:example.com", "ignore");
-    expect(manager.effectiveDecision("web:example.com")).toBe("ignore");
+    // Session-scoped ignore: requires sessionId, in-memory only.
+    manager.decideEnvironment("web:example.com", "ignore", undefined, "s1");
+    expect(manager.effectiveDecision("web:example.com", "s1")).toBe("ignore");
+    // Other sessions don't see it.
+    expect(manager.effectiveDecision("web:example.com", "s2")).toBe("approve");
   });
 
   it("stores environment_id and bundle_id when approving a bundle by hash", async () => {
@@ -207,12 +211,14 @@ describe("EnvironmentManager", () => {
     });
 
     await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
-    manager.decideEnvironment("web:example.com", "accept", "hash-abc");
+    manager.decideEnvironment("web:example.com", "accept", "hash-abc", "s1");
 
-    const snapshot = manager.diagnosticSnapshot();
+    const snapshot = manager.diagnosticSnapshot("s1");
     expect(snapshot).toHaveLength(1);
-    // Per-bundle decision should be "accept".
+    // Per-bundle decision should be "accept" from s1's perspective.
     expect(snapshot[0].bundles[0].effectiveDecision).toBe("accept");
+    // Without sessionId, the session decision is invisible (only permanent shows).
+    expect(manager.diagnosticSnapshot()[0].bundles[0].effectiveDecision).toBe("undecided");
     // The top-level (environment-keyed) decision won't match the bundle hash.
   });
 
@@ -243,12 +249,12 @@ describe("EnvironmentManager", () => {
     });
 
     await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    manager.decideEnvironment("web:example.com", "accept", "hash-abc");
-    expect(manager.effectiveDecision("hash-abc")).toBe("accept");
+    manager.decideEnvironment("web:example.com", "accept", "hash-abc", "s1");
+    expect(manager.effectiveDecision("hash-abc", "s1")).toBe("accept");
 
-    // Advance past the active window — environment moves to recent, accept is forgotten.
+    // Advance past the active window — environment moves to recent, session-scoped accept is forgotten.
     nowMs += 1_001;
-    expect(manager.effectiveDecision("hash-abc")).toBe("undecided");
+    expect(manager.effectiveDecision("hash-abc", "s1")).toBe("undecided");
   });
 
   it("approve persists across environment expiry", async () => {
@@ -286,7 +292,7 @@ describe("EnvironmentManager", () => {
     expect(manager.effectiveDecision("hash-abc")).toBe("approve");
   });
 
-  it("tracks subscriptions without entering environments", async () => {
+  it("does not broadcast offers on registration — offers are deferred to enter", async () => {
     const repositoryService = mockRepositoryService();
     vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
       {
@@ -316,16 +322,8 @@ describe("EnvironmentManager", () => {
 
     await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
 
-    expect(listener.onEnvironmentOffered).toHaveBeenCalledWith({
-      environmentId: "web:example.com",
-      bundleId: "testing",
-      bundleHash: "hash-1",
-      sourceName: "Example",
-      canonicalSourceUrl: undefined,
-      skills: ["consult"],
-      mcpServers: ["crm"],
-      apps: ["slack"],
-    });
+    // Registration should NOT broadcast offers.
+    expect(listener.onEnvironmentOffered).not.toHaveBeenCalled();
     expect(listener.onEnvironmentEntered).not.toHaveBeenCalled();
     expect(manager.enteredEnvironments("s1")).toEqual([]);
   });
@@ -368,7 +366,7 @@ describe("EnvironmentManager", () => {
     ]);
   });
 
-  it("enters an environment and calls onEnvironmentEntered with skill paths", async () => {
+  it("enters an environment and calls onEnvironmentEntered with approved skill paths", async () => {
     const repositoryService = mockRepositoryService();
     vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
       {
@@ -397,7 +395,7 @@ describe("EnvironmentManager", () => {
     manager.subscribe("s1", listener);
 
     await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    // Approve the bundle so skills are included.
+    // Approve the bundle before entering so skills are included.
     manager.decideEnvironment("web:example.com", "approve", "hash-1");
 
     const entered = manager.enterEnvironment("s1", "web:example.com");
@@ -409,6 +407,8 @@ describe("EnvironmentManager", () => {
       ["/repo/web/example.com/.bundles/testing/skills/consult"],
       undefined,
     );
+    // No offers for already-approved bundles.
+    expect(listener.onEnvironmentOffered).not.toHaveBeenCalled();
 
     const defaultSkillsDir = path.join(tempHome, ".rook", "environment-repository", "web", "example.com", ".bundles", "default", "skills");
     expect(existsSync(defaultSkillsDir)).toBe(true);
@@ -450,6 +450,98 @@ describe("EnvironmentManager", () => {
     expect(remaining).toEqual([]);
     expect(manager.enteredEnvironments("s1")).toEqual([]);
     expect(listener.onEnvironmentExited).toHaveBeenCalledWith("web:example.com");
+  });
+
+  it("session decisions are cleared when exiting an environment", async () => {
+    const repositoryService = mockRepositoryService();
+    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
+      {
+        bundle: {
+          id: "web:example.com#testing",
+          bundleId: "testing",
+          environmentId: "web:example.com",
+          repository: "/repo",
+          bundlePath: "/repo/web/example.com/.bundles/testing",
+          skills: [],
+          mcpServers: [],
+          apps: [],
+          valid: true,
+          errors: [],
+        },
+        bundleHash: "hash-1",
+      },
+    ] as any);
+    const manager = new EnvironmentManager(repositoryService, decisions, {
+      activeEnvironmentWindowMs: 6 * 60_000,
+      recentEnvironmentRetentionMs: 30 * 60_000,
+      logger: { info: vi.fn() },
+      now: () => nowMs,
+    });
+    const listener = mockListener();
+    manager.subscribe("s1", listener);
+
+    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
+    manager.enterEnvironment("s1", "web:example.com");
+
+    // Accept the bundle for session s1.
+    manager.decideEnvironment("web:example.com", "accept", "hash-1", "s1");
+    expect(manager.effectiveDecision("hash-1", "s1")).toBe("accept");
+
+    // Exit the environment — session decisions should be cleared.
+    manager.exitEnvironment("s1", "web:example.com");
+    expect(manager.effectiveDecision("hash-1", "s1")).toBe("undecided");
+  });
+
+  it("session decisions are isolated across sessions", async () => {
+    const repositoryService = mockRepositoryService();
+    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
+      {
+        bundle: {
+          id: "web:example.com#testing",
+          bundleId: "testing",
+          environmentId: "web:example.com",
+          repository: "/repo",
+          bundlePath: "/repo/web/example.com/.bundles/testing",
+          skills: [{ id: "consult", files: {} }],
+          mcpServers: [],
+          apps: [],
+          valid: true,
+          errors: [],
+        },
+        bundleHash: "hash-1",
+      },
+    ] as any);
+    const manager = new EnvironmentManager(repositoryService, decisions, {
+      activeEnvironmentWindowMs: 6 * 60_000,
+      recentEnvironmentRetentionMs: 30 * 60_000,
+      logger: { info: vi.fn() },
+      now: () => nowMs,
+    });
+    const l1 = mockListener();
+    const l2 = mockListener();
+    manager.subscribe("s1", l1);
+    manager.subscribe("s2", l2);
+
+    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
+
+    // Session 1 enters and accepts.
+    manager.enterEnvironment("s1", "web:example.com");
+    manager.decideEnvironment("web:example.com", "accept", "hash-1", "s1");
+    expect(manager.effectiveDecision("hash-1", "s1")).toBe("accept");
+
+    // Session 2 enters — should get its own fresh offer, not affected by s1's decision.
+    vi.mocked(l2.onEnvironmentOffered).mockClear();
+    manager.enterEnvironment("s2", "web:example.com");
+    expect(l2.onEnvironmentOffered).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environmentId: "web:example.com",
+        bundleId: "testing",
+        bundleHash: "hash-1",
+        sourceName: "Example",
+      }),
+    );
+    // s2's onEnvironmentEntered should have empty skills (bundle still undecided from s2's perspective).
+    expect(l2.onEnvironmentEntered).toHaveBeenCalledWith("web:example.com", [], undefined);
   });
 
   it("entering a child environment also enters its active parents", async () => {
@@ -570,7 +662,7 @@ describe("EnvironmentManager", () => {
     expect(instructions).toContain('"vault": "WorkVault"');
   });
 
-  it("enterEnvironment skips bundles that are not approved or accepted", async () => {
+  it("offers undecided bundles when entering, and loads skills after approval", async () => {
     const repositoryService = mockRepositoryService();
     vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
       {
@@ -598,15 +690,37 @@ describe("EnvironmentManager", () => {
     const listener = mockListener();
     manager.subscribe("s1", listener);
 
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    // Do NOT decide on the bundle — it's undecided.
+    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
 
+    // Enter with an undecided bundle — it should be offered but not loaded.
     manager.enterEnvironment("s1", "web:example.com");
 
-    // Entered should still be called, but with empty skill paths.
+    expect(manager.enteredEnvironments("s1")).toEqual(["web:example.com"]);
+    // onEnvironmentEntered called with empty skills (bundle is undecided).
     expect(listener.onEnvironmentEntered).toHaveBeenCalledWith(
       "web:example.com",
       [],
+      undefined,
+    );
+    // Offer emitted for the undecided bundle.
+    expect(listener.onEnvironmentOffered).toHaveBeenCalledWith({
+      environmentId: "web:example.com",
+      bundleId: "testing",
+      bundleHash: "hash-1",
+      sourceName: "Example",
+      canonicalSourceUrl: undefined,
+      skills: ["consult"],
+      mcpServers: [],
+      apps: [],
+    });
+
+    // Now accept for this session — should trigger a re-enter with skills.
+    vi.mocked(listener.onEnvironmentEntered).mockClear();
+    manager.decideEnvironment("web:example.com", "accept", "hash-1", "s1");
+
+    expect(listener.onEnvironmentEntered).toHaveBeenCalledWith(
+      "web:example.com",
+      ["/repo/web/example.com/.bundles/testing/skills/consult"],
       undefined,
     );
   });

--- a/server/src/server/environment/EnvironmentManager.ts
+++ b/server/src/server/environment/EnvironmentManager.ts
@@ -3,14 +3,13 @@ import type { EnvironmentDecisionStore } from "./EnvironmentDecisionStore.js";
 import type { EnvironmentPreview } from "../../shared/environment.js";
 import type { EnvironmentRepositoryService } from "./EnvironmentRepositoryService.js";
 import { ensureDefaultEnvironmentBinding, renderEnvironmentBindingPrompt } from "./EnvironmentBinding.js";
+import { SessionDecisionRegistry } from "./SessionDecisionRegistry.js";
 import type {
-  EnvironmentBundleOffer,
   EnvironmentDecision,
   EnvironmentEventListener,
   EnvironmentOfferInfo,
   EnvironmentRecord,
   EffectiveDecision,
-  EphemeralDecision,
   EnvironmentResolution,
 } from "./types.js";
 
@@ -59,17 +58,22 @@ export interface EnvironmentManagerOptions {
 }
 
 /**
- * Simplified environment manager.
+ * Environment manager.
  *
- * Current behavior:
+ * Decision model (the 2×2):
+ *   positive × permanent = "approve" → SQLite, survives restarts
+ *   positive × session   = "accept"  → in-memory per-session, cleared on exit/expiry
+ *   negative × session   = "ignore"  → in-memory per-session, cleared on exit/expiry
+ *   negative × permanent = "reject"  → SQLite, survives restarts
+ *
+ * Behavior:
  * - keep environments in memory as either active or recent
  * - on registration, resolve any valid bundles and remember their exact-content hashes
- * - active = touched by register within the active window
- * - when the active window expires, the environment moves to recent
- * - recent entries are retained for a second, longer TTL before being forgotten
- * - log register / expiry activity
- * - push bundle offer / resolution events into subscribed rooms
- * - do not yet load bundle capabilities into runtimes during registration
+ * - bundle offers are only issued when a session enters an environment, not on registration
+ * - session decisions (accept/ignore) are per-session — session 2 entering the same env
+ *   sees its own fresh offers regardless of what session 1 decided
+ * - when a session exits an environment, its session decisions for that env are cleared
+ * - when a user approves/accepts, any session already inside the env gets skills reloaded
  */
 function environmentHierarchy(environmentId: string): string[] {
   const separator = environmentId.indexOf(":");
@@ -87,7 +91,7 @@ function environmentHierarchy(environmentId: string): string[] {
 
 export class EnvironmentManager {
   private readonly remembered = new Map<string, RememberedEnvironmentEntry>();
-  private readonly ephemeral = new Map<string, EphemeralDecision>();
+  private readonly sessionDecisions: SessionDecisionRegistry;
   private readonly listeners = new Map<string, EnvironmentEventListener>();
   private readonly explicitlyEntered = new Map<string, Set<string>>();
   private readonly entered = new Map<string, Set<string>>();
@@ -99,9 +103,10 @@ export class EnvironmentManager {
 
   constructor(
     private readonly repositoryService: EnvironmentRepositoryService,
-    private readonly decisions: EnvironmentDecisionStore,
+    decisions: EnvironmentDecisionStore,
     options: EnvironmentManagerOptions = {},
   ) {
+    this.sessionDecisions = new SessionDecisionRegistry(decisions);
     this.activeEnvironmentWindowMs = options.activeEnvironmentWindowMs ?? 6 * 60_000;
     this.recentEnvironmentRetentionMs = options.recentEnvironmentRetentionMs ?? 30 * 60_000;
     this.logger = options.logger ?? console;
@@ -171,26 +176,19 @@ export class EnvironmentManager {
     const currentBundleHashes = new Set(bundles.map((bundle) => bundle.bundleHash));
     for (const previousBundle of previousBundles) {
       if (currentBundleHashes.has(previousBundle.bundleHash)) continue;
-      this.ephemeral.delete(previousBundle.bundleHash);
+      this.sessionDecisions.clearAllForBundle(previousBundle.bundleHash);
       this.broadcastBundleResolution(env.id, previousBundle.bundleId, previousBundle.bundleHash, "unavailable");
     }
-    for (const bundle of bundles) {
-      if (previousBundleHashes.has(bundle.bundleHash)) continue;
-      if (this.effectiveDecision(bundle.bundleHash) !== "undecided") continue;
-      this.broadcastBundleOffer({
-        environmentId: env.id,
-        bundleId: bundle.bundleId,
-        bundleHash: bundle.bundleHash,
-        sourceName: info.sourceName,
-        canonicalSourceUrl: info.canonicalSourceUrl,
-        skills: bundle.skills,
-        mcpServers: bundle.mcpServers,
-        apps: bundle.apps,
-      });
-    }
+    // Offers are deferred until a session enters the environment (see syncEnteredEnvironments).
   }
 
-  decideEnvironment(environmentId: string, decision: EnvironmentDecision, bundleHash?: string): void {
+  /**
+   * Record a decision. Persistent decisions (approve/reject) go to SQLite.
+   * Session decisions (accept/ignore) are per-session in-memory and cleared on exit/expiry.
+   *
+   * @param sessionId required for session-scoped decisions (accept/ignore); optional for permanent.
+   */
+  decideEnvironment(environmentId: string, decision: EnvironmentDecision, bundleHash?: string, sessionId?: string): void {
     this.pruneMemory();
     const decisionKey = bundleHash ?? environmentId;
     const bundle = bundleHash
@@ -198,10 +196,17 @@ export class EnvironmentManager {
       : undefined;
 
     if (decision === "approve" || decision === "reject") {
-      this.decisions.setDecision(decisionKey, environmentId, bundle?.bundleId ?? null, decision);
-      this.ephemeral.delete(decisionKey);
+      // Permanent: store in SQLite, clear session-level overrides.
+      this.sessionDecisions.setPermanent(decisionKey, environmentId, bundle?.bundleId ?? null, decision);
     } else {
-      this.ephemeral.set(decisionKey, decision);
+      // Session-scoped: store per-session. If no sessionId is provided,
+      // apply to every session that has entered this environment (fallback).
+      const targetSessions = sessionId
+        ? [sessionId]
+        : [...this.entered.entries()].filter(([, envs]) => envs.has(environmentId)).map(([sid]) => sid);
+      for (const sid of targetSessions) {
+        this.sessionDecisions.setSession(sid, decisionKey, decision);
+      }
     }
 
     if (bundle) {
@@ -212,13 +217,24 @@ export class EnvironmentManager {
         decision === "accept" || decision === "approve" ? "approved" : "dismissed",
       );
     }
+
+    // When accepting or approving a bundle, reload skills for any session already inside this env.
+    if (decision === "accept" || decision === "approve") {
+      for (const [sid, entered] of this.entered.entries()) {
+        if (!entered.has(environmentId)) continue;
+        const listener = this.listeners.get(sid);
+        if (!listener) continue;
+        const entry = this.remembered.get(environmentId);
+        if (!entry || entry.status !== "active") continue;
+        listener.onEnvironmentEntered(environmentId, this.skillPathsForEntry(entry, sid), entry.contextText);
+      }
+    }
   }
 
-  effectiveDecision(bundleHash: string): EffectiveDecision {
+  /** Get the effective decision for a bundle hash from a session's perspective. */
+  effectiveDecision(bundleHash: string, sessionId?: string): EffectiveDecision {
     this.pruneMemory();
-    const ephemeral = this.ephemeral.get(bundleHash);
-    if (ephemeral) return ephemeral;
-    return this.decisions.getDecision(bundleHash) ?? "undecided";
+    return this.sessionDecisions.effective(bundleHash, sessionId);
   }
 
   subscribe(sessionId: string, listener: EnvironmentEventListener): void {
@@ -226,28 +242,14 @@ export class EnvironmentManager {
     this.listeners.set(sessionId, listener);
     if (!this.explicitlyEntered.has(sessionId)) this.explicitlyEntered.set(sessionId, new Set());
     if (!this.entered.has(sessionId)) this.entered.set(sessionId, new Set());
-    for (const entry of this.remembered.values()) {
-      if (entry.status !== "active") continue;
-      for (const bundle of entry.bundles) {
-        if (this.effectiveDecision(bundle.bundleHash) !== "undecided") continue;
-        listener.onEnvironmentOffered({
-          environmentId: entry.record.id,
-          bundleId: bundle.bundleId,
-          bundleHash: bundle.bundleHash,
-          sourceName: entry.info.sourceName,
-          canonicalSourceUrl: entry.info.canonicalSourceUrl,
-          skills: bundle.skills,
-          mcpServers: bundle.mcpServers,
-          apps: bundle.apps,
-        });
-      }
-    }
+    // Offers are deferred until the session enters an environment.
   }
 
   unsubscribe(sessionId: string): void {
     this.listeners.delete(sessionId);
     this.explicitlyEntered.delete(sessionId);
     this.entered.delete(sessionId);
+    this.sessionDecisions.clearSession(sessionId);
   }
 
   async getEnvironmentPreview(environmentId: string): Promise<EnvironmentPreview> {
@@ -309,7 +311,7 @@ export class EnvironmentManager {
     return this.syncEnteredEnvironments(sessionId, listener);
   }
 
-  diagnosticSnapshot(): DiagnosticEnvironmentEntry[] {
+  diagnosticSnapshot(sessionId?: string): DiagnosticEnvironmentEntry[] {
     this.pruneMemory();
     return [...this.remembered.entries()]
       .map(([environmentId, entry]) => ({
@@ -323,11 +325,11 @@ export class EnvironmentManager {
         contextText: entry.contextText,
         bundles: entry.bundles.map((bundle) => ({
           ...bundle,
-          effectiveDecision: this.effectiveDecision(bundle.bundleHash),
+          effectiveDecision: this.effectiveDecision(bundle.bundleHash, sessionId),
         })),
         bundleIds: entry.bundleIds,
         bundleCollectionPaths: entry.bundleCollectionPaths,
-        effectiveDecision: this.effectiveDecision(environmentId),
+        effectiveDecision: this.effectiveDecision(environmentId, sessionId),
       }))
       .sort((a, b) => {
         if (a.status !== b.status) return a.status === "active" ? -1 : 1;
@@ -346,7 +348,7 @@ export class EnvironmentManager {
   }[] {
     this.pruneMemory();
     const entered = this.entered.get(sessionId) ?? new Set();
-    const entries = this.diagnosticSnapshot();
+    const entries = this.diagnosticSnapshot(sessionId);
 
     const list = entries.map((entry) => {
       const approved = entry.bundles.filter(
@@ -384,12 +386,32 @@ export class EnvironmentManager {
       if (!entry || entry.status !== "active") continue;
 
       ensureDefaultEnvironmentBinding(environmentId);
-      listener.onEnvironmentEntered(environmentId, this.skillPathsForEntry(entry), entry.contextText);
+      listener.onEnvironmentEntered(environmentId, this.skillPathsForEntry(entry, sessionId), entry.contextText);
+
+      // Offer undecided bundles only when this session enters the environment.
+      for (const bundle of entry.bundles) {
+        if (this.effectiveDecision(bundle.bundleHash, sessionId) !== "undecided") continue;
+        listener.onEnvironmentOffered({
+          environmentId,
+          bundleId: bundle.bundleId,
+          bundleHash: bundle.bundleHash,
+          sourceName: entry.info.sourceName,
+          canonicalSourceUrl: entry.info.canonicalSourceUrl,
+          skills: bundle.skills,
+          mcpServers: bundle.mcpServers,
+          apps: bundle.apps,
+        });
+      }
     }
 
     for (const environmentId of current) {
       if (next.has(environmentId)) continue;
       listener.onEnvironmentExited(environmentId);
+      // Clear this session's decisions for the exited environment's bundles.
+      const entry = this.remembered.get(environmentId);
+      if (entry) {
+        this.sessionDecisions.clearSessionForBundles(sessionId, entry.bundles.map((b) => b.bundleHash));
+      }
     }
 
     this.entered.set(sessionId, next);
@@ -408,10 +430,10 @@ export class EnvironmentManager {
     return effective;
   }
 
-  private skillPathsForEntry(entry: RememberedEnvironmentEntry): string[] {
+  private skillPathsForEntry(entry: RememberedEnvironmentEntry, sessionId: string): string[] {
     const skillPaths: string[] = [];
     for (const bundle of entry.bundles) {
-      const decision = this.effectiveDecision(bundle.bundleHash);
+      const decision = this.sessionDecisions.effective(bundle.bundleHash, sessionId);
       if (decision !== "accept" && decision !== "approve") continue;
       if (!bundle.bundlePath) continue;
       for (const skillId of bundle.skills) {
@@ -419,12 +441,6 @@ export class EnvironmentManager {
       }
     }
     return skillPaths;
-  }
-
-  private broadcastBundleOffer(offer: EnvironmentBundleOffer): void {
-    for (const listener of this.listeners.values()) {
-      listener.onEnvironmentOffered(offer);
-    }
   }
 
   private broadcastBundleResolution(environmentId: string, bundleId: string, bundleHash: string, resolution: EnvironmentResolution): void {
@@ -448,9 +464,9 @@ export class EnvironmentManager {
             status: "recent",
             activeUntil: undefined,
           });
-          this.ephemeral.delete(environmentId);
+          // Clear all sessions' decisions for this environment's bundles.
+          this.sessionDecisions.clearAllForBundles(entry.bundles.map((b) => b.bundleHash));
           for (const bundle of entry.bundles) {
-            this.ephemeral.delete(bundle.bundleHash);
             this.broadcastBundleResolution(environmentId, bundle.bundleId, bundle.bundleHash, "unavailable");
           }
           this.logger.info(
@@ -469,10 +485,7 @@ export class EnvironmentManager {
         const lastTouchedAt = Date.parse(entry.lastTouchedAt);
         if (lastTouchedAt + this.recentEnvironmentRetentionMs > now) continue;
         this.remembered.delete(environmentId);
-        this.ephemeral.delete(environmentId);
-        for (const bundle of entry.bundles) {
-          this.ephemeral.delete(bundle.bundleHash);
-        }
+        this.sessionDecisions.clearAllForBundles(entry.bundles.map((b) => b.bundleHash));
         this.logger.info(
           {
             environmentId,

--- a/server/src/server/environment/SessionDecisionRegistry.ts
+++ b/server/src/server/environment/SessionDecisionRegistry.ts
@@ -1,0 +1,81 @@
+import type { SessionDecision, EffectiveDecision, PermanentDecision } from "./types.js";
+import type { EnvironmentDecisionStore } from "./EnvironmentDecisionStore.js";
+
+/**
+ * Per-session, in-memory decision registry.
+ *
+ * Each session gets its own map of (bundleHash → accept/ignore).
+ * Permanent decisions (approve/reject) live in the EnvironmentDecisionStore (SQLite)
+ * and are consulted as a fallback via the provided store reference.
+ *
+ * Session decisions are cleared when:
+ * - the session exits the environment (caller calls clearSessionForBundles)
+ * - the environment expires (caller calls clearAllForBundles)
+ * - a bundle disappears on re-registration (caller calls clearAllForBundle)
+ * - the session unsubscribes (caller calls clearSession)
+ */
+export class SessionDecisionRegistry {
+  private readonly perSession = new Map<string, Map<string, SessionDecision>>();
+
+  constructor(private readonly permanentStore: EnvironmentDecisionStore) {}
+
+  /** Effective decision for a bundle hash from a session's perspective. */
+  effective(bundleHash: string, sessionId?: string): EffectiveDecision {
+    if (sessionId) {
+      const sessionDecision = this.perSession.get(sessionId)?.get(bundleHash);
+      if (sessionDecision) return sessionDecision;
+    }
+    return this.permanentStore.getDecision(bundleHash) ?? "undecided";
+  }
+
+  /** Store a permanent decision (clears any session-level override for this hash). */
+  setPermanent(bundleHash: string, environmentId: string, bundleId: string | null, decision: PermanentDecision): void {
+    this.permanentStore.setDecision(bundleHash, environmentId, bundleId, decision);
+    this.clearAllForBundle(bundleHash);
+  }
+
+  /** Store a session-scoped decision for the given session. Does nothing without sessionId. */
+  setSession(sessionId: string | undefined, bundleHash: string, decision: SessionDecision): void {
+    if (!sessionId) return;
+    let map = this.perSession.get(sessionId);
+    if (!map) {
+      map = new Map();
+      this.perSession.set(sessionId, map);
+    }
+    map.set(bundleHash, decision);
+  }
+
+  /** Drop all decisions for the given session (on unsubscribe). */
+  clearSession(sessionId: string): void {
+    this.perSession.delete(sessionId);
+  }
+
+  /** Drop this session's decisions for the given bundle hashes (on environment exit). */
+  clearSessionForBundles(sessionId: string, bundleHashes: Iterable<string>): void {
+    const map = this.perSession.get(sessionId);
+    if (!map) return;
+    for (const hash of bundleHashes) {
+      map.delete(hash);
+    }
+    if (map.size === 0) this.perSession.delete(sessionId);
+  }
+
+  /** Drop every session's decision for a single bundle hash (bundle removed on re-registration). */
+  clearAllForBundle(bundleHash: string): void {
+    for (const map of this.perSession.values()) {
+      map.delete(bundleHash);
+    }
+  }
+
+  /** Drop every session's decisions for multiple bundle hashes (environment expired). */
+  clearAllForBundles(bundleHashes: Iterable<string>): void {
+    for (const hash of bundleHashes) {
+      this.clearAllForBundle(hash);
+    }
+  }
+
+  /** Whether any session has any decision. */
+  get isEmpty(): boolean {
+    return this.perSession.size === 0;
+  }
+}

--- a/server/src/server/environment/types.ts
+++ b/server/src/server/environment/types.ts
@@ -7,13 +7,20 @@ export interface EnvironmentRecord {
   metadata: Record<string, unknown>;
 }
 
-/** Decisions that persist across availability episodes (stored in SQLite). */
-export type PersistentDecision = "approve" | "reject";
+/**
+ * Permanently approve / permanently reject — durable decisions stored in SQLite,
+ * survive restarts and environment expiry.
+ */
+export type PermanentDecision = "approve" | "reject";
 
-/** Decisions scoped to the current availability episode (in-memory, cleared on unavailable). */
-export type EphemeralDecision = "accept" | "ignore";
+/**
+ * Approve for session / reject for session — scoped to one session's current
+ * environment visit. Stored in memory only, cleared when the session exits the
+ * environment or the environment expires.
+ */
+export type SessionDecision = "accept" | "ignore";
 
-/** Effective decision for an environment right now, or "undecided" if the user hasn't chosen. */
+/** Effective decision for a bundle hash from a session's perspective, or "undecided". */
 export type EffectiveDecision = EnvironmentDecision | "undecided";
 
 /** How an offer was closed — used to dismiss prompts across every client of a room. */
@@ -38,9 +45,9 @@ export interface EnvironmentBundleOffer extends EnvironmentOfferInfo {
  * pushes these; the room turns them into runtime changes and client broadcasts.
  */
 export interface EnvironmentEventListener {
-  /** Available + undecided: prompt this room's clients to decide. */
+  /** An undecided bundle the user should review (prompt in UI). */
   onEnvironmentOffered(offer: EnvironmentBundleOffer): void;
-  /** Decision is accept/approve and the env is available: load skills (restart when idle).
+  /** Skills to load for this environment (approved/permanently-approved bundles only).
    * `contextText` (when present) is ambient context pushed into the agent on enter. */
   onEnvironmentEntered(environmentId: string, skillPaths: string[], contextText?: string): void;
   /** Env left or was turned negative: remove skills (restart when idle). */

--- a/server/src/server/location/LocationRegistrar.ts
+++ b/server/src/server/location/LocationRegistrar.ts
@@ -8,7 +8,7 @@ export interface LocationEnvironmentSink {
     info: { sourceName?: string; canonicalSourceUrl?: string },
     contextText?: string,
   ): Promise<void>;
-  decideEnvironment(environmentId: string, decision: "accept" | "approve" | "ignore" | "reject"): void;
+  decideEnvironment(environmentId: string, decision: "accept" | "approve" | "ignore" | "reject", bundleHash?: string, sessionId?: string): void;
 }
 
 /** The slice of LocationContextRepository the registrar needs (eases testing). */

--- a/server/src/server/routes/environmentRoutes.ts
+++ b/server/src/server/routes/environmentRoutes.ts
@@ -38,10 +38,11 @@ export async function registerEnvironmentRoutes(
     return { ok: true, id: trimmedId, registeredAt };
   });
 
-  app.post<{ Body: { environmentId?: unknown; bundleHash?: unknown; decision?: unknown } }>("/api/environments/decision", async (request, reply) => {
+  app.post<{ Body: { environmentId?: unknown; bundleHash?: unknown; decision?: unknown; sessionId?: unknown } }>("/api/environments/decision", async (request, reply) => {
     const environmentId = request.body?.environmentId;
     const bundleHash = typeof request.body?.bundleHash === "string" && request.body.bundleHash.trim() ? request.body.bundleHash.trim() : undefined;
     const decision = request.body?.decision;
+    const sessionId = typeof request.body?.sessionId === "string" && request.body.sessionId.trim() ? request.body.sessionId.trim() : undefined;
     if (typeof environmentId !== "string" || !environmentId.trim()) {
       reply.code(400).send({ error: "Missing environmentId" });
       return;
@@ -51,8 +52,8 @@ export async function registerEnvironmentRoutes(
       return;
     }
     const trimmedEnvironmentId = environmentId.trim();
-    request.log.info({ environmentId: trimmedEnvironmentId, bundleHash, decision }, "environment decision recorded");
-    environmentManager.decideEnvironment(trimmedEnvironmentId, decision as EnvironmentDecision, bundleHash);
+    request.log.info({ environmentId: trimmedEnvironmentId, bundleHash, decision, sessionId }, "environment decision recorded");
+    environmentManager.decideEnvironment(trimmedEnvironmentId, decision as EnvironmentDecision, bundleHash, sessionId);
     return { ok: true };
   });
 

--- a/server/src/shared/environment.ts
+++ b/server/src/shared/environment.ts
@@ -15,7 +15,13 @@ export interface EnvironmentPreview {
   bundles: EnvironmentBundlePreview[];
 }
 
-/** The 2×2 decision model: positive/negative × this-visit/permanent. */
+/**
+ * The 2×2 decision model:
+ * - "approve" = permanently approve (persists in SQLite, survives restarts)
+ * - "accept"  = approve for this session (in-memory, cleared on exit/expiry)
+ * - "ignore"  = reject for this session (in-memory, cleared on exit/expiry)
+ * - "reject"  = permanently reject (persists in SQLite, survives restarts)
+ */
 export type EnvironmentDecision = "accept" | "approve" | "ignore" | "reject";
 
 export const ENVIRONMENT_OFFER_AVAILABLE_KIND = "environment_offer_available";


### PR DESCRIPTION
Environment offers are now only issued when a session enters an environment — not broadcast to all sessions on registration. Session-scoped decisions (approve/reject for session) are per-session in-memory, cleared on exit/expiry.

### What changed
- **Offers deferred** to `syncEnteredEnvironments()` when a session enters
- **Per-session decisions** via new `SessionDecisionRegistry` — accept/ignore scoped to `(sessionId × bundleHash)`
- **Accept/approve triggers runtime rebuild** — newly approved skills load without re-entering
- **Terminology**: permanently approve / approve for session / reject for session / permanently reject
- **Mac client**: sends `sessionId` with decision API calls

### Test coverage
- Offers not broadcast on registration
- Undecided bundles offered on enter, skills loaded after accept
- Session decisions cleared on exit
- Cross-session isolation (session 2 gets fresh offers)

Refs: #77, #2