### PR TITLE
Log environment metadata captures

### DIFF
--- a/PRODUCT/AS-BUILT-ARCHITECTURE.md
+++ b/PRODUCT/AS-BUILT-ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Rookery - As-Built Architecture
 
-**Last Updated**: 2026-06-16
+**Last Updated**: 2026-07-07
 
 This document is the short, current architecture description for the repo as it exists today. It intentionally avoids historical detail and low-level implementation notes.
 
@@ -13,7 +13,6 @@ Rookery is a local-first monorepo centered on one service at `127.0.0.1:3000`:
 - when configured, bearer auth is required for all client access, including localhost
 
 - a **Fastify server**
-- a **React Native web chat UI**
 - a **WebSocket ACP bridge** to agent runtimes
 - an **environment manager** that can hot-load environment-linked skills into a session
 
@@ -23,8 +22,6 @@ The repo is organized into focused top-level packages: `server/` and a `clients/
 
 ```text
 Host clients / providers                         registers environment kind
-  ├─ Browser at :3000
-  ├─ Chrome extension                            web:<slug>
   ├─ Obsidian plugin
   ├─ macOS menu bar app (native Swift)           app:<slug>, web:<slug>   (foreground encounters, plus close detection)
   └─ iPhone app (native Swift)                   loc:<slug> (GPS geofence)
@@ -218,6 +215,7 @@ Storage model:
 - discovered bundles and their exact-content hashes live alongside each remembered environment in memory
 - ephemeral decisions (`accept`, `ignore`) live in memory
 - persistent decisions (`approve`, `reject`) live in SQLite keyed by bundle-content hash
+- optional registration-capture sinks can be wired in at server bootstrap; the current default sink creates `IGNORED/environment_metadata_captures/` and appends JSONL registration records there
 
 ### 6.4 How environments affect sessions
 
@@ -274,9 +272,10 @@ The client is structured around:
 
 Current ecosystem around `:3000`:
 
-- **Chrome extension**: detects supported web contexts and registers `web:<slug>` environments
+- there is no current in-repo browser chat client hosted by the server; `buildServer({ enableClient })` keeps `enableClient` only as a legacy no-op
+- there is no current in-repo Chrome extension package
 - **Obsidian plugin**: embeds the app in a sidebar view
-- **macOS menu bar app**: native SwiftUI client with the same backend; registers newly seen user-visible app/page encounters, re-registers them every 5 minutes while still in its local TTL cache, and otherwise lets the server age them out
+- **macOS menu bar app**: native SwiftUI client with the same backend; registers newly seen user-visible app/page encounters, including `web:<slug>` environments from the active browser, re-registers them every 5 minutes while still in its local TTL cache, and otherwise lets the server age them out
 - **iPhone app**: native SwiftUI client that registers `loc:<slug>` environments from GPS geofences, making the agent location-aware (skills load as you arrive at a defined place). It also drives ptiles-based business discovery on arrival, registering `loc:<domain>/…` environments — see [`location-environment-awareness.md`](./location-environment-awareness.md). Adds Live Activity / Dynamic Island presence and on-device voice.
 
 The two native Swift clients share one cross-platform layer — models, the REST/ACP-WebSocket clients, the design system and chat-block views, voice, and Live Activity attributes — through the `clients/RookKit` Swift package, so they stay protocol- and design-consistent with a single source of truth.

--- a/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
@@ -832,6 +832,7 @@ class RookViewModel(
                 put("slug", place.id)
                 put("latitude", place.latitude)
                 put("longitude", place.longitude)
+                put("radiusMeters", place.radius)
             }
             runCatching { api.registerEnvironment(envId, place.name, metadata) }
         }
@@ -846,6 +847,7 @@ class RookViewModel(
                 put("slug", place.id)
                 put("latitude", place.latitude)
                 put("longitude", place.longitude)
+                put("radiusMeters", place.radius)
             }
             runCatching { api.registerEnvironment(envId, place.name, metadata) }
         }

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -23,8 +23,8 @@ binding, and bearer-token auth, start with [docs/setup.md](../../docs/setup.md).
   radius). `LocationProvider` monitors each as a `CLCircularRegion`. Entering a
   region builds `loc:<slug>`, pre-checks the server for matching bundles
   (`GET /api/environments/preview`), and if any exist registers the environment
-  (`POST /api/environments/register`) with `latitude`/`longitude`/`regionId`
-  metadata. The server pushes a bundle offer over the session websocket; you
+  (`POST /api/environments/register`) with `slug`, `latitude`, `longitude`, and
+  `radiusMeters` metadata. The server pushes a bundle offer over the session websocket; you
   review the bundle name plus the names of any skills, MCP servers, and apps it
   contains, then decide with the same 2×2 choices as every other client.
   Leaving the region simply stops refreshing it from the phone; the server ages

--- a/clients/iphone/Rook.xcodeproj/project.pbxproj
+++ b/clients/iphone/Rook.xcodeproj/project.pbxproj
@@ -373,7 +373,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.d56ksd4ff9.RookTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.RookTests;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -394,7 +394,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.d56ksd4ff9.Rook;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook;
 				PRODUCT_NAME = Rook;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -411,7 +411,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.d56ksd4ff9.RookTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.RookTests;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -487,7 +487,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.d56ksd4ff9.Rook.RookWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook.RookWidgets;
 				PRODUCT_NAME = RookWidgets;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
@@ -570,7 +570,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.d56ksd4ff9.Rook.RookWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook.RookWidgets;
 				PRODUCT_NAME = RookWidgets;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
@@ -591,7 +591,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.d56ksd4ff9.Rook;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook;
 				PRODUCT_NAME = Rook;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -360,6 +360,7 @@ final class RookModel: ObservableObject {
                 "slug": .string(place.id),
                 "latitude": .number(place.latitude),
                 "longitude": .number(place.longitude),
+                "radiusMeters": .number(place.radius),
             ]
             try? await api.registerEnvironment(id: envId, sourceName: place.name, metadata: metadata)
         }
@@ -374,6 +375,7 @@ final class RookModel: ObservableObject {
                 "slug": .string(place.id),
                 "latitude": .number(place.latitude),
                 "longitude": .number(place.longitude),
+                "radiusMeters": .number(place.radius),
             ]
             try? await api.registerEnvironment(id: envId, sourceName: place.name, metadata: metadata)
         }

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -1090,6 +1090,51 @@ final class RookMacModel: ObservableObject {
         return ids
     }
 
+    private static func environmentCandidates(
+        bundleId: String,
+        appName: String,
+        windowTitle: String? = nil,
+        rawURL: String? = nil
+    ) -> [EnvironmentCandidate] {
+        var candidates: [EnvironmentCandidate] = []
+
+        var appMetadata: [String: JSONValue] = [
+            "bundleId": .string(bundleId),
+            "appName": .string(appName),
+        ]
+        if let windowTitle, !windowTitle.isEmpty {
+            appMetadata["windowTitle"] = .string(windowTitle)
+        }
+
+        if let windowTitle,
+           let vault = Self.obsidianVaultName(from: windowTitle) {
+            var vaultMetadata = appMetadata
+            vaultMetadata["vaultName"] = .string(vault)
+            candidates.append(EnvironmentCandidate(
+                id: "app:\(bundleId)/\(Self.encodeEnvironmentPathComponent(vault))",
+                sourceName: "\(appName) · \(vault)",
+                metadata: vaultMetadata
+            ))
+        }
+        candidates.append(EnvironmentCandidate(
+            id: "app:\(bundleId)",
+            sourceName: appName,
+            metadata: appMetadata
+        ))
+
+        if Self.browserBundleIds.contains(bundleId),
+           let rawURL {
+            candidates.append(contentsOf: Self.webEnvironmentCandidates(
+                rawURL: rawURL,
+                bundleId: bundleId,
+                appName: appName,
+                windowTitle: windowTitle
+            ))
+        }
+
+        return candidates.sorted { Self.environmentDepth($0.id) < Self.environmentDepth($1.id) }
+    }
+
     /// Produces hierarchical web environment candidates for a browser URL.
     /// Returns one candidate per path segment depth (e.g. `web:x.com` and `web:x.com/home`).
     private static func webEnvironmentCandidates(
@@ -1192,45 +1237,15 @@ final class RookMacModel: ObservableObject {
     }
 
     private func deriveForegroundEnvironmentCandidates(app: ForegroundApp, title: String?) -> [EnvironmentCandidate] {
-        var candidates: [EnvironmentCandidate] = []
-
-        var appMetadata: [String: JSONValue] = [
-            "bundleId": .string(app.bundleId),
-            "appName": .string(app.name),
-        ]
-        if let title, !title.isEmpty {
-            appMetadata["windowTitle"] = .string(title)
-        }
-
-        // Always register the base app environment; additionally register a
-        // vault-scoped child when the window title contains an Obsidian vault name.
-        if let title,
-           let vault = Self.obsidianVaultName(from: title) {
-            var vaultMetadata = appMetadata
-            vaultMetadata["vaultName"] = .string(vault)
-            candidates.append(EnvironmentCandidate(
-                id: "app:\(app.bundleId)/\(Self.encodeEnvironmentPathComponent(vault))",
-                sourceName: "\(app.name) · \(vault)",
-                metadata: vaultMetadata
-            ))
-        }
-        candidates.append(EnvironmentCandidate(
-            id: "app:\(app.bundleId)",
-            sourceName: app.name,
-            metadata: appMetadata
-        ))
-
-        if Self.browserBundleIds.contains(app.bundleId),
-           let rawURL = AXReader.activeTabURL(pid: app.pid) {
-            candidates.append(contentsOf: Self.webEnvironmentCandidates(
-                rawURL: rawURL,
-                bundleId: app.bundleId,
-                appName: app.name,
-                windowTitle: title
-            ))
-        }
-
-        return candidates.sorted { Self.environmentDepth($0.id) < Self.environmentDepth($1.id) }
+        let rawURL = Self.browserBundleIds.contains(app.bundleId)
+            ? AXReader.activeTabURL(pid: app.pid)
+            : nil
+        return Self.environmentCandidates(
+            bundleId: app.bundleId,
+            appName: app.name,
+            windowTitle: title,
+            rawURL: rawURL
+        )
     }
 
     private func encounterEnvironmentCandidates(_ candidates: [EnvironmentCandidate], reason: String) {
@@ -1350,25 +1365,17 @@ final class RookMacModel: ObservableObject {
                 continue
             }
 
-            let appCandidate = EnvironmentCandidate(
-                id: "app:\(bundleId)",
-                sourceName: name,
-                metadata: [
-                    "bundleId": .string(bundleId),
-                    "appName": .string(name),
-                ]
-            )
-            byId[appCandidate.id] = appCandidate
-
-            if Self.browserBundleIds.contains(bundleId),
-               let rawURL = AXReader.activeTabURL(pid: app.processIdentifier) {
-                for candidate in Self.webEnvironmentCandidates(
-                    rawURL: rawURL,
-                    bundleId: bundleId,
-                    appName: name
-                ) {
-                    byId[candidate.id] = candidate
-                }
+            let title = AXReader.focusedWindowTitle(pid: app.processIdentifier)
+            let rawURL = Self.browserBundleIds.contains(bundleId)
+                ? AXReader.activeTabURL(pid: app.processIdentifier)
+                : nil
+            for candidate in Self.environmentCandidates(
+                bundleId: bundleId,
+                appName: name,
+                windowTitle: title,
+                rawURL: rawURL
+            ) {
+                byId[candidate.id] = candidate
             }
         }
         return byId.values.sorted { Self.environmentDepth($0.id) < Self.environmentDepth($1.id) }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -50,32 +50,42 @@ raise SystemExit(1)
 SIM_UDID="$(resolve_iphone_simulator)" || die "could not find an available iPhone simulator"
 log "using iPhone simulator: $SIM_UDID"
 
-log "running server tests"
-(
-  cd "$REPO_ROOT/server"
-  npm test
-)
+declare -a FAILURES=()
 
-log "running RookKit Swift package tests"
-(
-  cd "$REPO_ROOT/clients/RookKit"
-  swift test
-)
+run_step() {
+  local name="$1"
+  shift
+  log "running $name"
+  if "$@"; then
+    log "$name passed"
+  else
+    local code=$?
+    log "$name failed (exit $code)"
+    FAILURES+=("$name (exit $code)")
+  fi
+}
 
-log "running iPhone XCTest suite"
-xcodebuild \
+run_step "server tests" bash -lc "cd '$REPO_ROOT/server' && npm test"
+run_step "RookKit Swift package tests" bash -lc "cd '$REPO_ROOT/clients/RookKit' && swift test"
+run_step "iPhone XCTest suite" xcodebuild \
   -project "$REPO_ROOT/clients/iphone/Rook.xcodeproj" \
   -scheme Rook \
   -configuration Debug \
   -destination "id=$SIM_UDID" \
   test
-
-log "running macOS build validation"
-xcodebuild \
+run_step "macOS build validation" xcodebuild \
   -project "$REPO_ROOT/clients/mac/Rook.xcodeproj" \
   -scheme Rook \
   -sdk macosx \
   -configuration Debug \
   build
+
+if ((${#FAILURES[@]} > 0)); then
+  log "failures:"
+  for failure in "${FAILURES[@]}"; do
+    log "  - $failure"
+  done
+  exit 1
+fi
 
 log "all tests passed"

--- a/server/README.md
+++ b/server/README.md
@@ -160,7 +160,7 @@ The goal is not perfect purity yet; this is the direction to follow when adding 
 - `GET /api/agent/sessions?agent=<id>`: list saved sessions for an agent.
 - `GET /api/agent/session/recent`: fetch the most recent saved session record across agents.
 - `POST /api/agent/start`: start, reuse, or restart a session runtime.
-- `POST /api/environments/register { id, metadata?, canonicalSourceUrl?, sourceName? }`: mark an environment available. If `id` is hierarchical (for example `app:md.obsidian/Peeps` or `web:en.wikipedia.org/wiki/Main_Page`), the server also treats all parent prefixes as available.
+- `POST /api/environments/register { id, metadata?, canonicalSourceUrl?, sourceName? }`: mark an environment available. If `id` is hierarchical (for example `app:md.obsidian/Peeps` or `web:en.wikipedia.org/wiki/Main_Page`), the server also treats all parent prefixes as available. Server bootstrap wires in a small JSONL capture sink that ensures `IGNORED/environment_metadata_captures/` exists and appends each explicit registration there for later inspection.
 - `POST /api/environments/decision { environmentId, bundleHash, decision }`: record `accept | approve | ignore | reject` for an offered bundle.
 - `GET /api/environments/preview?environmentId=...`: return full bundle/file preview data for inspection tooling and future richer review UI.
 - `GET /api/diagnostics/environments`: return active/recent environment diagnostics including discovered bundles.
@@ -175,6 +175,7 @@ The goal is not perfect purity yet; this is the direction to follow when adding 
   - `EnvironmentEventStub.ts`, `types.ts`: room/runtime plumbing.
 - **Environment layer (`src/server/environment`)**:
   - `EnvironmentManager.ts`: global coordinator for environment availability and the 2×2 decision model; discovers bundles on registration and pushes bundle offer/resolve events into subscribed rooms.
+  - `environmentMetadataCapture.ts`: small pluggable registration-capture sink module; the default server wiring uses a JSONL sink under `IGNORED/environment_metadata_captures/`.
   - `EnvironmentRepositoryService.ts`: thin service wrapper around repository lookups; returns bundle-organized environment content and computes exact-content bundle hashes for decisions.
   - `types.ts`: `EnvironmentRecord`, `EnvironmentEventListener`, decision/helper types.
 - **Agent runtime layer (`src/server/agents`)**:
@@ -219,7 +220,7 @@ Transcript history is no longer Rookery-owned durable replay state; restored his
 
 The **`SessionRoom`** is the live coordinator for one session. It holds the current `BaseAgent` runtime, serialises event publication, and fans events out to WebSocket subscribers. Rooms are managed by **`SessionRoomManager`** (keyed by `sessionId`).
 
-The **`EnvironmentManager`** sits alongside the room manager. When a room is created it subscribes to the `EnvironmentManager`. External providers (for example the Chrome extension or macOS app) signal availability directly via `POST /api/environments/register`. The manager tracks global availability plus persistent/ephemeral decisions, asks `EnvironmentRepositoryService` for environment bundle content, then pushes offer / enter / exit / resolution events into subscribed rooms. `SessionRoom` is what turns those into client-visible state and runtime rebuilds.
+The **`EnvironmentManager`** sits alongside the room manager. When a room is created it subscribes to the `EnvironmentManager`. External providers (for example the Chrome extension or macOS app) signal availability directly via `POST /api/environments/register`. The manager tracks global availability plus persistent/ephemeral decisions, asks `EnvironmentRepositoryService` for environment bundle content, and can call an injected registration-capture sink. In the default server wiring that sink appends explicit registration metadata captures to `IGNORED/environment_metadata_captures/`. `SessionRoom` is what turns the resulting environment events into client-visible state and runtime rebuilds.
 
 **`POST /api/agent/start`** is the only way to create or modify a room (`createOrReuseRoom` in `index.ts`):
 

--- a/server/src/server/agents/agentDiscovery.test.ts
+++ b/server/src/server/agents/agentDiscovery.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { REPO_ROOT } from "../paths.js";
@@ -23,6 +24,7 @@ describe("agentDiscovery", () => {
       { id: "PiAgent", parentId: null },
       { id: "ClaudeAgent", parentId: null },
       { id: "CursorAgent", parentId: null },
+      { id: "MockAgent", parentId: null },
       { id: "MyPiOpenAiAgent", parentId: "PiAgent" },
       { id: "MyClaudeAgent", parentId: "ClaudeAgent" },
       { id: "Worker", parentId: null },
@@ -37,7 +39,12 @@ describe("agentDiscovery", () => {
     const launcherPath = piAgent.options.env.PI_ACP_PI_COMMAND;
     expect(launcherPath).toContain(".var/rook/generated/pi-launchers/");
     const launcherSource = await (await import("node:fs/promises")).readFile(launcherPath, "utf8");
-    expect(launcherSource).toContain(JSON.stringify(path.join(REPO_ROOT, "skills", "create-skills")));
+    const createSkillsPath = path.join(REPO_ROOT, "skills", "create-skills");
+    if (existsSync(createSkillsPath)) {
+      expect(launcherSource).toContain(JSON.stringify(createSkillsPath));
+    } else {
+      expect(launcherSource).not.toContain(JSON.stringify(createSkillsPath));
+    }
     expect(launcherSource).toContain(JSON.stringify(path.join(REPO_ROOT, "dev-tools", "prompt-trace-logger.ts")));
 
     const claudeAgent = createAgent("MyClaudeAgent") as unknown as { options: { env: Record<string, string> } };

--- a/server/src/server/environment/EnvironmentManager.test.ts
+++ b/server/src/server/environment/EnvironmentManager.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EnvironmentManager } from "./EnvironmentManager.js";
 import { EnvironmentDecisionStore } from "./EnvironmentDecisionStore.js";
 import type { EnvironmentRepositoryService } from "./EnvironmentRepositoryService.js";
+import { JsonlEnvironmentMetadataCaptureSink } from "./environmentMetadataCapture.js";
 import type { EnvironmentEventListener } from "./types.js";
 
 function mockRepositoryService(): EnvironmentRepositoryService {
@@ -31,6 +32,7 @@ describe("EnvironmentManager", () => {
   let nowMs: number;
   let originalHome: string | undefined;
   let tempHome: string;
+  let captureDir: string;
 
   beforeEach(() => {
     decisions = new EnvironmentDecisionStore(":memory:");
@@ -38,6 +40,7 @@ describe("EnvironmentManager", () => {
     originalHome = process.env.HOME;
     tempHome = mkdtempSync(path.join(os.tmpdir(), "rook-home-"));
     process.env.HOME = tempHome;
+    captureDir = path.join(tempHome, "IGNORED", "environment_metadata_captures");
   });
 
   afterEach(() => {
@@ -47,12 +50,17 @@ describe("EnvironmentManager", () => {
     rmSync(tempHome, { recursive: true, force: true });
   });
 
+  function captureSink() {
+    return new JsonlEnvironmentMetadataCaptureSink(captureDir);
+  }
+
   function newManager(activeWindowMs = 6 * 60_000, recentRetentionMs = 30 * 60_000): EnvironmentManager {
     return new EnvironmentManager(mockRepositoryService(), decisions, {
       activeEnvironmentWindowMs: activeWindowMs,
       recentEnvironmentRetentionMs: recentRetentionMs,
       logger: { info: vi.fn() },
       now: () => nowMs,
+      registrationCaptureSink: captureSink(),
     });
   }
 
@@ -62,6 +70,40 @@ describe("EnvironmentManager", () => {
     await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
 
     expect(manager.isAvailable("web:example.com")).toBe(true);
+  });
+
+  it("creates IGNORED/environment_metadata_captures and appends environment metadata captures as jsonl", async () => {
+    const manager = newManager();
+
+    await manager.registerAvailableEnvironment(
+      { id: "web:example.com/docs", metadata: { title: "Docs", tags: ["api"] } },
+      { sourceName: "Example Docs", canonicalSourceUrl: "https://example.com/docs" },
+    );
+    await manager.registerAvailableEnvironment(
+      { id: "web:example.com/docs", metadata: { title: "Docs 2" } },
+      { sourceName: "Example Docs" },
+    );
+
+    const filePath = path.join(captureDir, "web-example.com--docs.jsonl");
+    expect(existsSync(path.join(tempHome, "IGNORED"))).toBe(true);
+    expect(existsSync(captureDir)).toBe(true);
+    expect(existsSync(filePath)).toBe(true);
+
+    const lines = readFileSync(filePath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatchObject({
+      capturedAt: "2026-07-02T12:00:00.000Z",
+      environmentId: "web:example.com/docs",
+      sourceName: "Example Docs",
+      canonicalSourceUrl: "https://example.com/docs",
+      metadata: { title: "Docs", tags: ["api"] },
+    });
+    expect(lines[1]).toMatchObject({
+      capturedAt: "2026-07-02T12:00:00.000Z",
+      environmentId: "web:example.com/docs",
+      sourceName: "Example Docs",
+      metadata: { title: "Docs 2" },
+    });
   });
 
   it("moves an active environment to recent after the active window", async () => {

--- a/server/src/server/environment/EnvironmentManager.ts
+++ b/server/src/server/environment/EnvironmentManager.ts
@@ -3,6 +3,10 @@ import type { EnvironmentDecisionStore } from "./EnvironmentDecisionStore.js";
 import type { EnvironmentPreview } from "../../shared/environment.js";
 import type { EnvironmentRepositoryService } from "./EnvironmentRepositoryService.js";
 import { ensurePersonalEnvironmentBinding } from "./EnvironmentBinding.js";
+import {
+  NoopEnvironmentRegistrationCaptureSink,
+  type EnvironmentRegistrationCaptureSink,
+} from "./environmentMetadataCapture.js";
 import { renderEnvironmentPrompt } from "./EnvironmentPromptTemplate.js";
 import { renderRookIdentityPrompt } from "./RookIdentityPrompt.js";
 import { SessionDecisionRegistry } from "./SessionDecisionRegistry.js";
@@ -58,6 +62,7 @@ export interface EnvironmentManagerOptions {
   recentEnvironmentRetentionMs?: number;
   logger?: { info: (...args: any[]) => void };
   now?: () => number;
+  registrationCaptureSink?: EnvironmentRegistrationCaptureSink;
 }
 
 /**
@@ -103,6 +108,7 @@ export class EnvironmentManager {
   private readonly logger: { info: (...args: any[]) => void };
   private readonly now: () => number;
   private readonly expiryTimer: ReturnType<typeof setInterval>;
+  private readonly registrationCaptureSink: EnvironmentRegistrationCaptureSink;
 
   constructor(
     private readonly repositoryService: EnvironmentRepositoryService,
@@ -114,6 +120,7 @@ export class EnvironmentManager {
     this.recentEnvironmentRetentionMs = options.recentEnvironmentRetentionMs ?? 30 * 60_000;
     this.logger = options.logger ?? console;
     this.now = options.now ?? Date.now;
+    this.registrationCaptureSink = options.registrationCaptureSink ?? new NoopEnvironmentRegistrationCaptureSink();
     this.expiryTimer = setInterval(() => this.pruneMemory(), Math.min(this.activeEnvironmentWindowMs, 60_000));
     this.expiryTimer.unref?.();
   }
@@ -124,6 +131,17 @@ export class EnvironmentManager {
     const now = this.now();
     const nowIso = new Date(now).toISOString();
     const existing = this.remembered.get(env.id);
+    try {
+      await this.registrationCaptureSink.capture({
+        capturedAt: nowIso,
+        environmentId: env.id,
+        sourceName: info.sourceName,
+        canonicalSourceUrl: info.canonicalSourceUrl,
+        metadata: env.metadata,
+      });
+    } catch (error) {
+      this.logger.info({ environmentId: env.id, error }, "failed to append environment metadata capture");
+    }
     const registeredAt = existing?.status === "active" ? (existing.registeredAt ?? nowIso) : nowIso;
     const activeUntil = new Date(now + this.activeEnvironmentWindowMs).toISOString();
     const resolvedBundles = await this.repositoryService.getResolvedBundles(env.id);

--- a/server/src/server/environment/environmentMetadataCapture.ts
+++ b/server/src/server/environment/environmentMetadataCapture.ts
@@ -1,0 +1,40 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { REPO_ROOT } from "../paths.js";
+
+export interface EnvironmentMetadataCaptureRecord {
+  capturedAt: string;
+  environmentId: string;
+  sourceName?: string;
+  canonicalSourceUrl?: string;
+  metadata: Record<string, unknown>;
+}
+
+export interface EnvironmentRegistrationCaptureSink {
+  initialize(): Promise<void>;
+  capture(record: EnvironmentMetadataCaptureRecord): Promise<void>;
+}
+
+export const DEFAULT_ENVIRONMENT_METADATA_CAPTURE_DIR = path.join(REPO_ROOT, "IGNORED", "environment_metadata_captures");
+
+export function environmentMetadataCaptureFileName(environmentId: string): string {
+  return `${environmentId.replaceAll(":", "-").replaceAll("/", "--").replaceAll("\\", "--")}.jsonl`;
+}
+
+export class JsonlEnvironmentMetadataCaptureSink implements EnvironmentRegistrationCaptureSink {
+  constructor(private readonly dir = DEFAULT_ENVIRONMENT_METADATA_CAPTURE_DIR) {}
+
+  async initialize(): Promise<void> {
+    await mkdir(this.dir, { recursive: true });
+  }
+
+  async capture(record: EnvironmentMetadataCaptureRecord): Promise<void> {
+    await this.initialize();
+    await appendFile(path.join(this.dir, environmentMetadataCaptureFileName(record.environmentId)), `${JSON.stringify(record)}\n`, "utf8");
+  }
+}
+
+export class NoopEnvironmentRegistrationCaptureSink implements EnvironmentRegistrationCaptureSink {
+  async initialize(): Promise<void> {}
+  async capture(_record: EnvironmentMetadataCaptureRecord): Promise<void> {}
+}

--- a/server/src/server/index.test.ts
+++ b/server/src/server/index.test.ts
@@ -594,7 +594,10 @@ describe("server", () => {
           registeredAt: expect.any(String),
           lastTouchedAt: expect.any(String),
           activeUntil: expect.any(String),
-          effectiveDecision: "accept",
+          effectiveDecision: "undecided",
+          bundles: expect.any(Array),
+          bundleIds: expect.any(Array),
+          bundleCollectionPaths: expect.any(Array),
         }),
       ],
       counts: {

--- a/server/src/server/index.ts
+++ b/server/src/server/index.ts
@@ -10,6 +10,7 @@ import { CompositeEnvironmentRepository } from "./environment/CompositeEnvironme
 import { DirectoryEnvironmentRepository } from "./environment/DirectoryEnvironmentRepository.js";
 import { LocationContextRepository } from "./environment/LocationContextRepository.js";
 import { EnvironmentRepositoryService } from "./environment/EnvironmentRepositoryService.js";
+import { JsonlEnvironmentMetadataCaptureSink } from "./environment/environmentMetadataCapture.js";
 import { EnvironmentIdentifier } from "./location/EnvironmentIdentifier.js";
 import { MockBuildingSkillSuggester } from "./location/BuildingSkillSuggester.js";
 import { PtilesPoiLookupProvider } from "./location/PtilesPoiLookupProvider.js";
@@ -72,10 +73,13 @@ export async function buildServer(options: BuildServerOptions = {}) {
   ]);
   const environmentRepositoryService = new EnvironmentRepositoryService(environmentRepository);
   const environmentDecisionStore = new EnvironmentDecisionStore(options.environmentDecisionStoreLocation);
+  const environmentMetadataCaptureSink = new JsonlEnvironmentMetadataCaptureSink();
+  await environmentMetadataCaptureSink.initialize();
   const environmentManager = new EnvironmentManager(environmentRepositoryService, environmentDecisionStore, {
     activeEnvironmentWindowMs: options.environmentActiveWindowMs ?? Number(process.env.ROOK_ENVIRONMENT_ACTIVE_WINDOW_MS ?? 5 * 60_000 + 15_000),
     recentEnvironmentRetentionMs: options.environmentRecentRetentionMs ?? Number(process.env.ROOK_ENVIRONMENT_RECENT_RETENTION_MS ?? 30 * 60_000),
     logger: app.log,
+    registrationCaptureSink: environmentMetadataCaptureSink,
   });
   // Ptiles is an internal geo-identification detail: fetch byte ranges directly from
   // the upstream host (single egress, allowlisted file names) — no public route.


### PR DESCRIPTION
This logs environment registration metadata to disk and tightens up a few client payloads so the captures are more useful in practice.

Closes #75.

What changed:
- add a pluggable JSONL capture sink under `IGNORED/environment_metadata_captures/`, one append-only file per environment id
- wire the sink into server bootstrap and cover it with tests
- include `radiusMeters` in iPhone and Android location registrations
- make the mac client reuse one environment-candidate path so foreground, reconnect, and browser/web registrations carry consistent metadata
- update the relevant README / PRODUCT architecture notes

Validation:
- `./scripts/run-tests.sh`