### PR TITLE
Bind session websockets and hydrate running sessions from server state

### DIFF
--- a/AS-BUILT-ARCHITECTURE/README.md
+++ b/AS-BUILT-ARCHITECTURE/README.md
@@ -15,7 +15,7 @@ This directory replaces the old single-file architecture summary with per-surfac
 
 Rook is built around two protocol boundaries:
 
-1. client ↔ server: session discovery over REST (`GET /api/sessions`); agent interaction over one ACP WebSocket per session at `/api/ws`
+1. client ↔ server: session discovery + transcript hydration over REST (`GET /api/sessions`, `GET /api/sessions/:id/transcript`); agent interaction over one session-bound ACP WebSocket per session at `/api/ws?sessionId=...`
 2. server ↔ runtime: ACP over stdio subprocesses, one process per public session
 
 The server is the stable broker. Clients are thin native surfaces over the same REST + ACP contract.

--- a/AS-BUILT-ARCHITECTURE/README.md
+++ b/AS-BUILT-ARCHITECTURE/README.md
@@ -15,7 +15,7 @@ This directory replaces the old single-file architecture summary with per-surfac
 
 Rook is built around two protocol boundaries:
 
-1. client ↔ server: ACP over one connection-level WebSocket at `/api/ws`
+1. client ↔ server: session discovery over REST (`GET /api/sessions`); agent interaction over one ACP WebSocket per session at `/api/ws`
 2. server ↔ runtime: ACP over stdio subprocesses, one process per public session
 
 The server is the stable broker. Clients are thin native surfaces over the same REST + ACP contract.

--- a/AS-BUILT-ARCHITECTURE/iphone-client.md
+++ b/AS-BUILT-ARCHITECTURE/iphone-client.md
@@ -92,11 +92,12 @@ Same shared contract as other clients:
 5. when an environment enters, the chat shows a business banner with display name and website favicons
 
 ### Chat flow
-1. model connects to `/api/ws`
-2. session creation/resume is done over ACP
-3. `AcpSocket` reduces wire frames into `AcpClientEvent`s
-4. `RookModel` turns them into chat blocks, status text, queueing, and errors
-5. on reconnect the model reloads the current session and re-announces place state
+1. session list is fetched via REST
+2. `RookModel` creates or retrieves a `SessionHandle` per session
+3. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
+4. the handle opens a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and reduces wire frames into `AcpClientEvent`s
+5. `RookModel` mirrors handle state into published chat/UI state and layers on voice / Live Activity behavior
+6. on reconnect the model reattaches to the current session handle and re-announces place state
 
 ### Voice flow
 1. user starts listening
@@ -112,6 +113,7 @@ Same shared contract as other clients:
 ## Notable architectural characteristics
 
 - the iPhone app reuses the Mac chat/network stack but replaces foreground-app context with physical-place context
+- like the Mac client, it now uses one session-bound WebSocket per session and hydrates running sessions from server-owned transcript history
 - region monitoring handles named places; visit/dwell detection handles nearby-business discovery
 - place registration is guarded by environment preview so empty places do not create empty offers
 - the Live Activity is an ambient architecture surface, not just a chat status indicator

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -9,6 +9,14 @@ The macOS client is a native SwiftUI menu bar app with a regular app window. It 
 - `RookMacModel`
   - main app state and reducer
   - owns server state, sessions, chat blocks, environment offers, environment list, voice, and provider state
+- `SessionHandle`
+  - per-session state container: owns a dedicated `AcpSocket` (one WebSocket per session), blocks, run state, streaming/replay buffers, queued messages, mode/config state
+  - handles all ACP event reduction and reconnection for its session
+  - multiple handles coexist; switching sessions is a pointer change
+- `ChatSessionController`
+  - registry of `SessionHandle`s keyed by session ID
+  - loads session list via REST (`GET /api/sessions`)
+  - proxies current-session UI state from the active handle
 - `EnvironmentsDetailView`
   - renders the environment-memory list
   - uses `RookKit.EnvironmentListPresentation` for shared presentation rules, including hiding raw URL `sourceName` rows for `web:` environments
@@ -90,11 +98,12 @@ Via `RookKit`:
 4. on server availability it loads runtimes/sessions and auto-resumes the most recent session
 
 ### Chat flow
-1. model ensures ACP socket connection
-2. user creates or resumes a session
-3. `AcpSocket` emits flattened `AcpClientEvent`s
-4. `RookMacModel` reduces them into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
-5. queued messages are delivered automatically once the agent goes idle
+1. session list is fetched via REST, not the WebSocket
+2. tapping a session creates or retrieves a `SessionHandle`
+3. the handle opens a dedicated WebSocket, runs `initialize`, and calls `session/load`
+4. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
+5. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
+6. queued messages are delivered automatically once the agent goes idle
 
 ### Foreground environment detection
 1. `ForegroundAppMonitor` detects app activation or window-title change
@@ -123,6 +132,8 @@ Via `RookKit`:
 ## Notable architectural characteristics
 
 - the mac app is both a client and an environment provider
+- session discovery is REST; agent interaction is one ACP WebSocket per session
+- `SessionHandle` isolates all session state — blocks, streaming buffers, reconnection — so switching never tears down a running session
 - environment registration is local-first and derived from visible user context
 - the Mac bridge centralizes Accessibility, Automation, and Screen Recording permissions in one native app
 - reconnect and queued-message handling are built into the client reducer

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -100,10 +100,11 @@ Via `RookKit`:
 ### Chat flow
 1. session list is fetched via REST, not the WebSocket
 2. tapping a session creates or retrieves a `SessionHandle`
-3. the handle opens a dedicated WebSocket, runs `initialize`, and calls `session/load`
-4. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
-5. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
-6. queued messages are delivered automatically once the agent goes idle
+3. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
+4. the handle opens a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and runs `initialize`
+5. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
+6. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
+7. queued messages are delivered automatically once the agent goes idle
 
 ### Foreground environment detection
 1. `ForegroundAppMonitor` detects app activation or window-title change

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -30,10 +30,9 @@
 ## Main interfaces
 
 ### ACP socket API
-`AcpSocket` exposes:
-- `connect(request:)`
+`AcpSocket` exposes one-session-per-connection ACP methods:
+- `connect(request:)` — opens WebSocket, runs `initialize` handshake
 - `disconnect()`
-- `sessionList()`
 - `createSession(runtimeId:title:cwd:)`
 - `loadSession(_:)`
 - `sendPrompt(text:)`
@@ -49,6 +48,7 @@
 `RookAPI` exposes:
 - `healthResult()` / `health()`
 - `agents()`
+- `sessions()` — session list over REST (replaces the old WebSocket `session/list`)
 - `environmentPreview(environmentId:)`
 - `registerEnvironment(id:sourceName:metadata:)`
 - `identifyEnvironments(_:)`

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -7,8 +7,11 @@
 ## Main components
 
 - `Net/AcpSocket.swift`
-  - connection-level ACP WebSocket client for `/api/ws`
+  - session-bound ACP WebSocket client for `/api/ws?sessionId=...`
   - owns request/response bookkeeping and event reduction
+- `Net/SessionHandle.swift`
+  - shared per-session state container used by both Apple clients
+  - owns one `AcpSocket`, transcript hydration, replay avoidance, reconnection, and live event reduction
 - `Net/RookAPI.swift`
   - REST client for health, runtimes, environments, and location identification
 - `Models/ApiTypes.swift`
@@ -49,6 +52,7 @@
 - `healthResult()` / `health()`
 - `agents()`
 - `sessions()` — session list over REST (replaces the old WebSocket `session/list`)
+- `sessionTranscript(sessionId:)` — normalized transcript hydration for second viewers / running sessions
 - `environmentPreview(environmentId:)`
 - `registerEnvironment(id:sourceName:metadata:)`
 - `identifyEnvironments(_:)`
@@ -102,7 +106,7 @@
 4. the prompt response marks the run complete or failed
 
 ### Shared rendering flow
-1. app reducers construct `ChatBlock`s
+1. `SessionHandle` (or app-specific reducers around it) constructs `ChatBlock`s from transcript hydration + live ACP events
 2. RookKit design views render the block list consistently across macOS and iOS
 3. markdown/tool payload helpers normalize output for display
 4. `EnvironmentListPresentation` applies shared list-refresh behavior and shared row-level display rules for environment metadata

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -71,6 +71,7 @@ See also: [database.md](./database.md)
 ### REST control plane
 - `GET /api/health`
 - `GET /api/agent_runtimes`
+- `GET /api/sessions` — session listing over REST (replaces WebSocket `session/list`)
 - `POST /api/environments/register`
 - `POST /api/environments/decision`
 - `GET /api/environments/preview`
@@ -103,6 +104,9 @@ Persisted in SQLite:
 - `cwd`
 - `startedAt`
 - `updatedAt`
+
+The `GET /api/sessions` response additionally includes a `running` boolean
+(derived from whether a `SessionRuntime` is active for that session).
 
 Related table:
 - `session_environments(session_id, environment_id, entered_at)`

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The server is a Fastify service on `127.0.0.1:7665` with an optional second remote/VPN listener. It exposes a connection-level ACP WebSocket facade at `/api/ws`, a REST control plane for runtimes and environments, and an internal runtime broker that launches one ACP subprocess per public session.
+The server is a Fastify service on `127.0.0.1:7665` with an optional second remote/VPN listener. It exposes a session-bound ACP WebSocket facade at `/api/ws`, a REST control plane for runtimes, sessions, transcripts, and environments, and an internal runtime broker that launches one ACP subprocess per public session.
 
 ## Main components
 
@@ -52,10 +52,12 @@ See also: [database.md](./database.md)
 
 ### WebSocket ACP facade
 - route: `GET /api/ws`
+- websocket may be session-bound up front via `?sessionId=<public-session-id>`
+- once bound, the websocket is restricted to that session only
 - client methods handled directly:
   - `initialize`
-  - `session/list`
-  - `session/new`
+  - `session/list` (unbound websocket only; REST preferred)
+  - `session/new` (unbound websocket only)
   - `session/load`
   - `session/resume`
   - `session/prompt`
@@ -72,6 +74,7 @@ See also: [database.md](./database.md)
 - `GET /api/health`
 - `GET /api/agent_runtimes`
 - `GET /api/sessions` — session listing over REST (replaces WebSocket `session/list`)
+- `GET /api/sessions/:sessionId/transcript` — server-owned normalized transcript for hydrators / second viewers
 - `POST /api/environments/register`
 - `POST /api/environments/decision`
 - `GET /api/environments/preview`
@@ -88,6 +91,7 @@ See also: [database.md](./database.md)
 
 Current durable persistence is SQLite-backed and centered on:
 - session records
+- append-only normalized transcript events per session
 - session-environment membership
 - durable environment bundle decisions
 
@@ -108,8 +112,9 @@ Persisted in SQLite:
 The `GET /api/sessions` response additionally includes a `running` boolean
 (derived from whether a `SessionRuntime` is active for that session).
 
-Related table:
+Related tables:
 - `session_environments(session_id, environment_id, entered_at)`
+- `session_transcript_events(sequence, session_id, created_at, event_json)`
 
 ### Environment decision model
 - `accept` — allow for this session/visit
@@ -149,12 +154,13 @@ Related table:
 5. later client `session/load`s the public session
 
 ### Prompt execution
-1. client sends ACP `session/prompt`
+1. client sends ACP `session/prompt` on a session-bound websocket
 2. ACP facade resolves the public session
 3. `AgentRuntimeManager` rewrites to the runtime-local session ID
 4. `SessionRuntime` forwards the request to the subprocess
 5. runtime emits `session/update` notifications
-6. server rewrites session IDs back to the public ID and forwards them to subscribed clients
+6. server normalizes live transcript events into `session_transcript_events`
+7. server rewrites session IDs back to the public ID and forwards live notifications to subscribed watchers of that same session
 
 ### Environment offer and approval
 1. a provider registers an environment with `POST /api/environments/register`
@@ -179,7 +185,9 @@ Related table:
 ## Notable architectural characteristics
 
 - one public session = one runtime subprocess
-- pure ACP on both protocol boundaries
+- websocket connections are session-bound, not general multi-session ACP pipes
+- `session/load` replay is requester-private; it no longer fans out to every watcher of that session
+- the server owns a durable normalized transcript for each session so additional viewers can hydrate without runtime replay
 - environment state is session-specific at runtime launch time
-- durable decisions and session membership are SQLite-backed
+- durable decisions, transcript history, and session membership are SQLite-backed
 - location identification is provider-pluggable behind `PoiLookupProvider`

--- a/clients/RookKit/Sources/RookKit/Models/ChatState.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ChatState.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+// MARK: - Shared chat state types used by both Apple clients
+
+public struct QueuedChatMessage: Identifiable, Equatable {
+    public let id: String
+    public var text: String
+    public var draftText: String
+    public var isEditing = false
+
+    public init(id: String, text: String, draftText: String, isEditing: Bool = false) {
+        self.id = id
+        self.text = text
+        self.draftText = draftText
+        self.isEditing = isEditing
+    }
+}
+
+public struct PendingPermissionRequest: Equatable {
+    public var requestId: String
+    public var toolCall: AcpPermissionToolCall
+    public var options: [AcpPermissionOption]
+
+    public init(requestId: String, toolCall: AcpPermissionToolCall, options: [AcpPermissionOption]) {
+        self.requestId = requestId
+        self.toolCall = toolCall
+        self.options = options
+    }
+}
+
+public struct ContextUsageState: Equatable {
+    public var used: Int
+    public var size: Int
+    public var cost: AcpUsageCost?
+
+    public init(used: Int, size: Int, cost: AcpUsageCost? = nil) {
+        self.used = used
+        self.size = size
+        self.cost = cost
+    }
+}

--- a/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
+++ b/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
@@ -91,6 +91,14 @@ public struct RookAPI {
         return body.runtimes
     }
 
+    public func sessions() async throws -> [AgentSessionSummary] {
+        struct SessionsResponse: Decodable {
+            let sessions: [JSONValue]
+        }
+        let response: SessionsResponse = try await get(path: "api/sessions", query: [:])
+        return response.sessions.map { AgentSessionSummary(raw: $0) }
+    }
+
     public func environmentPreview(environmentId: String) async throws -> EnvironmentPreview {
         try await get(
             path: "api/environments/preview",

--- a/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
+++ b/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
@@ -29,16 +29,23 @@ public struct RookAPI {
     }
 
     public var webSocketURL: URL {
+        webSocketURL(sessionId: nil)
+    }
+
+    public func webSocketURL(sessionId: String?) -> URL {
         var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
         components.scheme = baseURL.scheme == "https" ? "wss" : "ws"
         components.path = "/api/ws"
+        if let sessionId, !sessionId.isEmpty {
+            components.queryItems = [URLQueryItem(name: "sessionId", value: sessionId)]
+        }
         return components.url!
     }
 
     public var webAppURL: URL { baseURL }
 
-    public func webSocketRequest() -> URLRequest {
-        var request = authorizedRequest(url: webSocketURL)
+    public func webSocketRequest(sessionId: String? = nil) -> URLRequest {
+        var request = authorizedRequest(url: webSocketURL(sessionId: sessionId))
         request.timeoutInterval = 30
         return request
     }
@@ -97,6 +104,14 @@ public struct RookAPI {
         }
         let response: SessionsResponse = try await get(path: "api/sessions", query: [:])
         return response.sessions.map { AgentSessionSummary(raw: $0) }
+    }
+
+    public func sessionTranscript(sessionId: String) async throws -> [JSONValue] {
+        struct TranscriptResponse: Decodable {
+            let events: [JSONValue]
+        }
+        let response: TranscriptResponse = try await get(path: "api/sessions/\(sessionId)/transcript", query: [:])
+        return response.events
     }
 
     public func environmentPreview(environmentId: String) async throws -> EnvironmentPreview {

--- a/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
+++ b/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
@@ -91,6 +91,21 @@ public final class SessionHandle {
         isLoaded = true
     }
 
+    public func attach(transcript events: [JSONValue]) async throws {
+        if isLoaded {
+            onStateChange?()
+            return
+        }
+        resetVisibleState()
+        for event in events {
+            applyTranscriptEvent(event)
+        }
+        try await ensureSocketConnected()
+        socket.selectSession(sessionId)
+        isLoaded = true
+        onStateChange?()
+    }
+
     public func close() {
         reconnectTask?.cancel()
         streamingFlushTask?.cancel()
@@ -201,10 +216,103 @@ public final class SessionHandle {
         }
     }
 
+    private func resetVisibleState() {
+        blocks = []
+        queuedMessages = []
+        isRunning = false
+        statusLine = ""
+        contextUsage = nil
+        currentModes = nil
+        configOptions = []
+        pendingPermission = nil
+        lastStopReason = nil
+        autoScrollEnabled = true
+        enteredEnvironments = []
+        blockCounter = 0
+        scrollTick = 0
+    }
+
+    private func applyTranscriptEvent(_ event: JSONValue) {
+        let kind = event["kind"]?.stringValue ?? ""
+        switch kind {
+        case "user_message_chunk":
+            if let text = event["text"]?.stringValue { appendBlock(.user(text: text)) }
+        case "agent_message_chunk":
+            if let text = event["text"]?.stringValue { appendBlock(.assistantText(text: text, streaming: false)) }
+        case "agent_thought_chunk":
+            if let text = event["text"]?.stringValue { appendBlock(.thinking(text: text, streaming: false)) }
+        case "tool_call":
+            guard let toolCallId = event["toolCallId"]?.stringValue else { return }
+            let state = ToolBlockState(
+                toolCallId: toolCallId,
+                title: event["title"]?.stringValue ?? "Tool",
+                kindLabel: event["toolKind"]?.stringValue ?? "",
+                status: transcriptStatus(event["status"]?.stringValue),
+                arguments: stringifyTranscriptJSON(event["rawInput"]),
+                output: ""
+            )
+            appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
+        case "tool_call_update":
+            guard let toolCallId = event["toolCallId"]?.stringValue else { return }
+            updateTool(toolCallId) { tool in
+                if let toolName = event["toolName"]?.stringValue, tool.title.isEmpty { tool.title = toolName }
+                switch event["status"]?.stringValue {
+                case "pending": advanceToolStatus(&tool, to: .pending)
+                case "in_progress": advanceToolStatus(&tool, to: .running); tool.output = stringifyTranscriptJSON(event["rawOutput"])
+                case "completed": advanceToolStatus(&tool, to: .completed); tool.output = stringifyTranscriptJSON(event["rawOutput"])
+                case "failed": advanceToolStatus(&tool, to: .failed); tool.output = stringifyTranscriptJSON(event["rawOutput"])
+                case "cancelled": advanceToolStatus(&tool, to: .cancelled)
+                default: break
+                }
+            }
+        case "plan_update":
+            if case .array(let entries)? = event["entries"] {
+                let planEntries = entries.enumerated().compactMap { index, item -> PlanEntry? in
+                    guard let content = item["content"]?.stringValue ?? item["text"]?.stringValue else { return nil }
+                    return PlanEntry(id: Int(item["id"]?.numberValue ?? Double(index)), content: content, priority: item["priority"]?.stringValue ?? "", status: item["status"]?.stringValue ?? "")
+                }
+                upsertPlanBlock(planEntries)
+            }
+        case "usage_update":
+            if let used = event["used"]?.numberValue, let size = event["size"]?.numberValue {
+                contextUsage = ContextUsageState(used: Int(used), size: Int(size), cost: nil)
+            }
+        case "run_completed":
+            isRunning = false
+            statusLine = ""
+        case "run_failed":
+            isRunning = false
+            statusLine = ""
+            if let message = event["message"]?.stringValue { appendErrorBlock(source: "run", message: message) }
+        default:
+            break
+        }
+    }
+
+    private func transcriptStatus(_ raw: String?) -> ToolBlockStatus {
+        switch raw {
+        case "in_progress": return .running
+        case "completed": return .completed
+        case "failed": return .failed
+        case "cancelled": return .cancelled
+        case "ready": return .ready
+        case "input_streaming": return .inputStreaming
+        default: return .pending
+        }
+    }
+
+    private func stringifyTranscriptJSON(_ value: JSONValue?) -> String {
+        guard let value else { return "" }
+        if case .string(let text) = value { return text }
+        if case .null = value { return "" }
+        if let data = try? JSONEncoder().encode(value), let text = String(data: data, encoding: .utf8) { return text }
+        return ""
+    }
+
     // MARK: - Private: connection
 
     private func ensureSocketConnected() async throws {
-        _ = try await socket.connect(request: api.webSocketRequest())
+        _ = try await socket.connect(request: api.webSocketRequest(sessionId: sessionId))
     }
 
     private func scheduleReconnect(delaySeconds: Double) {

--- a/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
+++ b/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
@@ -34,6 +34,10 @@ public final class SessionHandle {
     public private(set) var autoScrollEnabled = true { didSet { onStateChange?() } }
     public private(set) var scrollTick = 0 { didSet { onStateChange?() } }
 
+    /// True after the first successful `load()` — prevents re-sending
+    /// `session/load` when switching back to an already-connected handle.
+    public private(set) var isLoaded = false
+
     // MARK: - Private streaming / replay state
     private var blockCounter = 0
     private var enteredEnvironments: Set<String> = []
@@ -69,6 +73,11 @@ public final class SessionHandle {
     }
 
     public func load() async throws {
+        if isLoaded {
+            // Already connected and subscribed — just report current state.
+            onStateChange?()
+            return
+        }
         try await ensureSocketConnected()
         isReplaying = true
         replayUserBuffer = ""
@@ -79,12 +88,14 @@ public final class SessionHandle {
         isReplaying = false
         flushReplayBuffers()
         isRunning = false
+        isLoaded = true
     }
 
     public func close() {
         reconnectTask?.cancel()
         streamingFlushTask?.cancel()
         socket.disconnect()
+        isLoaded = false
     }
 
     public func stopAgent() {

--- a/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
+++ b/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
@@ -1,36 +1,38 @@
 import Foundation
-import RookKit
 
 /// Owns a dedicated WebSocket, blocks, run state, and streaming state for one
 /// session.  Multiple handles coexist — switching sessions is just changing
 /// which handle the UI observes.
 @MainActor
-final class SessionHandle {
-    let sessionId: String
+public final class SessionHandle {
+    public let sessionId: String
 
-    var onStateChange: (() -> Void)?
-    var onEnvironmentOffered: ((EnvironmentOffer) -> Void)?
-    var onEnvironmentOfferResolved: ((String, String) -> Void)?
-    var onEnvironmentEntered: ((String) -> Void)?
-    var onEnvironmentExited: ((String, String?) -> Void)?
+    public var onStateChange: (() -> Void)?
+    public var onEnvironmentOffered: ((EnvironmentOffer) -> Void)?
+    public var onEnvironmentOfferResolved: ((String, String) -> Void)?
+    public var onEnvironmentEntered: ((String) -> Void)?
+    public var onEnvironmentExited: ((String, String?) -> Void)?
+
+    /// Called for every agent text chunk — iPhone uses this for voice synthesis buffering.
+    public var onAgentTextChunk: ((String) -> Void)?
 
     private let api: RookAPI
     private let socket = AcpSocket()
 
     // MARK: - Observable state (same shape ChatSessionController exposed)
-    private(set) var blocks: [ChatBlock] = [] { didSet { onStateChange?() } }
-    private(set) var queuedMessages: [QueuedChatMessage] = [] { didSet { onStateChange?() } }
-    private(set) var isRunning = false { didSet { onStateChange?() } }
-    private(set) var statusLine = "" { didSet { onStateChange?() } }
-    private(set) var socketConnected = false { didSet { onStateChange?() } }
-    private(set) var reconnecting = false { didSet { onStateChange?() } }
-    private(set) var contextUsage: ContextUsageState? { didSet { onStateChange?() } }
-    private(set) var currentModes: AcpModesState? { didSet { onStateChange?() } }
-    private(set) var configOptions: [AcpConfigOption] = [] { didSet { onStateChange?() } }
-    private(set) var pendingPermission: PendingPermissionRequest? { didSet { onStateChange?() } }
-    private(set) var lastStopReason: String? { didSet { onStateChange?() } }
-    private(set) var autoScrollEnabled = true { didSet { onStateChange?() } }
-    private(set) var scrollTick = 0 { didSet { onStateChange?() } }
+    public private(set) var blocks: [ChatBlock] = [] { didSet { onStateChange?() } }
+    public private(set) var queuedMessages: [QueuedChatMessage] = [] { didSet { onStateChange?() } }
+    public private(set) var isRunning = false { didSet { onStateChange?() } }
+    public private(set) var statusLine = "" { didSet { onStateChange?() } }
+    public private(set) var socketConnected = false { didSet { onStateChange?() } }
+    public private(set) var reconnecting = false { didSet { onStateChange?() } }
+    public private(set) var contextUsage: ContextUsageState? { didSet { onStateChange?() } }
+    public private(set) var currentModes: AcpModesState? { didSet { onStateChange?() } }
+    public private(set) var configOptions: [AcpConfigOption] = [] { didSet { onStateChange?() } }
+    public private(set) var pendingPermission: PendingPermissionRequest? { didSet { onStateChange?() } }
+    public private(set) var lastStopReason: String? { didSet { onStateChange?() } }
+    public private(set) var autoScrollEnabled = true { didSet { onStateChange?() } }
+    public private(set) var scrollTick = 0 { didSet { onStateChange?() } }
 
     // MARK: - Private streaming / replay state
     private var blockCounter = 0
@@ -48,7 +50,7 @@ final class SessionHandle {
     private var replayAssistantBuffer = ""
     private var replayThinkingBuffer = ""
 
-    init(sessionId: String, api: RookAPI) {
+    public init(sessionId: String, api: RookAPI) {
         self.sessionId = sessionId
         self.api = api
         socket.onEvent = { [weak self] event in
@@ -61,12 +63,12 @@ final class SessionHandle {
 
     // MARK: - Lifecycle
 
-    func connectAndLoad(title: String, cwd: String) async throws {
+    public func connectAndLoad(title: String, cwd: String) async throws {
         try await ensureSocketConnected()
         _ = try await socket.createSession(runtimeId: "", title: title, cwd: cwd)
     }
 
-    func load() async throws {
+    public func load() async throws {
         try await ensureSocketConnected()
         isReplaying = true
         replayUserBuffer = ""
@@ -79,13 +81,13 @@ final class SessionHandle {
         isRunning = false
     }
 
-    func close() {
+    public func close() {
         reconnectTask?.cancel()
         streamingFlushTask?.cancel()
         socket.disconnect()
     }
 
-    func stopAgent() {
+    public func stopAgent() {
         guard isRunning else { return }
         userCancelledRun = true
         statusLine = "Stopping…"
@@ -94,7 +96,7 @@ final class SessionHandle {
 
     // MARK: - Messaging
 
-    func send(_ text: String) {
+    public func send(_ text: String) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         if isRunning || !socket.isConnected {
@@ -107,24 +109,24 @@ final class SessionHandle {
         deliver(trimmed)
     }
 
-    func removeQueuedMessage(at index: Int) {
+    public func removeQueuedMessage(at index: Int) {
         guard queuedMessages.indices.contains(index) else { return }
         queuedMessages.remove(at: index)
     }
 
-    func beginEditingQueuedMessage(_ id: String) {
+    public func beginEditingQueuedMessage(_ id: String) {
         updateQueuedMessage(id) { $0.isEditing = true; $0.draftText = $0.text }
     }
 
-    func updateQueuedMessageDraft(_ id: String, text: String) {
+    public func updateQueuedMessageDraft(_ id: String, text: String) {
         updateQueuedMessage(id) { $0.draftText = text }
     }
 
-    func cancelEditingQueuedMessage(_ id: String) {
+    public func cancelEditingQueuedMessage(_ id: String) {
         updateQueuedMessage(id) { $0.isEditing = false; $0.draftText = $0.text }
     }
 
-    func saveQueuedMessageEdit(_ id: String) {
+    public func saveQueuedMessageEdit(_ id: String) {
         updateQueuedMessage(id) { message in
             let trimmed = message.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
             message.text = trimmed.isEmpty ? message.text : trimmed
@@ -133,7 +135,7 @@ final class SessionHandle {
         }
     }
 
-    func decidePermission(optionId: String?) {
+    public func decidePermission(optionId: String?) {
         guard let pendingPermission else { return }
         self.pendingPermission = nil
         do {
@@ -143,43 +145,43 @@ final class SessionHandle {
         }
     }
 
-    func setMode(_ modeId: String) {
+    public func setMode(_ modeId: String) {
         Task {
             do { try await socket.setMode(modeId) }
             catch { appendErrorBlock(source: "protocol", message: error.localizedDescription) }
         }
     }
 
-    func setConfigOption(_ configId: String, value: String) {
+    public func setConfigOption(_ configId: String, value: String) {
         Task {
             do { try await socket.setConfigOption(configId: configId, value: value) }
             catch { appendErrorBlock(source: "protocol", message: error.localizedDescription) }
         }
     }
 
-    func resolveEnvironmentOffer(environmentId: String, bundleHash: String, decision: String) async throws {
+    public func resolveEnvironmentOffer(environmentId: String, bundleHash: String, decision: String) async throws {
         try await socket.resolveEnvironmentOffer(environmentId: environmentId, bundleHash: bundleHash, decision: decision)
     }
 
-    func refreshForCurrentSessionReset() {
+    public func refreshForCurrentSessionReset() {
         enteredEnvironments = []
     }
 
-    func resumeAutoScroll() {
+    public func resumeAutoScroll() {
         let wasEnabled = autoScrollEnabled
         autoScrollEnabled = true
         if !wasEnabled { scrollTick += 1 }
     }
 
-    func pauseAutoScroll() {
+    public func pauseAutoScroll() {
         autoScrollEnabled = false
     }
 
-    func appendSystemMessage(_ text: String) {
+    public func appendSystemMessage(_ text: String) {
         appendBlock(.system(text: text))
     }
 
-    func finalizeActiveTools(as finalStatus: ToolBlockStatus) {
+    public func finalizeActiveTools(as finalStatus: ToolBlockStatus) {
         for index in blocks.indices {
             guard case .tool(var state) = blocks[index].kind else { continue }
             guard !state.status.isTerminal else { continue }
@@ -278,6 +280,7 @@ final class SessionHandle {
             } else {
                 statusLine = "Responding…"
                 appendStreamingText(text, isThinking: false)
+                onAgentTextChunk?(text)
             }
         case .agentThoughtChunk(let text):
             if isReplaying {

--- a/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
@@ -261,10 +261,11 @@ class RookViewModel(
         autoResumeAttempted = true
         scope.launch {
             try {
-                ensureSocketConnected()
-                val recent = socket.sessionList().firstOrNull()?.let(::AgentSessionSummary) ?: return@launch
-                socket.loadSession(recent.id)
-                enterChat(recent, resumed = true, switchToChat = false)
+                if (_sessions.value.isEmpty()) {
+                    _sessions.value = api.sessions().map(::AgentSessionSummary)
+                }
+                val recent = _sessions.value.firstOrNull() ?: return@launch
+                resumeSession(recent)
             } catch (_: Exception) {
             }
         }
@@ -276,8 +277,7 @@ class RookViewModel(
         scope.launch {
             _sessionsLoading.value = true
             try {
-                ensureSocketConnected()
-                _sessions.value = socket.sessionList().map(::AgentSessionSummary)
+                _sessions.value = api.sessions().map(::AgentSessionSummary)
                 _sessionsError.value = ""
             } catch (e: Exception) {
                 _sessionsError.value = e.message ?: "Failed to load sessions"

--- a/clients/android/app/src/main/java/com/rookery/rook/net/RookApi.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/net/RookApi.kt
@@ -92,6 +92,12 @@ class RookApi(
         return json.decodeFromJsonElement(RuntimeResponse.serializer(), body).runtimes
     }
 
+    suspend fun sessions(): List<JsonObject> {
+        @Serializable data class SessionsResponse(val sessions: List<JsonObject>)
+        val body = getJson("api/sessions")
+        return json.decodeFromJsonElement(SessionsResponse.serializer(), body).sessions
+    }
+
     suspend fun environmentPreview(environmentId: String): EnvironmentPreview {
         val body = getJson("api/environments/preview", mapOf("environmentId" to environmentId))
         return json.decodeFromJsonElement(EnvironmentPreview.serializer(), body)

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -29,7 +29,7 @@ binding, and bearer-token auth, start with [docs/setup.md](../../docs/setup.md).
   contains, then decide with the same 2×2 choices as every other client.
   Leaving the region simply stops refreshing it from the phone; the server ages
   it out on its own.
-- **Full chat parity.** Agent picker, session start/resume, streaming ACP chat
+- **Full chat parity.** Agent picker, REST-backed session discovery, per-session websocket attach, transcript hydration for already-running sessions, and streaming ACP chat
   (text, thinking, tool calls, plans, errors, context usage) — including
   auto-rendering well-formed JSON tool arguments as human-readable YAML and
   assistant markdown with native drag-selection, standard copy/paste behavior,
@@ -100,7 +100,7 @@ dropped.
 
 ### The location → skill loop
 
-Mirrors `RookMacModel.handleForegroundApp`, with place in place of mac:
+Mirrors `RookMacModel.handleForegroundApp`, with place in place of mac. Chat/session behavior mirrors the Mac too: one websocket per session, server-owned transcript hydration for already-running sessions, and no disruptive `session/load` on simple reselect/reopen.
 
 1. You define places → `PlaceStore`; `LocationProvider` monitors their regions
    (Always auth recommended for background entry).

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -142,7 +142,7 @@ Fast paths from the repo root:
 ./scripts/run-rook.sh iphone --server-url http://your-mac.tailxxxx.ts.net:3000
 ```
 
-`run-rook.sh iphone` builds and launches the current physical-iPhone client, using `--server-url` if given, else `ROOK_REMOTE_HOSTNAME` or `ROOK_BIND_IP` to determine a server address your phone can reach. The server itself still binds localhost for the Mac app; `ROOK_BIND_IP` adds the second remote listener. It intentionally does **not** hardcode a development team into `project.yml`; pass `--team` / `ROOK_IOS_DEVELOPMENT_TEAM` when needed, or let the script auto-detect your local team for personal use. Keep the phone unlocked while the launcher installs and opens the app; otherwise iOS denies the launch request.
+`run-rook.sh iphone` builds and launches the current physical-iPhone client, using `--server-url` if given, else `ROOK_REMOTE_HOSTNAME` or `ROOK_BIND_IP` to determine a server address your phone can reach. The server itself still binds localhost for the Mac app; `ROOK_BIND_IP` adds the second remote listener. Signing follows the Xcode project’s configured `DEVELOPMENT_TEAM` and stable `com.rookkeeper...` bundle identifiers, so the launcher no longer rewrites bundle IDs or asks for a separate `--team` override. Keep the phone unlocked while the launcher installs and opens the app; otherwise iOS denies the launch request.
 
 Manual steps:
 

--- a/clients/iphone/Rook.xcodeproj/project.pbxproj
+++ b/clients/iphone/Rook.xcodeproj/project.pbxproj
@@ -265,6 +265,12 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					80BB71880E0AA3D6EC52CD82 = {
+						DevelopmentTeam = 3G24HSNP93;
+					};
+					BECEADD2309FE9E37792DF18 = {
+						DevelopmentTeam = 3G24HSNP93;
+					};
 				};
 			};
 			buildConfigurationList = 8D92C9375EB3AAE1CAF52C4A /* Build configuration list for PBXProject "Rook" */;
@@ -373,7 +379,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.RookTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookkeeper.RookTests;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -387,6 +393,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sources/Rook.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 3G24HSNP93;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Sources/Info.plist;
@@ -394,7 +401,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookkeeper.Rook;
 				PRODUCT_NAME = Rook;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -411,7 +418,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.RookTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookkeeper.RookTests;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -479,6 +486,7 @@
 		766D2248AD7B005D9822D0AE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = 3G24HSNP93;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RookWidgets/Info.plist;
@@ -487,7 +495,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook.RookWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookkeeper.Rook.RookWidgets;
 				PRODUCT_NAME = RookWidgets;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
@@ -562,6 +570,7 @@
 		A7E8AF5E57CF240F44D67F1F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = 3G24HSNP93;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = RookWidgets/Info.plist;
@@ -570,7 +579,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook.RookWidgets;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookkeeper.Rook.RookWidgets;
 				PRODUCT_NAME = RookWidgets;
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 5.9;
@@ -584,6 +593,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = Sources/Rook.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				DEVELOPMENT_TEAM = 3G24HSNP93;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = Sources/Info.plist;
@@ -591,7 +601,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook;
+				PRODUCT_BUNDLE_IDENTIFIER = com.rookkeeper.Rook;
 				PRODUCT_NAME = Rook;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/clients/iphone/Sources/Info.plist
+++ b/clients/iphone/Sources/Info.plist
@@ -33,17 +33,17 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
 		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSAllowsLocalNetworking</key>
 		<true/>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>ts.net</key>
 			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
 		</dict>

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -85,14 +85,12 @@ final class RookModel: ObservableObject {
     @Published var authTokenString: String
 
     private(set) var api: RookAPI
-    private let socket = AcpSocket()
+    private var handles: [String: SessionHandle] = [:]
     private var healthTimer: Timer?
     private var environmentListAutoRefreshTask: Task<Void, Never>?
+    private var autoResumeAttempted = false
     private var blockCounter = 0
     private var enteredEnvironments: Set<String> = []
-    private var autoResumeAttempted = false
-    private var reconnectTask: Task<Void, Never>?
-    private var userCancelledRun = false
 
     init() {
         let env = ProcessInfo.processInfo.environment["ROOK_SERVER_BASE_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -125,12 +123,6 @@ final class RookModel: ObservableObject {
             authToken: authToken
         )
 
-        socket.onEvent = { [weak self] event in
-            self?.handleSocketEvent(event)
-        }
-        socket.onConnectionChange = { [weak self] connected in
-            self?.handleSocketConnectionChange(connected)
-        }
         healthTimer = Timer.scheduledTimer(withTimeInterval: 4, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 await self?.refreshHealth()
@@ -400,7 +392,7 @@ final class RookModel: ObservableObject {
             KeychainStore.setString(trimmedToken, for: "RookAuthToken")
         }
         api = RookAPI(baseURL: url, authToken: trimmedToken)
-        socket.disconnect()
+        currentHandle?.close()
         currentSession = nil
         Task { await refreshHealth() }
     }
@@ -450,6 +442,11 @@ final class RookModel: ObservableObject {
 
     // MARK: - Runtimes & sessions
 
+    private var currentHandle: SessionHandle? {
+        guard let session = currentSession else { return nil }
+        return handles[session.id]
+    }
+
     func loadAgents() async {
         do {
             agents = try await api.agents()
@@ -475,18 +472,16 @@ final class RookModel: ObservableObject {
     }
 
     private func ensureSocketConnected() async throws {
-        _ = try await socket.connect(request: api.webSocketRequest())
+        // No longer needed — SessionHandle manages its own socket.
     }
 
     private func autoResumeRecentSessionIfNeeded() async {
         guard !autoResumeAttempted, currentSession == nil else { return }
         autoResumeAttempted = true
         do {
-            try await ensureSocketConnected()
-            let recent = try await socket.sessionList().first
-            guard let recent else { return }
-            try await socket.loadSession(recent.id)
-            enterChat(session: recent, resumed: true, switchToChat: false)
+            if sessions.isEmpty { sessions = try await api.sessions() }
+            guard let recent = sessions.first else { return }
+            resumeSession(recent)
         } catch {
             sessionsError = error.localizedDescription
         }
@@ -499,8 +494,7 @@ final class RookModel: ObservableObject {
         sessionsLoading = true
         defer { sessionsLoading = false }
         do {
-            try await ensureSocketConnected()
-            sessions = try await socket.sessionList()
+            sessions = try await api.sessions()
             sessionsError = ""
         } catch {
             sessionsError = error.localizedDescription
@@ -513,11 +507,13 @@ final class RookModel: ObservableObject {
         Task {
             defer { startingSession = false }
             do {
-                try await ensureSocketConnected()
-                let sessionId = try await socket.createSession(runtimeId: agentId, title: trimmed.isEmpty ? "session" : trimmed, cwd: FileManager.default.currentDirectoryPath)
+                let tempSocket = AcpSocket()
+                _ = try await tempSocket.connect(request: api.webSocketRequest())
+                let sessionId = try await tempSocket.createSession(runtimeId: agentId, title: trimmed.isEmpty ? "session" : trimmed, cwd: FileManager.default.currentDirectoryPath)
+                tempSocket.disconnect()
                 await loadSessions()
                 if let session = sessions.first(where: { $0.id == sessionId }) {
-                    enterChat(session: session, resumed: false)
+                    resumeSession(session)
                 }
             } catch {
                 sessionsError = error.localizedDescription
@@ -530,9 +526,17 @@ final class RookModel: ObservableObject {
         Task {
             defer { startingSession = false }
             do {
-                try await ensureSocketConnected()
-                try await socket.loadSession(session.id)
-                enterChat(session: session, resumed: true, switchToChat: true)
+                let handle = getOrCreateHandle(for: session)
+                wireHandle(handle)
+                currentSession = session
+                try await handle.load()
+                selectedAgentId = nil
+                chatVisible = true
+                enteredEnvironments = []
+                environmentListItems = []
+                appendBlock(.system(text: "Resumed session — earlier messages aren't replayed."))
+                updateLiveActivity()
+                refreshEnvironmentList()
             } catch {
                 sessionsError = error.localizedDescription
             }
@@ -549,39 +553,63 @@ final class RookModel: ObservableObject {
         chatVisible = true
     }
 
-    private func enterChat(session: AgentSessionSummary, resumed: Bool, switchToChat: Bool = true) {
-        reconnectTask?.cancel()
-        selectedAgentId = nil
-        chatVisible = switchToChat
-        currentSession = session
-        blocks = []
-        queuedMessages = []
-        isRunning = false
-        statusLine = ""
-        contextUsage = nil
-        enteredEnvironments = []
-        environmentListItems = []
-        if resumed {
-            appendBlock(.system(text: "Resumed session — earlier messages aren't replayed."))
-        }
-        socket.selectSession(session.id)
-        updateLiveActivity()
-        refreshEnvironmentList()
-    }
-
     func leaveChat() {
-        socket.disconnect()
-        reconnectTask?.cancel()
+        for handle in handles.values { handle.close() }
+        handles = [:]
         currentSession = nil
         chatVisible = false
-        // Don't hard-end — if you're at a place with skills, the activity stays
-        // up as the ambient place card; updateLiveActivity ends it otherwise.
         updateLiveActivity()
+    }
+
+    private func getOrCreateHandle(for session: AgentSessionSummary) -> SessionHandle {
+        if let existing = handles[session.id] { return existing }
+        let handle = SessionHandle(sessionId: session.id, api: api)
+        handles[session.id] = handle
+        return handle
+    }
+
+    private func wireHandle(_ handle: SessionHandle) {
+        handle.onStateChange = { [weak self] in self?.syncChatState() }
+        handle.onAgentTextChunk = { [weak self] text in
+            guard let self, self.voiceModeEnabled else { return }
+            self.spokenTurnBuffer += text
+        }
+        handle.onEnvironmentOffered = { [weak self] offer in
+            self?.pendingOffer = offer
+            self?.offerBundles = []
+            self?.offerError = ""
+            self?.offerLoading = false
+        }
+        handle.onEnvironmentOfferResolved = { [weak self] _, _ in
+            self?.pendingOffer = nil
+            self?.offerBundles = []
+        }
+        handle.onEnvironmentEntered = { [weak self] environmentId in
+            self?.enteredEnvironments.insert(environmentId)
+        }
+        handle.onEnvironmentExited = { [weak self] environmentId, _ in
+            self?.enteredEnvironments.remove(environmentId)
+        }
+    }
+
+    private func syncChatState() {
+        guard let handle = currentHandle else { return }
+        blocks = handle.blocks
+        isRunning = handle.isRunning
+        statusLine = handle.statusLine
+        socketConnected = handle.socketConnected
+        reconnecting = handle.reconnecting
+        if let usage = handle.contextUsage {
+            contextUsage = (usage.used, usage.size)
+        } else {
+            contextUsage = nil
+        }
+        scrollTick = handle.scrollTick
     }
 
     // MARK: - App lifecycle (scenePhase)
 
-    private var pendingSocketResume = false
+    private var pendingSocketResume = false  // handled by SessionHandle reconnection
 
     /// iOS suspends the websocket when the app backgrounds. Tear it down
     /// intentionally (silent — no phantom "connection lost") and stop any
@@ -590,28 +618,21 @@ final class RookModel: ObservableObject {
     /// running in the background, so you're still "at" the place, and the
     /// server will age old registrations out if they stop being refreshed.
     func handleEnteredBackground() {
-        guard currentSession != nil else {
-            return
-        }
-        if socket.isConnected {
-            socket.disconnect()
-            pendingSocketResume = true
-        }
-        if isRunning {
-            finalizeStreamingBlocks()
-            isRunning = false
-            statusLine = ""
-        }
+        guard currentSession != nil else { return }
+        pendingSocketResume = true
+        // SessionHandle manages its own socket lifecycle.
     }
 
     func handleBecameActive() {
         reannouncePlaceEnvironment()
-        // Start/refresh the Live Activity now that we're foreground (Activity.request
-        // is foreground-only, so a background place arrival couldn't start it).
         updateLiveActivity()
-        if pendingSocketResume, currentSession != nil, !socket.isConnected {
+        if pendingSocketResume, let session = currentSession {
             pendingSocketResume = false
-            scheduleReconnect(delaySeconds: 0)
+            Task {
+                let handle = getOrCreateHandle(for: session)
+                wireHandle(handle)
+                try? await handle.load()
+            }
         }
         Task { await refreshHealth() }
     }
@@ -619,246 +640,25 @@ final class RookModel: ObservableObject {
     // MARK: - Chat
 
     func send(_ text: String) {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, currentSession != nil else {
-            return
-        }
-        if isRunning || !socket.isConnected {
-            queuedMessages.append(trimmed)
-            if !socket.isConnected {
-                scheduleReconnect(delaySeconds: 0)
-            }
-            return
-        }
-        deliver(trimmed)
-    }
-
-    func stopAgent() {
-        guard isRunning else {
-            return
-        }
-        userCancelledRun = true
-        statusLine = "Stopping…"
-        voice.stopSpeaking()
-        spokenTurnBuffer = ""
-        socket.sendCancel()
-    }
-
-    func removeQueuedMessage(at index: Int) {
-        guard queuedMessages.indices.contains(index) else {
-            return
-        }
-        queuedMessages.remove(at: index)
-    }
-
-    private func deliver(_ text: String) {
-        finalizeStreamingBlocks()
-        appendBlock(.user(text: text))
-        isRunning = true
-        statusLine = "Agent is working…"
-        spokenTurnBuffer = ""
-        socket.sendPrompt(text: text)
+        currentHandle?.send(text)
         updateLiveActivity()
     }
 
-    private func deliverNextQueuedIfIdle() {
-        guard !isRunning, socket.isConnected, !queuedMessages.isEmpty else {
-            return
-        }
-        let next = queuedMessages.removeFirst()
-        Task {
-            try? await Task.sleep(nanoseconds: 120_000_000)
-            guard !isRunning, socket.isConnected else {
-                queuedMessages.insert(next, at: 0)
-                return
-            }
-            deliver(next)
-        }
+    func stopAgent() {
+        guard isRunning else { return }
+        voice.stopSpeaking()
+        spokenTurnBuffer = ""
+        currentHandle?.stopAgent()
     }
 
-    private func scheduleReconnect(delaySeconds: Double) {
-        guard currentSession != nil else {
-            return
-        }
-        reconnectTask?.cancel()
-        reconnecting = true
-        reconnectTask = Task {
-            if delaySeconds > 0 {
-                try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
-            }
-            guard !Task.isCancelled, let session = currentSession else {
-                return
-            }
-            if await api.health() {
-                do {
-                    try await ensureSocketConnected()
-                    try await socket.loadSession(session.id)
-                    guard !Task.isCancelled else { return }
-                    reconnecting = false
-                    deliverNextQueuedIfIdle()
-                } catch {
-                    if !Task.isCancelled { scheduleReconnect(delaySeconds: 3) }
-                }
-            } else if !Task.isCancelled {
-                scheduleReconnect(delaySeconds: 3)
-            }
-        }
+    func removeQueuedMessage(at index: Int) {
+        currentHandle?.removeQueuedMessage(at: index)
     }
 
-    private func handleSocketConnectionChange(_ connected: Bool) {
-        socketConnected = connected
-        if connected {
-            reconnectTask?.cancel()
-            reconnectTask = nil
-            reconnecting = false
-            return
-        }
-        if isRunning {
-            isRunning = false
-            statusLine = ""
-            finalizeStreamingBlocks()
-            appendErrorBlock(source: "connection", message: "Connection lost while the agent was running.")
-        }
-        if currentSession != nil {
-            scheduleReconnect(delaySeconds: 2)
-        }
-    }
 
-    // MARK: - Event reduction
 
-    func handleSocketEvent(_ event: AcpClientEvent) {
-        switch event {
-        case .userMessageChunk(let text):
-            appendBlock(.user(text: text))
-        case .agentMessageChunk(let text):
-            statusLine = "Responding…"
-            appendStreamingText(text, isThinking: false)
-            if voiceModeEnabled {
-                spokenTurnBuffer += text
-            }
-        case .agentThoughtChunk(let text):
-            statusLine = "Thinking…"
-            appendStreamingText(text, isThinking: true)
-        case .toolCallStarted(let toolCallId, let title, let kind, let status, let rawInput):
-            statusLine = "Using tool: \(title)"
-            let state = ToolBlockState(
-                toolCallId: toolCallId,
-                title: title,
-                kindLabel: kind,
-                status: status == "in_progress" ? .running : .pending,
-                arguments: rawInput ?? "",
-                output: ""
-            )
-            appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
-        case .toolCallUpdate(let toolCallId, let status, let toolName, let output):
-            updateTool(toolCallId) { tool in
-                if let toolName, tool.title.isEmpty {
-                    tool.title = toolName
-                }
-                switch status {
-                case "pending": tool.status = .pending
-                case "in_progress":
-                    tool.status = .running
-                    if let output { tool.output = output }
-                case "completed":
-                    tool.status = .completed
-                    if let output { tool.output = output }
-                case "failed":
-                    tool.status = .failed
-                    if let output { tool.output = output }
-                case "cancelled": tool.status = .cancelled
-                default: break
-                }
-            }
-        case .toolInputSnapshot(let toolCallId, _, let text):
-            updateTool(toolCallId) { tool in
-                tool.status = .inputStreaming
-                tool.arguments = text
-            }
-        case .toolInputDelta(let toolCallId, _, let delta):
-            updateTool(toolCallId) { tool in
-                tool.status = .inputStreaming
-                tool.arguments += delta
-            }
-        case .toolCallReady(let toolCallId, _):
-            updateTool(toolCallId) { tool in
-                tool.status = .ready
-            }
-        case .toolOutputSnapshot(let toolCallId, _, let text):
-            updateTool(toolCallId) { tool in
-                tool.status = .running
-                tool.output = text
-            }
-        case .toolOutputDelta(let toolCallId, _, let delta):
-            updateTool(toolCallId) { tool in
-                tool.status = .running
-                tool.output += delta
-            }
-        case .permissionRequest:
-            break
-        case .planUpdate(let entries):
-            upsertPlanBlock(entries)
-        case .usageUpdate(let used, let size, _):
-            contextUsage = (used, size)
-        case .modesState:
-            break
-        case .currentModeUpdate:
-            break
-        case .configOptionUpdate:
-            break
-        case .runCompleted(let stopReason):
-            finalizeStreamingBlocks()
-            if stopReason == "cancelled" {
-                finalizeActiveTools(as: .cancelled)
-            }
-            isRunning = false
-            statusLine = ""
-            userCancelledRun = false
-            if voiceModeEnabled, !spokenTurnBuffer.isEmpty {
-                voice.speak(spokenTurnBuffer)
-            }
-            spokenTurnBuffer = ""
-            updateLiveActivity()
-            deliverNextQueuedIfIdle()
-        case .runFailed(let message):
-            finalizeStreamingBlocks()
-            isRunning = false
-            statusLine = ""
-            spokenTurnBuffer = ""
-            if userCancelledRun {
-                finalizeActiveTools(as: .cancelled)
-                userCancelledRun = false
-                appendBlock(.system(text: "Stopped."))
-            } else {
-                appendErrorBlock(source: "run", message: message)
-            }
-            updateLiveActivity()
-            deliverNextQueuedIfIdle()
-        case .protocolError(let message):
-            appendErrorBlock(source: "protocol", message: message)
-        case .connectionError(let message):
-            appendErrorBlock(source: "connection", message: message)
-        case .environmentOffered(let offer):
-            handleEnvironmentOffered(offer)
-        case .environmentOfferResolved(let environmentId, let bundleHash):
-            handleEnvironmentOfferResolved(environmentId, bundleHash: bundleHash)
-        case .environmentEntered(let environmentId):
-            if enteredEnvironments.insert(environmentId).inserted {
-                let entered = nearbyCandidates.first { $0.environmentId == environmentId }
-                let websites = orderedUniqueWebsites(entered: entered, all: nearbyCandidates)
-                let label = locationBannerLabel(entered: entered, candidates: nearbyCandidates)
-                appendBlock(.environment(EnvironmentBanner(displayName: label, websites: websites)))
-            }
-            refreshEnvironmentList()
-        case .environmentExited(let environmentId, let error):
-            if enteredEnvironments.remove(environmentId) != nil {
-                let suffix = error.map { " (\($0))" } ?? ""
-                appendBlock(.system(text: "Exited environment \(environmentId)\(suffix)."))
-            }
-            refreshEnvironmentList()
-        }
-        scrollTick += 1
-    }
+
+
 
     /// Banner label for an entered location: the business name when one match is clearly
     /// best, "Surrounding businesses" when ambiguous, or nil (generic) when unknown.
@@ -899,89 +699,14 @@ final class RookModel: ObservableObject {
         appendBlock(.error(source: source, message: message))
     }
 
-    private func appendStreamingText(_ text: String, isThinking: Bool) {
-        if let last = blocks.indices.last {
-            switch blocks[last].kind {
-            case .assistantText(let existing, true) where !isThinking:
-                blocks[last].kind = .assistantText(text: existing + text, streaming: true)
-                return
-            case .thinking(let existing, true) where isThinking:
-                blocks[last].kind = .thinking(text: existing + text, streaming: true)
-                return
-            default:
-                break
-            }
-        }
-        if isThinking {
-            appendBlock(.thinking(text: text, streaming: true))
-        } else {
-            appendBlock(.assistantText(text: text, streaming: true))
-        }
-    }
 
-    private func finalizeStreamingBlocks() {
-        for index in blocks.indices {
-            switch blocks[index].kind {
-            case .assistantText(let text, true):
-                blocks[index].kind = .assistantText(text: text, streaming: false)
-            case .thinking(let text, true):
-                blocks[index].kind = .thinking(text: text, streaming: false)
-            default:
-                break
-            }
-        }
-    }
 
-    func finalizeActiveTools(as finalStatus: ToolBlockStatus) {
-        for index in blocks.indices {
-            guard case .tool(var state) = blocks[index].kind else { continue }
-            guard !state.status.isTerminal else { continue }
-            state.status = finalStatus
-            blocks[index].kind = .tool(state)
-        }
-    }
 
-    private func updateTool(_ toolCallId: String, _ mutate: (inout ToolBlockState) -> Void) {
-        for index in blocks.indices.reversed() {
-            if case .tool(var state) = blocks[index].kind, state.toolCallId == toolCallId {
-                mutate(&state)
-                blocks[index].kind = .tool(state)
-                return
-            }
-        }
-        var state = ToolBlockState(toolCallId: toolCallId, title: "Tool", kindLabel: "", status: .running, arguments: "", output: "")
-        mutate(&state)
-        appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
-    }
 
-    private func upsertPlanBlock(_ entries: [PlanEntry]) {
-        for index in blocks.indices.reversed() {
-            if case .plan = blocks[index].kind {
-                blocks[index].kind = .plan(entries: entries)
-                return
-            }
-        }
-        appendBlock(.plan(entries: entries))
-    }
 
     // MARK: - Environment offers
 
-    private func handleEnvironmentOffered(_ offer: EnvironmentOffer) {
-        guard pendingOffer?.environmentId != offer.environmentId else {
-            return
-        }
-        pendingOffer = offer
-        offerBundles = []
-        offerError = ""
-        offerLoading = false
-    }
 
-    private func handleEnvironmentOfferResolved(_ environmentId: String, bundleHash: String) {
-        guard pendingOffer?.environmentId == environmentId, pendingOffer?.bundleHash == bundleHash else {
-            return
-        }
-        clearOffer()
-    }
 
     func decideEnvironment(_ decision: String) {
         guard let offer = pendingOffer, let session = currentSession else {
@@ -989,7 +714,7 @@ final class RookModel: ObservableObject {
         }
         Task {
             do {
-                try await socket.resolveEnvironmentOffer(environmentId: offer.environmentId, bundleHash: offer.bundleHash, decision: decision)
+                try await currentHandle?.resolveEnvironmentOffer(environmentId: offer.environmentId, bundleHash: offer.bundleHash, decision: decision)
                 if decision == "accept" || decision == "approve" {
                     appendBlock(.system(text: "Bundle \(offer.bundleId) allowed for \(offer.environmentId)."))
                 }

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -529,12 +529,18 @@ final class RookModel: ObservableObject {
                 let handle = getOrCreateHandle(for: session)
                 wireHandle(handle)
                 currentSession = session
-                try await handle.load()
+                if handle.isLoaded {
+                    try await handle.load()
+                } else if session.running {
+                    let events = try await api.sessionTranscript(sessionId: session.id)
+                    try await handle.attach(transcript: events)
+                } else {
+                    try await handle.load()
+                }
                 selectedAgentId = nil
                 chatVisible = true
                 enteredEnvironments = []
                 environmentListItems = []
-                appendBlock(.system(text: "Resumed session — earlier messages aren't replayed."))
                 updateLiveActivity()
                 refreshEnvironmentList()
             } catch {
@@ -631,7 +637,13 @@ final class RookModel: ObservableObject {
             Task {
                 let handle = getOrCreateHandle(for: session)
                 wireHandle(handle)
-                try? await handle.load()
+                if handle.isLoaded {
+                    try? await handle.load()
+                } else if session.running, let events = try? await api.sessionTranscript(sessionId: session.id) {
+                    try? await handle.attach(transcript: events)
+                } else {
+                    try? await handle.load()
+                }
             }
         }
         Task { await refreshHealth() }

--- a/clients/iphone/project.yml
+++ b/clients/iphone/project.yml
@@ -1,6 +1,6 @@
 name: Rook
 options:
-  bundleIdPrefix: com.rookery
+  bundleIdPrefix: com.rookkeeper
   deploymentTarget:
     iOS: "17.0"
 settings:
@@ -22,7 +22,8 @@ targets:
       - target: RookWidgets
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.rookery.Rook
+        PRODUCT_BUNDLE_IDENTIFIER: com.rookkeeper.Rook
+        DEVELOPMENT_TEAM: 3G24HSNP93
         PRODUCT_NAME: Rook
         INFOPLIST_FILE: Sources/Info.plist
         CODE_SIGN_ENTITLEMENTS: Sources/Rook.entitlements
@@ -39,7 +40,8 @@ targets:
       - package: RookKit
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.rookery.Rook.RookWidgets
+        PRODUCT_BUNDLE_IDENTIFIER: com.rookkeeper.Rook.RookWidgets
+        DEVELOPMENT_TEAM: 3G24HSNP93
         PRODUCT_NAME: RookWidgets
         INFOPLIST_FILE: RookWidgets/Info.plist
         TARGETED_DEVICE_FAMILY: "1"
@@ -55,7 +57,7 @@ targets:
       - target: Rook
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.rookery.RookTests
+        PRODUCT_BUNDLE_IDENTIFIER: com.rookkeeper.RookTests
         GENERATE_INFOPLIST_FILE: "YES"
         TARGETED_DEVICE_FAMILY: "1"
         SWIFT_VERSION: "5.9"

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -13,9 +13,9 @@ WebSocket protocol. For repo-level setup, `.env`, binding, and auth, start with
 ## Features
 
 - **Agent picker** - unified Sessions home screen listing all sessions across runtimes, with a New Chat form that selects a configured runtime.
-- **Sessions** - session history ordered by most recently updated; resume any session by clicking it. Session creation and loading use ACP (`session/new`, `session/load`) over the connection-level WebSocket.
-- **Auto-resume** - on launch the app rejoins the most recent session via ACP `session/load`.
-- **Streaming chat** — `session/prompt` over `ws://127.0.0.1:7665/api/ws`;
+- **Sessions** - session history ordered by most recently updated; resume any session by clicking it. Discovery is REST (`GET /api/sessions`). Live interaction is one session-bound WebSocket per session.
+- **Auto-resume** - on launch the app rejoins the most recent session; if it is already running, it hydrates from `GET /api/sessions/:id/transcript` instead of reloading the runtime.
+- **Streaming chat** — `session/prompt` over `ws://127.0.0.1:7665/api/ws?sessionId=...`;
   renders agent text, thinking (collapsible), tool calls with normalized raw
   input/output (including auto-rendering well-formed JSON tool arguments as
   human-readable YAML), and assistant markdown with native drag-selection,

--- a/clients/mac/Rook.xcodeproj/project.pbxproj
+++ b/clients/mac/Rook.xcodeproj/project.pbxproj
@@ -30,7 +30,6 @@
 		E1AE321D976D7E91E7CCE85F /* EnvironmentOfferControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700CE33894B323CBE9D99B12 /* EnvironmentOfferControllerTests.swift */; };
 		EBC50709AA957F9E95F341E3 /* LogViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087B8D63F86E9DD505D802D /* LogViewerView.swift */; };
 		EC3CCE47D902A251BD27408A /* RookMacChatSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */; };
-		846A32C3BB81E3C29B621792 /* SessionHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30877432D1026706D7E805DA /* SessionHandle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,7 +68,6 @@
 		D2293B2834523398CFD7FB21 /* EnvironmentOfferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentOfferView.swift; sourceTree = "<group>"; };
 		DE39DA6CCC172D89C0BD7648 /* EnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentProviderTests.swift; sourceTree = "<group>"; };
 		E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookMacChatSessionController.swift; sourceTree = "<group>"; };
-		30877432D1026706D7E805DA /* SessionHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHandle.swift; sourceTree = "<group>"; };
 		FCDBF5403D71795728D9928A /* MacBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -138,7 +136,6 @@
 		665805576D7C265839A301AE /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				30877432D1026706D7E805DA /* SessionHandle.swift */,
 				E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */,
 				60DF8054837AA98A422E1919 /* RookMacModel.swift */,
 				269B251888C4528269DA7E81 /* RookMacSupport.swift */,
@@ -284,7 +281,6 @@
 				C0541E82132250AD65401A01 /* InputSynthesizer.swift in Sources */,
 				EBC50709AA957F9E95F341E3 /* LogViewerView.swift in Sources */,
 				86F91627A128BBD4CBF341B2 /* MacBridge.swift in Sources */,
-				846A32C3BB81E3C29B621792 /* SessionHandle.swift in Sources */,
 				BC167FA11552D7BB927EA275 /* RookApp.swift in Sources */,
 				EC3CCE47D902A251BD27408A /* RookMacChatSessionController.swift in Sources */,
 				9E2E7BC2509E40784F0BCA14 /* RookMacModel.swift in Sources */,

--- a/clients/mac/Rook.xcodeproj/project.pbxproj
+++ b/clients/mac/Rook.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		E1AE321D976D7E91E7CCE85F /* EnvironmentOfferControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700CE33894B323CBE9D99B12 /* EnvironmentOfferControllerTests.swift */; };
 		EBC50709AA957F9E95F341E3 /* LogViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087B8D63F86E9DD505D802D /* LogViewerView.swift */; };
 		EC3CCE47D902A251BD27408A /* RookMacChatSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */; };
+		846A32C3BB81E3C29B621792 /* SessionHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30877432D1026706D7E805DA /* SessionHandle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -68,6 +69,7 @@
 		D2293B2834523398CFD7FB21 /* EnvironmentOfferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentOfferView.swift; sourceTree = "<group>"; };
 		DE39DA6CCC172D89C0BD7648 /* EnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentProviderTests.swift; sourceTree = "<group>"; };
 		E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookMacChatSessionController.swift; sourceTree = "<group>"; };
+		30877432D1026706D7E805DA /* SessionHandle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionHandle.swift; sourceTree = "<group>"; };
 		FCDBF5403D71795728D9928A /* MacBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridge.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -136,6 +138,7 @@
 		665805576D7C265839A301AE /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				30877432D1026706D7E805DA /* SessionHandle.swift */,
 				E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */,
 				60DF8054837AA98A422E1919 /* RookMacModel.swift */,
 				269B251888C4528269DA7E81 /* RookMacSupport.swift */,
@@ -281,6 +284,7 @@
 				C0541E82132250AD65401A01 /* InputSynthesizer.swift in Sources */,
 				EBC50709AA957F9E95F341E3 /* LogViewerView.swift in Sources */,
 				86F91627A128BBD4CBF341B2 /* MacBridge.swift in Sources */,
+				846A32C3BB81E3C29B621792 /* SessionHandle.swift in Sources */,
 				BC167FA11552D7BB927EA275 /* RookApp.swift in Sources */,
 				EC3CCE47D902A251BD27408A /* RookMacChatSessionController.swift in Sources */,
 				9E2E7BC2509E40784F0BCA14 /* RookMacModel.swift in Sources */,

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -1,6 +1,9 @@
 import Foundation
 import RookKit
 
+/// Session lifecycle and registry.  One `SessionHandle` per session, each
+/// with its own WebSocket.  Switching sessions changes which handle the UI
+/// observes — background sessions keep running.
 @MainActor
 final class ChatSessionController {
     var onStateChange: (() -> Void)?
@@ -11,8 +14,9 @@ final class ChatSessionController {
     var onEnvironmentExited: ((String, String?) -> Void)?
 
     private let api: RookAPI
-    private let socket = AcpSocket()
+    private var handles: [String: SessionHandle] = [:]
 
+    // MARK: - Session list (REST, not WebSocket)
     private(set) var sessions: [AgentSessionSummary] = [] { didSet { onStateChange?() } }
     private(set) var sessionsLoading = false { didSet { onStateChange?() } }
     private(set) var sessionsError = "" { didSet { onStateChange?() } }
@@ -24,58 +28,44 @@ final class ChatSessionController {
             onCurrentSessionChange?(currentSession)
         }
     }
-    private(set) var blocks: [ChatBlock] = [] { didSet { onStateChange?() } }
-    private(set) var queuedMessages: [QueuedChatMessage] = [] { didSet { onStateChange?() } }
-    private(set) var isRunning = false { didSet { onStateChange?() } }
-    private(set) var statusLine = "" { didSet { onStateChange?() } }
-    private(set) var socketConnected = false { didSet { onStateChange?() } }
-    private(set) var reconnecting = false { didSet { onStateChange?() } }
-    private(set) var contextUsage: ContextUsageState? { didSet { onStateChange?() } }
-    private(set) var currentModes: AcpModesState? { didSet { onStateChange?() } }
-    private(set) var configOptions: [AcpConfigOption] = [] { didSet { onStateChange?() } }
-    private(set) var pendingPermission: PendingPermissionRequest? { didSet { onStateChange?() } }
-    private(set) var lastStopReason: String? { didSet { onStateChange?() } }
-    private(set) var autoScrollEnabled = true { didSet { onStateChange?() } }
-    private(set) var scrollTick = 0 { didSet { onStateChange?() } }
 
-    private var blockCounter = 0
-    private var enteredEnvironments: Set<String> = []
-    private var userCancelledRun = false
-    private var streamingTextAccumulator = ""
-    private var streamingIsThinking = false
-    private var streamingFlushTask: Task<Void, Never>?
-    private var toolArgBuffers: [String: String] = [:]
-    private var toolOutputBuffers: [String: String] = [:]
     private var autoResumeAttempted = false
-    private var reconnectTask: Task<Void, Never>?
-    private var queuedMessageCounter = 0
-    private var isReplaying = false
-    private var replayUserBuffer = ""
-    private var replayAssistantBuffer = ""
-    private var replayThinkingBuffer = ""
+
+    /// The handle for whichever session the UI is currently looking at.
+    var currentHandle: SessionHandle? {
+        guard let session = currentSession else { return nil }
+        return handles[session.id]
+    }
+
+    // MARK: - Chat state (proxied from current handle)
+    var blocks: [ChatBlock] { currentHandle?.blocks ?? [] }
+    var queuedMessages: [QueuedChatMessage] { currentHandle?.queuedMessages ?? [] }
+    var isRunning: Bool { currentHandle?.isRunning ?? false }
+    var statusLine: String { currentHandle?.statusLine ?? "" }
+    var socketConnected: Bool { currentHandle?.socketConnected ?? false }
+    var reconnecting: Bool { currentHandle?.reconnecting ?? false }
+    var contextUsage: ContextUsageState? { currentHandle?.contextUsage }
+    var currentModes: AcpModesState? { currentHandle?.currentModes }
+    var configOptions: [AcpConfigOption] { currentHandle?.configOptions ?? [] }
+    var pendingPermission: PendingPermissionRequest? { currentHandle?.pendingPermission }
+    var lastStopReason: String? { currentHandle?.lastStopReason }
+    var autoScrollEnabled: Bool { currentHandle?.autoScrollEnabled ?? true }
+    var scrollTick: Int { currentHandle?.scrollTick ?? 0 }
 
     init(api: RookAPI) {
         self.api = api
-        socket.onEvent = { [weak self] event in
-            self?.handleSocketEvent(event)
-        }
-        socket.onConnectionChange = { [weak self] connected in
-            self?.handleSocketConnectionChange(connected)
-        }
     }
 
     func stop() {
-        socket.disconnect()
-        reconnectTask?.cancel()
-        streamingFlushTask?.cancel()
+        for handle in handles.values { handle.close() }
+        handles = [:]
     }
 
     func loadSessions() async {
         sessionsLoading = true
         defer { sessionsLoading = false }
         do {
-            try await ensureSocketConnected()
-            sessions = try await socket.sessionList()
+            sessions = try await api.sessions()
             sessionsError = ""
         } catch {
             sessionsError = error.localizedDescription
@@ -86,12 +76,9 @@ final class ChatSessionController {
         guard !autoResumeAttempted, currentSession == nil else { return }
         autoResumeAttempted = true
         do {
-            try await ensureSocketConnected()
-            if let recent = try await socket.sessionList().first {
-                prepareForSessionResume(session: recent)
-                try await socket.loadSession(recent.id)
-                finishSessionResume(session: recent)
-            }
+            if sessions.isEmpty { sessions = try await api.sessions() }
+            guard let recent = sessions.first else { return }
+            resumeSession(recent)
         } catch {
             sessionsError = error.localizedDescription
         }
@@ -102,24 +89,29 @@ final class ChatSessionController {
         let title = trimmed.isEmpty ? "session" : trimmed
         startingSession = true
         Task {
-            defer {
-                self.startingSession = false
-                completion?()
-            }
+            defer { self.startingSession = false; completion?() }
             do {
-                try await ensureSocketConnected()
-                let sessionId = try await socket.createSession(runtimeId: agentId, title: title, cwd: FileManager.default.currentDirectoryPath)
+                // Create the session via a temporary socket, then hand off
+                // to a permanent handle that loads it on its own WebSocket.
+                let tempSocket = AcpSocket()
+                _ = try await tempSocket.connect(request: api.webSocketRequest())
+                let sessionId = try await tempSocket.createSession(
+                    runtimeId: agentId,
+                    title: title,
+                    cwd: FileManager.default.currentDirectoryPath
+                )
+                tempSocket.disconnect()
+
                 await loadSessions()
-                let session = sessions.first(where: { $0.id == sessionId })
+                let summary = sessions.first(where: { $0.id == sessionId })
                     ?? AgentSessionSummary(raw: .object([
                         "sessionId": .string(sessionId),
                         "title": .string(title),
                         "_meta": .object(["runtimeId": .string(agentId)]),
                     ]))
-                enterChat(session: session)
+                resumeSession(summary)
             } catch {
                 sessionsError = error.localizedDescription
-                appendErrorBlock(source: "session", message: error.localizedDescription)
             }
         }
     }
@@ -127,646 +119,50 @@ final class ChatSessionController {
     func resumeSession(_ session: AgentSessionSummary, completion: (() -> Void)? = nil) {
         startingSession = true
         Task {
-            defer {
-                self.startingSession = false
-                completion?()
-            }
+            defer { self.startingSession = false; completion?() }
             do {
-                try await ensureSocketConnected()
-                prepareForSessionResume(session: session)
-                try await socket.loadSession(session.id)
-                finishSessionResume(session: session)
+                let handle = getOrCreateHandle(for: session)
+                currentSession = session
+                wireHandle(handle)
+                try await handle.load()
             } catch {
                 sessionsError = error.localizedDescription
-                appendErrorBlock(source: "session", message: "Failed to load session: \(error.localizedDescription)")
             }
         }
     }
 
-    func send(_ text: String) {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, currentSession != nil else {
-            return
-        }
-        if isRunning || !socket.isConnected {
-            queuedMessages.append(makeQueuedMessage(trimmed))
-            if !socket.isConnected {
-                scheduleReconnect(delaySeconds: 0)
-            }
-            return
-        }
-        deliver(trimmed)
-    }
-
-    func stopAgent() {
-        guard isRunning else {
-            return
-        }
-        userCancelledRun = true
-        statusLine = "Stopping…"
-        socket.sendCancel()
-    }
-
-    func removeQueuedMessage(at index: Int) {
-        guard queuedMessages.indices.contains(index) else {
-            return
-        }
-        queuedMessages.remove(at: index)
-    }
-
-    func beginEditingQueuedMessage(_ id: String) {
-        updateQueuedMessage(id) { message in
-            message.isEditing = true
-            message.draftText = message.text
-        }
-    }
-
-    func updateQueuedMessageDraft(_ id: String, text: String) {
-        updateQueuedMessage(id) { message in
-            message.draftText = text
-        }
-    }
-
-    func cancelEditingQueuedMessage(_ id: String) {
-        updateQueuedMessage(id) { message in
-            message.isEditing = false
-            message.draftText = message.text
-        }
-    }
-
-    func saveQueuedMessageEdit(_ id: String) {
-        updateQueuedMessage(id) { message in
-            let trimmed = message.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-            message.text = trimmed.isEmpty ? message.text : trimmed
-            message.draftText = message.text
-            message.isEditing = false
-        }
-    }
-
-    func decidePermission(optionId: String?) {
-        guard let pendingPermission else {
-            return
-        }
-        self.pendingPermission = nil
-        do {
-            try socket.respondToPermissionRequest(requestId: pendingPermission.requestId, optionId: optionId)
-        } catch {
-            appendErrorBlock(source: "protocol", message: error.localizedDescription)
-        }
-    }
-
-    func setMode(_ modeId: String) {
-        Task {
-            do {
-                try await socket.setMode(modeId)
-            } catch {
-                appendErrorBlock(source: "protocol", message: error.localizedDescription)
-            }
-        }
-    }
-
-    func setConfigOption(_ configId: String, value: String) {
-        Task {
-            do {
-                try await socket.setConfigOption(configId: configId, value: value)
-            } catch {
-                appendErrorBlock(source: "protocol", message: error.localizedDescription)
-            }
-        }
-    }
-
+    func send(_ text: String) { currentHandle?.send(text) }
+    func stopAgent() { currentHandle?.stopAgent() }
+    func removeQueuedMessage(at index: Int) { currentHandle?.removeQueuedMessage(at: index) }
+    func beginEditingQueuedMessage(_ id: String) { currentHandle?.beginEditingQueuedMessage(id) }
+    func updateQueuedMessageDraft(_ id: String, text: String) { currentHandle?.updateQueuedMessageDraft(id, text: text) }
+    func cancelEditingQueuedMessage(_ id: String) { currentHandle?.cancelEditingQueuedMessage(id) }
+    func saveQueuedMessageEdit(_ id: String) { currentHandle?.saveQueuedMessageEdit(id) }
+    func decidePermission(optionId: String?) { currentHandle?.decidePermission(optionId: optionId) }
+    func setMode(_ modeId: String) { currentHandle?.setMode(modeId) }
+    func setConfigOption(_ configId: String, value: String) { currentHandle?.setConfigOption(configId, value: value) }
     func resolveEnvironmentOffer(environmentId: String, bundleHash: String, decision: String) async throws {
-        try await socket.resolveEnvironmentOffer(environmentId: environmentId, bundleHash: bundleHash, decision: decision)
+        try await currentHandle?.resolveEnvironmentOffer(environmentId: environmentId, bundleHash: bundleHash, decision: decision)
+    }
+    func refreshForCurrentSessionReset() { currentHandle?.refreshForCurrentSessionReset() }
+    func resumeAutoScroll() { currentHandle?.resumeAutoScroll() }
+    func pauseAutoScroll() { currentHandle?.pauseAutoScroll() }
+    func appendSystemMessage(_ text: String) { currentHandle?.appendSystemMessage(text) }
+
+    // MARK: - Private
+
+    private func getOrCreateHandle(for session: AgentSessionSummary) -> SessionHandle {
+        if let existing = handles[session.id] { return existing }
+        let handle = SessionHandle(sessionId: session.id, api: api)
+        handles[session.id] = handle
+        return handle
     }
 
-    func refreshForCurrentSessionReset() {
-        enteredEnvironments = []
-    }
-
-    func resumeAutoScroll() {
-        let wasEnabled = autoScrollEnabled
-        autoScrollEnabled = true
-        if !wasEnabled {
-            scrollTick += 1
-        }
-    }
-
-    func pauseAutoScroll() {
-        autoScrollEnabled = false
-    }
-
-    private func ensureSocketConnected() async throws {
-        _ = try await socket.connect(request: api.webSocketRequest())
-    }
-
-    private func prepareForSessionResume(session: AgentSessionSummary) {
-        reconnectTask?.cancel()
-        currentSession = session
-        blocks = []
-        queuedMessages = []
-        isRunning = false
-        statusLine = ""
-        contextUsage = nil
-        currentModes = nil
-        configOptions = []
-        pendingPermission = nil
-        lastStopReason = nil
-        enteredEnvironments = []
-        isReplaying = true
-        replayUserBuffer = ""
-        replayAssistantBuffer = ""
-        replayThinkingBuffer = ""
-        socket.selectSession(session.id)
-    }
-
-    private func finishSessionResume(session: AgentSessionSummary) {
-        isReplaying = false
-        flushReplayBuffers()
-        isRunning = false
-    }
-
-    private func enterChat(session: AgentSessionSummary) {
-        reconnectTask?.cancel()
-        currentSession = session
-        blocks = []
-        queuedMessages = []
-        isRunning = false
-        statusLine = ""
-        contextUsage = nil
-        currentModes = nil
-        configOptions = []
-        pendingPermission = nil
-        lastStopReason = nil
-        enteredEnvironments = []
-        socket.selectSession(session.id)
-    }
-
-    private func flushReplayBuffers() {
-        if !replayUserBuffer.isEmpty {
-            appendBlock(.user(text: replayUserBuffer))
-            replayUserBuffer = ""
-        }
-        if !replayThinkingBuffer.isEmpty {
-            appendBlock(.thinking(text: replayThinkingBuffer, streaming: false))
-            replayThinkingBuffer = ""
-        }
-        if !replayAssistantBuffer.isEmpty {
-            appendBlock(.assistantText(text: replayAssistantBuffer, streaming: false))
-            replayAssistantBuffer = ""
-        }
-    }
-
-    private func replayFlushIncompatibleSection(_ next: String) {
-        if next == "user" {
-            if !replayAssistantBuffer.isEmpty { flushReplaySection("assistant") }
-            if !replayThinkingBuffer.isEmpty { flushReplaySection("thinking") }
-        } else if next == "thinking" {
-            if !replayUserBuffer.isEmpty { flushReplaySection("user") }
-            if !replayAssistantBuffer.isEmpty { flushReplaySection("assistant") }
-        } else if next == "assistant" {
-            if !replayUserBuffer.isEmpty { flushReplaySection("user") }
-            if !replayThinkingBuffer.isEmpty { flushReplaySection("thinking") }
-        } else {
-            if !replayUserBuffer.isEmpty { flushReplaySection("user") }
-            if !replayThinkingBuffer.isEmpty { flushReplaySection("thinking") }
-            if !replayAssistantBuffer.isEmpty { flushReplaySection("assistant") }
-        }
-    }
-
-    private func flushReplaySection(_ section: String) {
-        switch section {
-        case "user":
-            if !replayUserBuffer.isEmpty {
-                appendBlock(.user(text: replayUserBuffer))
-                replayUserBuffer = ""
-            }
-        case "thinking":
-            if !replayThinkingBuffer.isEmpty {
-                appendBlock(.thinking(text: replayThinkingBuffer, streaming: false))
-                replayThinkingBuffer = ""
-            }
-        case "assistant":
-            if !replayAssistantBuffer.isEmpty {
-                appendBlock(.assistantText(text: replayAssistantBuffer, streaming: false))
-                replayAssistantBuffer = ""
-            }
-        default:
-            break
-        }
-    }
-
-    private func deliver(_ text: String) {
-        finalizeStreamingBlocks()
-        appendBlock(.user(text: text))
-        isRunning = true
-        statusLine = "Agent is working…"
-        lastStopReason = nil
-        autoScrollEnabled = true
-        socket.sendPrompt(text: text)
-    }
-
-    private func deliverNextQueuedIfIdle() {
-        guard !isRunning, socket.isConnected, !queuedMessages.isEmpty else {
-            return
-        }
-        let next = queuedMessages.removeFirst()
-        Task {
-            try? await Task.sleep(nanoseconds: 120_000_000)
-            guard !isRunning, socket.isConnected else {
-                queuedMessages.insert(next, at: 0)
-                return
-            }
-            deliver(next.text)
-        }
-    }
-
-    private func scheduleReconnect(delaySeconds: Double) {
-        guard currentSession != nil else {
-            return
-        }
-        reconnectTask?.cancel()
-        reconnecting = true
-        reconnectTask = Task {
-            if delaySeconds > 0 {
-                try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
-            }
-            guard !Task.isCancelled, let session = currentSession else {
-                return
-            }
-            if await api.health() {
-                do {
-                    try await ensureSocketConnected()
-                    try await socket.loadSession(session.id)
-                    guard !Task.isCancelled else { return }
-                    reconnecting = false
-                    deliverNextQueuedIfIdle()
-                } catch {
-                    if !Task.isCancelled {
-                        scheduleReconnect(delaySeconds: 3)
-                    }
-                }
-            } else if !Task.isCancelled {
-                scheduleReconnect(delaySeconds: 3)
-            }
-        }
-    }
-
-    private func handleSocketConnectionChange(_ connected: Bool) {
-        socketConnected = connected
-        if connected {
-            reconnectTask?.cancel()
-            reconnectTask = nil
-            reconnecting = false
-            return
-        }
-        if isRunning {
-            isRunning = false
-            statusLine = ""
-            finalizeStreamingBlocks()
-            appendErrorBlock(source: "connection", message: "Connection lost while the agent was running.")
-        }
-        if currentSession != nil {
-            scheduleReconnect(delaySeconds: 2)
-        }
-    }
-
-    private func handleSocketEvent(_ event: AcpClientEvent) {
-        switch event {
-        case .userMessageChunk(let text):
-            if isReplaying {
-                replayFlushIncompatibleSection("user")
-                replayUserBuffer += text
-            } else {
-                appendBlock(.user(text: text))
-            }
-        case .agentMessageChunk(let text):
-            if isReplaying {
-                replayFlushIncompatibleSection("assistant")
-                replayAssistantBuffer += text
-            } else {
-                statusLine = "Responding…"
-                appendStreamingText(text, isThinking: false)
-            }
-        case .agentThoughtChunk(let text):
-            if isReplaying {
-                replayFlushIncompatibleSection("thinking")
-                replayThinkingBuffer += text
-            } else {
-                statusLine = "Thinking…"
-                appendStreamingText(text, isThinking: true)
-            }
-        case .toolCallStarted(let toolCallId, let title, let kind, let status, let rawInput):
-            if isReplaying {
-                replayFlushIncompatibleSection("tool")
-            } else {
-                flushLiveIncompatibleSection()
-                statusLine = "Using tool: \(title)"
-            }
-            let state = ToolBlockState(
-                toolCallId: toolCallId,
-                title: title,
-                kindLabel: kind,
-                status: status == "in_progress" ? .running : .pending,
-                arguments: rawInput ?? "",
-                output: ""
-            )
-            appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
-        case .toolCallUpdate(let toolCallId, let status, let toolName, let output):
-            if isReplaying {
-                replayFlushIncompatibleSection("tool")
-            } else {
-                flushLiveIncompatibleSection()
-            }
-            updateTool(toolCallId) { tool in
-                if let toolName, tool.title.isEmpty {
-                    tool.title = toolName
-                }
-                switch status {
-                case "pending":
-                    advanceToolStatus(&tool, to: .pending)
-                case "in_progress":
-                    advanceToolStatus(&tool, to: .running)
-                    if let output { tool.output = output }
-                case "completed":
-                    advanceToolStatus(&tool, to: .completed)
-                    if let output { tool.output = output }
-                case "failed":
-                    advanceToolStatus(&tool, to: .failed)
-                    if let output { tool.output = output }
-                case "cancelled":
-                    advanceToolStatus(&tool, to: .cancelled)
-                default:
-                    break
-                }
-            }
-        case .toolInputSnapshot(let toolCallId, _, let text):
-            if isReplaying { updateTool(toolCallId) { $0.arguments = text }; return }
-            toolArgBuffers[toolCallId] = text
-            scheduleStreamingFlush()
-        case .toolInputDelta(let toolCallId, _, let delta):
-            if isReplaying { updateTool(toolCallId) { $0.arguments += delta }; return }
-            toolArgBuffers[toolCallId, default: ""] += delta
-            scheduleStreamingFlush()
-        case .toolCallReady(let toolCallId, _):
-            if isReplaying {
-                updateTool(toolCallId) { tool in
-                    advanceToolStatus(&tool, to: .ready)
-                }
-                return
-            }
-            flushLiveIncompatibleSection()
-            updateTool(toolCallId) { tool in
-                advanceToolStatus(&tool, to: .ready)
-            }
-        case .toolOutputSnapshot(let toolCallId, _, let text):
-            if isReplaying { updateTool(toolCallId) { $0.output = text }; return }
-            toolOutputBuffers[toolCallId] = text
-            scheduleStreamingFlush()
-        case .toolOutputDelta(let toolCallId, _, let delta):
-            if isReplaying { updateTool(toolCallId) { $0.output += delta }; return }
-            toolOutputBuffers[toolCallId, default: ""] += delta
-            scheduleStreamingFlush()
-        case .permissionRequest(let requestId, let toolCall, let options):
-            if isReplaying { return }
-            pendingPermission = PendingPermissionRequest(requestId: requestId, toolCall: toolCall, options: options)
-            statusLine = "Permission needed: \(toolCall.title)"
-        case .planUpdate(let entries):
-            upsertPlanBlock(entries)
-        case .usageUpdate(let used, let size, let cost):
-            contextUsage = ContextUsageState(used: used, size: size, cost: cost)
-        case .modesState(let currentModeId, let availableModes):
-            currentModes = AcpModesState(currentModeId: currentModeId, availableModes: availableModes)
-        case .currentModeUpdate(let modeId):
-            if let currentModes {
-                self.currentModes = AcpModesState(currentModeId: modeId, availableModes: currentModes.availableModes)
-            }
-        case .configOptionUpdate(let configOptions):
-            self.configOptions = configOptions
-        case .runCompleted(let stopReason):
-            if isReplaying { flushReplayBuffers(); return }
-            finalizeStreamingBlocks()
-            if stopReason == "cancelled" {
-                finalizeActiveTools(as: .cancelled)
-            }
-            isRunning = false
-            statusLine = ""
-            lastStopReason = stopReason
-            pendingPermission = nil
-            userCancelledRun = false
-            deliverNextQueuedIfIdle()
-        case .runFailed(let message):
-            if isReplaying { flushReplayBuffers(); return }
-            finalizeStreamingBlocks()
-            isRunning = false
-            statusLine = ""
-            pendingPermission = nil
-            if userCancelledRun || message.lowercased().contains("cancel") {
-                finalizeActiveTools(as: .cancelled)
-                userCancelledRun = false
-                lastStopReason = "cancelled"
-                appendBlock(.system(text: "Stopped."))
-            } else {
-                lastStopReason = "failed"
-                appendErrorBlock(source: "run", message: message)
-            }
-            deliverNextQueuedIfIdle()
-        case .protocolError(let message):
-            appendErrorBlock(source: "protocol", message: message)
-        case .connectionError(let message):
-            appendErrorBlock(source: "connection", message: message)
-        case .environmentOffered(let offer):
-            onEnvironmentOffered?(offer)
-        case .environmentOfferResolved(let environmentId, let bundleHash):
-            onEnvironmentOfferResolved?(environmentId, bundleHash)
-        case .environmentEntered(let environmentId):
-            if enteredEnvironments.insert(environmentId).inserted {
-                onEnvironmentEntered?(environmentId)
-                appendBlock(.system(text: "Entered environment \(environmentId)."))
-            }
-        case .environmentExited(let environmentId, let error):
-            if enteredEnvironments.remove(environmentId) != nil {
-                onEnvironmentExited?(environmentId, error)
-                let suffix = error.map { " (\($0))" } ?? ""
-                appendBlock(.system(text: "Exited environment \(environmentId)\(suffix)."))
-            }
-        }
-        scrollTick += 1
-    }
-
-    private func makeQueuedMessage(_ text: String) -> QueuedChatMessage {
-        queuedMessageCounter += 1
-        return QueuedChatMessage(id: "queued-\(queuedMessageCounter)", text: text, draftText: text)
-    }
-
-    private func updateQueuedMessage(_ id: String, mutate: (inout QueuedChatMessage) -> Void) {
-        guard let index = queuedMessages.firstIndex(where: { $0.id == id }) else {
-            return
-        }
-        mutate(&queuedMessages[index])
-    }
-
-    private func appendBlock(_ kind: ChatBlockKind, id: String? = nil) {
-        blockCounter += 1
-        blocks.append(ChatBlock(id: id ?? "block-\(blockCounter)", kind: kind))
-    }
-
-    private func appendErrorBlock(source: String, message: String) {
-        if case .error(let lastSource, let lastMessage)? = blocks.last?.kind,
-           lastSource == source, lastMessage == message {
-            return
-        }
-        appendBlock(.error(source: source, message: message))
-    }
-
-    private func scheduleStreamingFlush() {
-        streamingFlushTask?.cancel()
-        streamingFlushTask = Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 16_000_000)
-            guard !Task.isCancelled else { return }
-            applyStreamingFlush()
-        }
-    }
-
-    private func flushLiveIncompatibleSection() {
-        streamingFlushTask?.cancel()
-        streamingFlushTask = nil
-        applyStreamingFlush()
-    }
-
-    private func applyStreamingFlush() {
-        if !streamingTextAccumulator.isEmpty {
-            if let last = blocks.indices.last {
-                switch blocks[last].kind {
-                case .assistantText(let existing, true) where !streamingIsThinking:
-                    blocks[last].kind = .assistantText(text: existing + streamingTextAccumulator, streaming: true)
-                    streamingTextAccumulator = ""
-                case .thinking(let existing, true) where streamingIsThinking:
-                    blocks[last].kind = .thinking(text: existing + streamingTextAccumulator, streaming: true)
-                    streamingTextAccumulator = ""
-                default:
-                    break
-                }
-            }
-            if !streamingTextAccumulator.isEmpty {
-                if streamingIsThinking {
-                    appendBlock(.thinking(text: streamingTextAccumulator, streaming: true))
-                } else {
-                    appendBlock(.assistantText(text: streamingTextAccumulator, streaming: true))
-                }
-                streamingTextAccumulator = ""
-            }
-        }
-
-        if !toolArgBuffers.isEmpty {
-            let snap = toolArgBuffers
-            toolArgBuffers = [:]
-            for (toolCallId, text) in snap {
-                updateTool(toolCallId) { tool in
-                    advanceToolStatus(&tool, to: .inputStreaming)
-                    tool.arguments = text
-                }
-            }
-        }
-        if !toolOutputBuffers.isEmpty {
-            let snap = toolOutputBuffers
-            toolOutputBuffers = [:]
-            for (toolCallId, text) in snap {
-                updateTool(toolCallId) { tool in
-                    advanceToolStatus(&tool, to: .running)
-                    tool.output = text
-                }
-            }
-        }
-    }
-
-    private func appendStreamingText(_ text: String, isThinking: Bool) {
-        if streamingIsThinking != isThinking && !streamingTextAccumulator.isEmpty {
-            applyStreamingFlush()
-        }
-        streamingTextAccumulator += text
-        streamingIsThinking = isThinking
-        scheduleStreamingFlush()
-    }
-
-    private func finalizeStreamingBlocks() {
-        flushLiveIncompatibleSection()
-        streamingTextAccumulator = ""
-        toolArgBuffers = [:]
-        toolOutputBuffers = [:]
-        for index in blocks.indices {
-            switch blocks[index].kind {
-            case .assistantText(let text, true):
-                blocks[index].kind = .assistantText(text: text, streaming: false)
-            case .thinking(let text, true):
-                blocks[index].kind = .thinking(text: text, streaming: false)
-            default:
-                break
-            }
-        }
-    }
-
-    private func toolStatusRank(_ status: ToolBlockStatus) -> Int {
-        switch status {
-        case .pending:
-            return 0
-        case .inputStreaming:
-            return 1
-        case .ready:
-            return 2
-        case .running:
-            return 3
-        case .completed, .failed, .cancelled:
-            return 4
-        }
-    }
-
-    private func advanceToolStatus(_ tool: inout ToolBlockState, to next: ToolBlockStatus) {
-        guard !tool.status.isTerminal else { return }
-        if next.isTerminal || toolStatusRank(next) >= toolStatusRank(tool.status) {
-            tool.status = next
-        }
-    }
-
-    func appendSystemMessage(_ text: String) {
-        appendBlock(.system(text: text))
-    }
-
-    func finalizeActiveTools(as finalStatus: ToolBlockStatus) {
-        for index in blocks.indices {
-            guard case .tool(var state) = blocks[index].kind else { continue }
-            guard !state.status.isTerminal else { continue }
-            state.status = finalStatus
-            blocks[index].kind = .tool(state)
-        }
-    }
-
-    private func updateTool(_ toolCallId: String, _ mutate: (inout ToolBlockState) -> Void) {
-        for index in blocks.indices.reversed() {
-            if case .tool(var state) = blocks[index].kind, state.toolCallId == toolCallId {
-                mutate(&state)
-                blocks[index].kind = .tool(state)
-                return
-            }
-        }
-        var state = ToolBlockState(
-            toolCallId: toolCallId,
-            title: "Tool",
-            kindLabel: "",
-            status: .running,
-            arguments: "",
-            output: ""
-        )
-        mutate(&state)
-        appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
-    }
-
-    private func upsertPlanBlock(_ entries: [PlanEntry]) {
-        for index in blocks.indices.reversed() {
-            if case .plan = blocks[index].kind {
-                blocks[index].kind = .plan(entries: entries)
-                return
-            }
-        }
-        appendBlock(.plan(entries: entries))
+    private func wireHandle(_ handle: SessionHandle) {
+        handle.onStateChange = { [weak self] in self?.onStateChange?() }
+        handle.onEnvironmentOffered = { [weak self] in self?.onEnvironmentOffered?($0) }
+        handle.onEnvironmentOfferResolved = { [weak self] in self?.onEnvironmentOfferResolved?($0, $1) }
+        handle.onEnvironmentEntered = { [weak self] in self?.onEnvironmentEntered?($0) }
+        handle.onEnvironmentExited = { [weak self] in self?.onEnvironmentExited?($0, $1) }
     }
 }

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -124,7 +124,14 @@ final class ChatSessionController {
                 let handle = getOrCreateHandle(for: session)
                 currentSession = session
                 wireHandle(handle)
-                try await handle.load()
+                if handle.isLoaded {
+                    try await handle.load()
+                } else if session.running {
+                    let events = try await api.sessionTranscript(sessionId: session.id)
+                    try await handle.attach(transcript: events)
+                } else {
+                    try await handle.load()
+                }
             } catch {
                 sessionsError = error.localizedDescription
             }

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -18,25 +18,6 @@ enum ServerState: Equatable {
     case online
 }
 
-struct QueuedChatMessage: Identifiable, Equatable {
-    let id: String
-    var text: String
-    var draftText: String
-    var isEditing = false
-}
-
-struct PendingPermissionRequest: Equatable {
-    var requestId: String
-    var toolCall: AcpPermissionToolCall
-    var options: [AcpPermissionOption]
-}
-
-struct ContextUsageState: Equatable {
-    var used: Int
-    var size: Int
-    var cost: AcpUsageCost?
-}
-
 @MainActor
 final class RookMacModel: ObservableObject {
     static weak var shared: RookMacModel?

--- a/clients/mac/Sources/Models/SessionHandle.swift
+++ b/clients/mac/Sources/Models/SessionHandle.swift
@@ -1,0 +1,565 @@
+import Foundation
+import RookKit
+
+/// Owns a dedicated WebSocket, blocks, run state, and streaming state for one
+/// session.  Multiple handles coexist — switching sessions is just changing
+/// which handle the UI observes.
+@MainActor
+final class SessionHandle {
+    let sessionId: String
+
+    var onStateChange: (() -> Void)?
+    var onEnvironmentOffered: ((EnvironmentOffer) -> Void)?
+    var onEnvironmentOfferResolved: ((String, String) -> Void)?
+    var onEnvironmentEntered: ((String) -> Void)?
+    var onEnvironmentExited: ((String, String?) -> Void)?
+
+    private let api: RookAPI
+    private let socket = AcpSocket()
+
+    // MARK: - Observable state (same shape ChatSessionController exposed)
+    private(set) var blocks: [ChatBlock] = [] { didSet { onStateChange?() } }
+    private(set) var queuedMessages: [QueuedChatMessage] = [] { didSet { onStateChange?() } }
+    private(set) var isRunning = false { didSet { onStateChange?() } }
+    private(set) var statusLine = "" { didSet { onStateChange?() } }
+    private(set) var socketConnected = false { didSet { onStateChange?() } }
+    private(set) var reconnecting = false { didSet { onStateChange?() } }
+    private(set) var contextUsage: ContextUsageState? { didSet { onStateChange?() } }
+    private(set) var currentModes: AcpModesState? { didSet { onStateChange?() } }
+    private(set) var configOptions: [AcpConfigOption] = [] { didSet { onStateChange?() } }
+    private(set) var pendingPermission: PendingPermissionRequest? { didSet { onStateChange?() } }
+    private(set) var lastStopReason: String? { didSet { onStateChange?() } }
+    private(set) var autoScrollEnabled = true { didSet { onStateChange?() } }
+    private(set) var scrollTick = 0 { didSet { onStateChange?() } }
+
+    // MARK: - Private streaming / replay state
+    private var blockCounter = 0
+    private var enteredEnvironments: Set<String> = []
+    private var userCancelledRun = false
+    private var streamingTextAccumulator = ""
+    private var streamingIsThinking = false
+    private var streamingFlushTask: Task<Void, Never>?
+    private var toolArgBuffers: [String: String] = [:]
+    private var toolOutputBuffers: [String: String] = [:]
+    private var reconnectTask: Task<Void, Never>?
+    private var queuedMessageCounter = 0
+    private var isReplaying = false
+    private var replayUserBuffer = ""
+    private var replayAssistantBuffer = ""
+    private var replayThinkingBuffer = ""
+
+    init(sessionId: String, api: RookAPI) {
+        self.sessionId = sessionId
+        self.api = api
+        socket.onEvent = { [weak self] event in
+            self?.handleSocketEvent(event)
+        }
+        socket.onConnectionChange = { [weak self] connected in
+            self?.handleSocketConnectionChange(connected)
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func connectAndLoad(title: String, cwd: String) async throws {
+        try await ensureSocketConnected()
+        _ = try await socket.createSession(runtimeId: "", title: title, cwd: cwd)
+    }
+
+    func load() async throws {
+        try await ensureSocketConnected()
+        isReplaying = true
+        replayUserBuffer = ""
+        replayAssistantBuffer = ""
+        replayThinkingBuffer = ""
+        socket.selectSession(sessionId)
+        try await socket.loadSession(sessionId)
+        isReplaying = false
+        flushReplayBuffers()
+        isRunning = false
+    }
+
+    func close() {
+        reconnectTask?.cancel()
+        streamingFlushTask?.cancel()
+        socket.disconnect()
+    }
+
+    func stopAgent() {
+        guard isRunning else { return }
+        userCancelledRun = true
+        statusLine = "Stopping…"
+        socket.sendCancel()
+    }
+
+    // MARK: - Messaging
+
+    func send(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if isRunning || !socket.isConnected {
+            queuedMessages.append(makeQueuedMessage(trimmed))
+            if !socket.isConnected {
+                scheduleReconnect(delaySeconds: 0)
+            }
+            return
+        }
+        deliver(trimmed)
+    }
+
+    func removeQueuedMessage(at index: Int) {
+        guard queuedMessages.indices.contains(index) else { return }
+        queuedMessages.remove(at: index)
+    }
+
+    func beginEditingQueuedMessage(_ id: String) {
+        updateQueuedMessage(id) { $0.isEditing = true; $0.draftText = $0.text }
+    }
+
+    func updateQueuedMessageDraft(_ id: String, text: String) {
+        updateQueuedMessage(id) { $0.draftText = text }
+    }
+
+    func cancelEditingQueuedMessage(_ id: String) {
+        updateQueuedMessage(id) { $0.isEditing = false; $0.draftText = $0.text }
+    }
+
+    func saveQueuedMessageEdit(_ id: String) {
+        updateQueuedMessage(id) { message in
+            let trimmed = message.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
+            message.text = trimmed.isEmpty ? message.text : trimmed
+            message.draftText = message.text
+            message.isEditing = false
+        }
+    }
+
+    func decidePermission(optionId: String?) {
+        guard let pendingPermission else { return }
+        self.pendingPermission = nil
+        do {
+            try socket.respondToPermissionRequest(requestId: pendingPermission.requestId, optionId: optionId)
+        } catch {
+            appendErrorBlock(source: "protocol", message: error.localizedDescription)
+        }
+    }
+
+    func setMode(_ modeId: String) {
+        Task {
+            do { try await socket.setMode(modeId) }
+            catch { appendErrorBlock(source: "protocol", message: error.localizedDescription) }
+        }
+    }
+
+    func setConfigOption(_ configId: String, value: String) {
+        Task {
+            do { try await socket.setConfigOption(configId: configId, value: value) }
+            catch { appendErrorBlock(source: "protocol", message: error.localizedDescription) }
+        }
+    }
+
+    func resolveEnvironmentOffer(environmentId: String, bundleHash: String, decision: String) async throws {
+        try await socket.resolveEnvironmentOffer(environmentId: environmentId, bundleHash: bundleHash, decision: decision)
+    }
+
+    func refreshForCurrentSessionReset() {
+        enteredEnvironments = []
+    }
+
+    func resumeAutoScroll() {
+        let wasEnabled = autoScrollEnabled
+        autoScrollEnabled = true
+        if !wasEnabled { scrollTick += 1 }
+    }
+
+    func pauseAutoScroll() {
+        autoScrollEnabled = false
+    }
+
+    func appendSystemMessage(_ text: String) {
+        appendBlock(.system(text: text))
+    }
+
+    func finalizeActiveTools(as finalStatus: ToolBlockStatus) {
+        for index in blocks.indices {
+            guard case .tool(var state) = blocks[index].kind else { continue }
+            guard !state.status.isTerminal else { continue }
+            state.status = finalStatus
+            blocks[index].kind = .tool(state)
+        }
+    }
+
+    // MARK: - Private: connection
+
+    private func ensureSocketConnected() async throws {
+        _ = try await socket.connect(request: api.webSocketRequest())
+    }
+
+    private func scheduleReconnect(delaySeconds: Double) {
+        reconnectTask?.cancel()
+        reconnecting = true
+        reconnectTask = Task {
+            if delaySeconds > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+            }
+            guard !Task.isCancelled else { return }
+            if await api.health() {
+                do {
+                    try await ensureSocketConnected()
+                    try await socket.loadSession(sessionId)
+                    guard !Task.isCancelled else { return }
+                    reconnecting = false
+                    deliverNextQueuedIfIdle()
+                } catch {
+                    if !Task.isCancelled { scheduleReconnect(delaySeconds: 3) }
+                }
+            } else if !Task.isCancelled {
+                scheduleReconnect(delaySeconds: 3)
+            }
+        }
+    }
+
+    // MARK: - Private: delivery
+
+    private func deliver(_ text: String) {
+        finalizeStreamingBlocks()
+        appendBlock(.user(text: text))
+        isRunning = true
+        statusLine = "Agent is working…"
+        lastStopReason = nil
+        autoScrollEnabled = true
+        socket.sendPrompt(text: text)
+    }
+
+    private func deliverNextQueuedIfIdle() {
+        guard !isRunning, socket.isConnected, !queuedMessages.isEmpty else { return }
+        let next = queuedMessages.removeFirst()
+        Task {
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            guard !isRunning, socket.isConnected else {
+                queuedMessages.insert(next, at: 0)
+                return
+            }
+            deliver(next.text)
+        }
+    }
+
+    // MARK: - Private: event handling
+
+    private func handleSocketConnectionChange(_ connected: Bool) {
+        socketConnected = connected
+        if connected {
+            reconnectTask?.cancel()
+            reconnectTask = nil
+            reconnecting = false
+            return
+        }
+        if isRunning {
+            isRunning = false
+            statusLine = ""
+            finalizeStreamingBlocks()
+            appendErrorBlock(source: "connection", message: "Connection lost while the agent was running.")
+        }
+        scheduleReconnect(delaySeconds: 2)
+    }
+
+    private func handleSocketEvent(_ event: AcpClientEvent) {
+        switch event {
+        case .userMessageChunk(let text):
+            if isReplaying {
+                replayFlushIncompatibleSection("user")
+                replayUserBuffer += text
+            } else {
+                appendBlock(.user(text: text))
+            }
+        case .agentMessageChunk(let text):
+            if isReplaying {
+                replayFlushIncompatibleSection("assistant")
+                replayAssistantBuffer += text
+            } else {
+                statusLine = "Responding…"
+                appendStreamingText(text, isThinking: false)
+            }
+        case .agentThoughtChunk(let text):
+            if isReplaying {
+                replayFlushIncompatibleSection("thinking")
+                replayThinkingBuffer += text
+            } else {
+                statusLine = "Thinking…"
+                appendStreamingText(text, isThinking: true)
+            }
+        case .toolCallStarted(let toolCallId, let title, let kind, let status, let rawInput):
+            if isReplaying {
+                replayFlushIncompatibleSection("tool")
+            } else {
+                flushLiveIncompatibleSection()
+                statusLine = "Using tool: \(title)"
+            }
+            let state = ToolBlockState(
+                toolCallId: toolCallId,
+                title: title,
+                kindLabel: kind,
+                status: status == "in_progress" ? .running : .pending,
+                arguments: rawInput ?? "",
+                output: ""
+            )
+            appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
+        case .toolCallUpdate(let toolCallId, let status, let toolName, let output):
+            if isReplaying {
+                replayFlushIncompatibleSection("tool")
+            } else {
+                flushLiveIncompatibleSection()
+            }
+            updateTool(toolCallId) { tool in
+                if let toolName, tool.title.isEmpty { tool.title = toolName }
+                switch status {
+                case "pending": advanceToolStatus(&tool, to: .pending)
+                case "in_progress": advanceToolStatus(&tool, to: .running); if let output { tool.output = output }
+                case "completed": advanceToolStatus(&tool, to: .completed); if let output { tool.output = output }
+                case "failed": advanceToolStatus(&tool, to: .failed); if let output { tool.output = output }
+                case "cancelled": advanceToolStatus(&tool, to: .cancelled)
+                default: break
+                }
+            }
+        case .toolInputSnapshot(let toolCallId, _, let text):
+            if isReplaying { updateTool(toolCallId) { $0.arguments = text }; return }
+            toolArgBuffers[toolCallId] = text
+            scheduleStreamingFlush()
+        case .toolInputDelta(let toolCallId, _, let delta):
+            if isReplaying { updateTool(toolCallId) { $0.arguments += delta }; return }
+            toolArgBuffers[toolCallId, default: ""] += delta
+            scheduleStreamingFlush()
+        case .toolCallReady(let toolCallId, _):
+            if isReplaying { updateTool(toolCallId) { advanceToolStatus(&$0, to: .ready) }; return }
+            flushLiveIncompatibleSection()
+            updateTool(toolCallId) { advanceToolStatus(&$0, to: .ready) }
+        case .toolOutputSnapshot(let toolCallId, _, let text):
+            if isReplaying { updateTool(toolCallId) { $0.output = text }; return }
+            toolOutputBuffers[toolCallId] = text
+            scheduleStreamingFlush()
+        case .toolOutputDelta(let toolCallId, _, let delta):
+            if isReplaying { updateTool(toolCallId) { $0.output += delta }; return }
+            toolOutputBuffers[toolCallId, default: ""] += delta
+            scheduleStreamingFlush()
+        case .permissionRequest(let requestId, let toolCall, let options):
+            if isReplaying { return }
+            pendingPermission = PendingPermissionRequest(requestId: requestId, toolCall: toolCall, options: options)
+            statusLine = "Permission needed: \(toolCall.title)"
+        case .planUpdate(let entries):
+            upsertPlanBlock(entries)
+        case .usageUpdate(let used, let size, let cost):
+            contextUsage = ContextUsageState(used: used, size: size, cost: cost)
+        case .modesState(let currentModeId, let availableModes):
+            currentModes = AcpModesState(currentModeId: currentModeId, availableModes: availableModes)
+        case .currentModeUpdate(let modeId):
+            if let currentModes { self.currentModes = AcpModesState(currentModeId: modeId, availableModes: currentModes.availableModes) }
+        case .configOptionUpdate(let configOptions):
+            self.configOptions = configOptions
+        case .runCompleted(let stopReason):
+            if isReplaying { flushReplayBuffers(); return }
+            finalizeStreamingBlocks()
+            if stopReason == "cancelled" { finalizeActiveTools(as: .cancelled) }
+            isRunning = false
+            statusLine = ""
+            lastStopReason = stopReason
+            pendingPermission = nil
+            userCancelledRun = false
+            deliverNextQueuedIfIdle()
+        case .runFailed(let message):
+            if isReplaying { flushReplayBuffers(); return }
+            finalizeStreamingBlocks()
+            isRunning = false
+            statusLine = ""
+            pendingPermission = nil
+            if userCancelledRun || message.lowercased().contains("cancel") {
+                finalizeActiveTools(as: .cancelled)
+                userCancelledRun = false
+                lastStopReason = "cancelled"
+                appendBlock(.system(text: "Stopped."))
+            } else {
+                lastStopReason = "failed"
+                appendErrorBlock(source: "run", message: message)
+            }
+            deliverNextQueuedIfIdle()
+        case .protocolError(let message):
+            appendErrorBlock(source: "protocol", message: message)
+        case .connectionError(let message):
+            appendErrorBlock(source: "connection", message: message)
+        case .environmentOffered(let offer):
+            onEnvironmentOffered?(offer)
+        case .environmentOfferResolved(let environmentId, let bundleHash):
+            onEnvironmentOfferResolved?(environmentId, bundleHash)
+        case .environmentEntered(let environmentId):
+            if enteredEnvironments.insert(environmentId).inserted {
+                onEnvironmentEntered?(environmentId)
+                appendBlock(.system(text: "Entered environment \(environmentId)."))
+            }
+        case .environmentExited(let environmentId, let error):
+            if enteredEnvironments.remove(environmentId) != nil {
+                onEnvironmentExited?(environmentId, error)
+                let suffix = error.map { " (\($0))" } ?? ""
+                appendBlock(.system(text: "Exited environment \(environmentId)\(suffix)."))
+            }
+        }
+        scrollTick += 1
+    }
+
+    // MARK: - Private: blocks / streaming
+
+    private func makeQueuedMessage(_ text: String) -> QueuedChatMessage {
+        queuedMessageCounter += 1
+        return QueuedChatMessage(id: "queued-\(queuedMessageCounter)", text: text, draftText: text)
+    }
+
+    private func updateQueuedMessage(_ id: String, mutate: (inout QueuedChatMessage) -> Void) {
+        guard let index = queuedMessages.firstIndex(where: { $0.id == id }) else { return }
+        mutate(&queuedMessages[index])
+    }
+
+    private func appendBlock(_ kind: ChatBlockKind, id: String? = nil) {
+        blockCounter += 1
+        blocks.append(ChatBlock(id: id ?? "block-\(blockCounter)", kind: kind))
+    }
+
+    private func appendErrorBlock(source: String, message: String) {
+        if case .error(let lastSource, let lastMessage)? = blocks.last?.kind,
+           lastSource == source, lastMessage == message { return }
+        appendBlock(.error(source: source, message: message))
+    }
+
+    private func scheduleStreamingFlush() {
+        streamingFlushTask?.cancel()
+        streamingFlushTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 16_000_000)
+            guard !Task.isCancelled else { return }
+            applyStreamingFlush()
+        }
+    }
+
+    private func flushLiveIncompatibleSection() {
+        streamingFlushTask?.cancel()
+        streamingFlushTask = nil
+        applyStreamingFlush()
+    }
+
+    private func applyStreamingFlush() {
+        if !streamingTextAccumulator.isEmpty {
+            if let last = blocks.indices.last {
+                switch blocks[last].kind {
+                case .assistantText(let existing, true) where !streamingIsThinking:
+                    blocks[last].kind = .assistantText(text: existing + streamingTextAccumulator, streaming: true)
+                    streamingTextAccumulator = ""
+                case .thinking(let existing, true) where streamingIsThinking:
+                    blocks[last].kind = .thinking(text: existing + streamingTextAccumulator, streaming: true)
+                    streamingTextAccumulator = ""
+                default: break
+                }
+            }
+            if !streamingTextAccumulator.isEmpty {
+                if streamingIsThinking { appendBlock(.thinking(text: streamingTextAccumulator, streaming: true)) }
+                else { appendBlock(.assistantText(text: streamingTextAccumulator, streaming: true)) }
+                streamingTextAccumulator = ""
+            }
+        }
+        if !toolArgBuffers.isEmpty {
+            let snap = toolArgBuffers; toolArgBuffers = [:]
+            for (toolCallId, text) in snap {
+                updateTool(toolCallId) { tool in advanceToolStatus(&tool, to: .inputStreaming); tool.arguments = text }
+            }
+        }
+        if !toolOutputBuffers.isEmpty {
+            let snap = toolOutputBuffers; toolOutputBuffers = [:]
+            for (toolCallId, text) in snap {
+                updateTool(toolCallId) { tool in advanceToolStatus(&tool, to: .running); tool.output = text }
+            }
+        }
+    }
+
+    private func appendStreamingText(_ text: String, isThinking: Bool) {
+        if streamingIsThinking != isThinking && !streamingTextAccumulator.isEmpty { applyStreamingFlush() }
+        streamingTextAccumulator += text
+        streamingIsThinking = isThinking
+        scheduleStreamingFlush()
+    }
+
+    private func finalizeStreamingBlocks() {
+        flushLiveIncompatibleSection()
+        streamingTextAccumulator = ""
+        toolArgBuffers = [:]
+        toolOutputBuffers = [:]
+        for index in blocks.indices {
+            switch blocks[index].kind {
+            case .assistantText(let text, true): blocks[index].kind = .assistantText(text: text, streaming: false)
+            case .thinking(let text, true): blocks[index].kind = .thinking(text: text, streaming: false)
+            default: break
+            }
+        }
+    }
+
+    private func toolStatusRank(_ status: ToolBlockStatus) -> Int {
+        switch status {
+        case .pending: return 0
+        case .inputStreaming: return 1
+        case .ready: return 2
+        case .running: return 3
+        case .completed, .failed, .cancelled: return 4
+        }
+    }
+
+    private func advanceToolStatus(_ tool: inout ToolBlockState, to next: ToolBlockStatus) {
+        guard !tool.status.isTerminal else { return }
+        if next.isTerminal || toolStatusRank(next) >= toolStatusRank(tool.status) { tool.status = next }
+    }
+
+    private func updateTool(_ toolCallId: String, _ mutate: (inout ToolBlockState) -> Void) {
+        for index in blocks.indices.reversed() {
+            if case .tool(var state) = blocks[index].kind, state.toolCallId == toolCallId {
+                mutate(&state); blocks[index].kind = .tool(state); return
+            }
+        }
+        var state = ToolBlockState(toolCallId: toolCallId, title: "Tool", kindLabel: "", status: .running, arguments: "", output: "")
+        mutate(&state)
+        appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
+    }
+
+    private func upsertPlanBlock(_ entries: [PlanEntry]) {
+        for index in blocks.indices.reversed() {
+            if case .plan = blocks[index].kind { blocks[index].kind = .plan(entries: entries); return }
+        }
+        appendBlock(.plan(entries: entries))
+    }
+
+    // MARK: - Private: replay
+
+    private func flushReplayBuffers() {
+        if !replayUserBuffer.isEmpty { appendBlock(.user(text: replayUserBuffer)); replayUserBuffer = "" }
+        if !replayThinkingBuffer.isEmpty { appendBlock(.thinking(text: replayThinkingBuffer, streaming: false)); replayThinkingBuffer = "" }
+        if !replayAssistantBuffer.isEmpty { appendBlock(.assistantText(text: replayAssistantBuffer, streaming: false)); replayAssistantBuffer = "" }
+    }
+
+    private func replayFlushIncompatibleSection(_ next: String) {
+        switch next {
+        case "user":
+            if !replayAssistantBuffer.isEmpty { flushReplaySection("assistant") }
+            if !replayThinkingBuffer.isEmpty { flushReplaySection("thinking") }
+        case "thinking":
+            if !replayUserBuffer.isEmpty { flushReplaySection("user") }
+            if !replayAssistantBuffer.isEmpty { flushReplaySection("assistant") }
+        case "assistant":
+            if !replayUserBuffer.isEmpty { flushReplaySection("user") }
+            if !replayThinkingBuffer.isEmpty { flushReplaySection("thinking") }
+        default:
+            if !replayUserBuffer.isEmpty { flushReplaySection("user") }
+            if !replayThinkingBuffer.isEmpty { flushReplaySection("thinking") }
+            if !replayAssistantBuffer.isEmpty { flushReplaySection("assistant") }
+        }
+    }
+
+    private func flushReplaySection(_ section: String) {
+        switch section {
+        case "user": if !replayUserBuffer.isEmpty { appendBlock(.user(text: replayUserBuffer)); replayUserBuffer = "" }
+        case "thinking": if !replayThinkingBuffer.isEmpty { appendBlock(.thinking(text: replayThinkingBuffer, streaming: false)); replayThinkingBuffer = "" }
+        case "assistant": if !replayAssistantBuffer.isEmpty { appendBlock(.assistantText(text: replayAssistantBuffer, streaming: false)); replayAssistantBuffer = "" }
+        default: break
+        }
+    }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,13 +13,14 @@ The primary development entry point. Starts the server (if needed) and builds + 
 ```bash
 ./scripts/run-rook.sh server                    # start the main server
 ./scripts/run-rook.sh mac                       # build and launch the current macOS client
-./scripts/run-rook.sh iphone                    # build and deploy the current iPhone client
+./scripts/run-rook.sh iphone                    # build and deploy the current physical-iPhone client
+./scripts/run-rook.sh sim                       # build and launch the iPhone simulator client
 ./scripts/run-rook.sh android                   # placeholder target for now
 ./scripts/run-rook.sh server mac iphone         # run multiple current targets
 ./scripts/run-rook.sh stop                      # stop everything (server + launched apps)
 ```
 
-Flags: `--device NAME_OR_UDID`, `--team TEAM_ID`, `--server-url URL`, `--reset-permissions`, `--simulate-arrival "LAT,LON"`
+Flags: `--device NAME_OR_UDID`, `--server-url URL`, `--reset-permissions`, `--simulate-arrival "LAT,LON"`
 
 ### `run-tests.sh` — run all test suites
 

--- a/scripts/lib/run-rook/common.sh
+++ b/scripts/lib/run-rook/common.sh
@@ -164,15 +164,6 @@ PY
 )"
     if [[ -n "$udid" ]]; then
       xcrun devicectl device process terminate --device "$udid" "$DEFAULT_IOS_APP_BUNDLE_ID" >/dev/null 2>&1 || true
-      local stop_team stop_bundle_id _stop_widget_id _stop_test_id
-      stop_team="${TEAM_ID:-}"
-      if [[ -z "$stop_team" ]]; then
-        stop_team="$(auto_detect_team 2>/dev/null || true)"
-      fi
-      if [[ -n "$stop_team" ]]; then
-        IFS=$'\t' read -r stop_bundle_id _stop_widget_id _stop_test_id <<<"$(phone_bundle_ids "$stop_team")"
-        xcrun devicectl device process terminate --device "$udid" "$stop_bundle_id" >/dev/null 2>&1 || true
-      fi
     fi
   fi
   rm -f "$tmp"
@@ -210,41 +201,6 @@ ensure_xcode_project() {
     cd "$app_dir"
     xcodegen generate >/dev/null
   )
-}
-
-patch_iphone_project_bundle_ids() {
-  local project_path="$1"
-  local app_id="$2"
-  local widget_id="$3"
-  local test_id="$4"
-  python3 - <<'PY' "$project_path/project.pbxproj" "$app_id" "$widget_id" "$test_id"
-from pathlib import Path
-import sys
-pbxproj = Path(sys.argv[1])
-app_id, widget_id, test_id = sys.argv[2:5]
-text = pbxproj.read_text()
-text = text.replace("PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook.RookWidgets;", f"PRODUCT_BUNDLE_IDENTIFIER = {widget_id};")
-text = text.replace("PRODUCT_BUNDLE_IDENTIFIER = com.rookery.RookTests;", f"PRODUCT_BUNDLE_IDENTIFIER = {test_id};")
-text = text.replace("PRODUCT_BUNDLE_IDENTIFIER = com.rookery.Rook;", f"PRODUCT_BUNDLE_IDENTIFIER = {app_id};")
-pbxproj.write_text(text)
-PY
-}
-
-sanitize_bundle_segment() {
-  local raw="$1"
-  raw="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
-  [[ -n "$raw" ]] || raw="dev"
-  printf '%s' "$raw"
-}
-
-phone_bundle_ids() {
-  local team="$1"
-  local team_segment
-  team_segment="$(sanitize_bundle_segment "$team")"
-  local app_id="com.rookery.${team_segment}.Rook"
-  local widget_id="${app_id}.RookWidgets"
-  local test_id="com.rookery.${team_segment}.RookTests"
-  printf '%s\t%s\t%s\n' "$app_id" "$widget_id" "$test_id"
 }
 
 current_remote_target() {
@@ -310,49 +266,45 @@ PY
   return "$status"
 }
 
-auto_detect_team() {
-  local ids=""
-  local prov_paths=()
-  while IFS= read -r path; do
-    prov_paths+=("$path")
-  done < <(find "$HOME/Library/Developer/Xcode/DerivedData" "$HOME/Library/MobileDevice/Provisioning Profiles" \
-    \( -path '*/Rook.app/embedded.mobileprovision' -o -name '*.mobileprovision' \) 2>/dev/null)
-
-  if [[ ${#prov_paths[@]} -gt 0 ]]; then
-    ids="$(python3 - <<'PY' "${prov_paths[@]}"
-import plistlib, subprocess, sys
-ids=set()
-for path in sys.argv[1:]:
-    try:
-        xml=subprocess.check_output(["security", "cms", "-D", "-i", path], stderr=subprocess.DEVNULL)
-        plist=plistlib.loads(xml)
-        for team in plist.get("TeamIdentifier", []):
-            if team:
-                ids.add(team.upper())
-    except Exception:
-        pass
-print("\n".join(sorted(ids)))
-PY
-)"
-  fi
-
-  if [[ -z "${ids//[$'\n\r\t ']/}" ]]; then
-    ids="$(security find-certificate -a -c "Apple Development" 2>/dev/null | python3 -c '
+resolve_ios_simulator() {
+  local tmp
+  tmp="$(mktemp)"
+  xcrun simctl list devices available >"$tmp"
+  python3 - <<'PY' "$tmp" "$DEVICE_FILTER"
 import re,sys
-text=sys.stdin.read()
-ids=sorted({match.upper() for match in re.findall(r"Apple Development: .* \(([^)]+)\)", text)})
-print("\\n".join(ids))
-')"
-  fi
-
-  ids="$(printf '%s\n' "$ids" | sed '/^$/d' || true)"
-  local count
-  count="$(printf '%s\n' "$ids" | sed '/^$/d' | wc -l | tr -d ' ')"
-  if [[ "$count" == "1" ]]; then
-    printf '%s' "$ids"
-    return 0
-  fi
-  return 1
+path,want=sys.argv[1],sys.argv[2].strip().lower()
+rows=[]
+with open(path) as f:
+    for raw in f:
+        line=raw.strip()
+        m=re.match(r'^(.*?) \(([0-9A-F-]+)\) \((Shutdown|Booted)\)$', line)
+        if not m:
+            continue
+        name,udid,state=m.groups()
+        if not name.startswith('iPhone'):
+            continue
+        rows.append((name,udid,state))
+if want:
+    matches=[r for r in rows if want in f"{r[0]} {r[1]}".lower()]
+    if len(matches)==1:
+        print(f"{matches[0][0]}\t{matches[0][1]}\t{matches[0][2]}")
+        raise SystemExit(0)
+    if len(matches)>1:
+        print('MULTIPLE', file=sys.stderr)
+        for name,udid,state in matches:
+            print(f"- {name} ({udid}) [{state}]", file=sys.stderr)
+        raise SystemExit(2)
+    raise SystemExit(1)
+if rows:
+    booted=[r for r in rows if r[2]=='Booted']
+    chosen=(booted or rows)[0]
+    print(f"{chosen[0]}\t{chosen[1]}\t{chosen[2]}")
+    raise SystemExit(0)
+raise SystemExit(1)
+PY
+  local status=$?
+  rm -f "$tmp"
+  return "$status"
 }
 
 ensure_app_dir() {
@@ -408,6 +360,23 @@ open_mac_app_bundle() {
   activate_mac_app "$app_path"
 }
 
+ios_launch_env_json() {
+  local launch_env
+  if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
+    launch_env="{\"ROOK_AUTH_TOKEN\":$(json_escape "$SERVER_AUTH_TOKEN")"
+  else
+    launch_env="{"
+  fi
+  if [[ -n "$SIMULATE_ARRIVAL" ]]; then
+    log "simulating arrival at $SIMULATE_ARRIVAL (DEBUG ROOK_SIMULATE_ARRIVAL)"
+    if [[ "$launch_env" != "{" ]]; then
+      launch_env+=","
+    fi
+    launch_env+="\"ROOK_SIMULATE_ARRIVAL\":$(json_escape "$SIMULATE_ARRIVAL")"
+  fi
+  printf '%s' "$launch_env"
+}
+
 build_iphone_app() {
   need_cmd xcodebuild
   need_cmd xcrun
@@ -422,14 +391,6 @@ build_iphone_app() {
   local phone_name phone_udid
   IFS=$'\t' read -r phone_name phone_udid <<<"$phone"
   log "using device: $phone_name ($phone_udid)"
-
-  if [[ -z "$TEAM_ID" ]]; then
-    if TEAM_ID="$(auto_detect_team)"; then
-      warn "using local Apple Development team $TEAM_ID from Keychain; teammates should pass --team or ROOK_IOS_DEVELOPMENT_TEAM"
-    else
-      die "could not auto-detect a single Apple Development team; pass --team TEAM_ID or export ROOK_IOS_DEVELOPMENT_TEAM"
-    fi
-  fi
 
   local url
   if [[ -n "$SERVER_URL" ]]; then
@@ -454,11 +415,8 @@ EOF
 
   local proj="$app_dir/Rook.xcodeproj"
   local derived="$BUILD_ROOT/$derived_name"
-  local phone_app_bundle_id phone_widget_bundle_id phone_test_bundle_id
-  IFS=$'\t' read -r phone_app_bundle_id phone_widget_bundle_id phone_test_bundle_id <<<"$(phone_bundle_ids "$TEAM_ID")"
-  log "using iPhone bundle ids: $phone_app_bundle_id (+ widget/test variants)"
+  log "using iPhone bundle ids: $DEFAULT_IOS_APP_BUNDLE_ID (+ widget/test variants)"
   ensure_xcode_project "$app_dir" "$proj"
-  patch_iphone_project_bundle_ids "$proj" "$phone_app_bundle_id" "$phone_widget_bundle_id" "$phone_test_bundle_id"
   log "building Rook for $phone_name"
   local build_log="$RUN_ROOT/${derived_name}-build.log"
   if ! xcodebuild \
@@ -470,7 +428,6 @@ EOF
     -allowProvisioningUpdates \
     -allowProvisioningDeviceRegistration \
     CODE_SIGN_STYLE=Automatic \
-    DEVELOPMENT_TEAM="$TEAM_ID" \
     build >"$build_log" 2>&1; then
     tail -n 80 "$build_log" >&2 || true
     die "iPhone build failed (full log: $build_log)"
@@ -481,28 +438,23 @@ EOF
 
   if (( RESET_PERMISSIONS )); then
     log "uninstalling Rook on $phone_name to reset its privacy permissions"
-    xcrun devicectl device uninstall app --device "$phone_udid" "$phone_app_bundle_id" >/dev/null 2>&1 || true
+    xcrun devicectl device uninstall app --device "$phone_udid" "$DEFAULT_IOS_APP_BUNDLE_ID" >/dev/null 2>&1 || true
   fi
   log "installing Rook on $phone_name"
   xcrun devicectl device install app --device "$phone_udid" "$app_path" >/dev/null
   log "launching Rook on $phone_name with ROOK_SERVER_BASE_URL=$url"
-  local launch_env
-  if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
-    launch_env="{\"ROOK_SERVER_BASE_URL\":$(json_escape "$url"),\"ROOK_AUTH_TOKEN\":$(json_escape "$SERVER_AUTH_TOKEN")"
-  else
-    launch_env="{\"ROOK_SERVER_BASE_URL\":$(json_escape "$url")"
+  local phone_launch_env
+  phone_launch_env="$(ios_launch_env_json)"
+  if [[ "$phone_launch_env" != "{" ]]; then
+    phone_launch_env+=","
   fi
-  if [[ -n "$SIMULATE_ARRIVAL" ]]; then
-    log "simulating arrival at $SIMULATE_ARRIVAL (DEBUG ROOK_SIMULATE_ARRIVAL)"
-    launch_env+=",\"ROOK_SIMULATE_ARRIVAL\":$(json_escape "$SIMULATE_ARRIVAL")"
-  fi
-  launch_env+="}"
+  phone_launch_env+="\"ROOK_SERVER_BASE_URL\":$(json_escape "$url")}"
   local launch_log="$RUN_ROOT/${derived_name}-launch.log"
   if ! xcrun devicectl device process launch \
     --device "$phone_udid" \
     --terminate-existing \
-    -e "$launch_env" \
-    "$phone_app_bundle_id" >"$launch_log" 2>&1; then
+    -e "$phone_launch_env" \
+    "$DEFAULT_IOS_APP_BUNDLE_ID" >"$launch_log" 2>&1; then
     if grep -qiE 'explicitly trusted by the user|invalid code signature|inadequate entitlements' "$launch_log"; then
       cat "$launch_log" >&2 || true
       die "iPhone launch failed because the developer app certificate is not yet trusted on $phone_name; trust it in Settings -> General -> VPN & Device Management, then run ./scripts/run-rook.sh iphone again"
@@ -520,6 +472,65 @@ EOF
 [run-rook] server URL: $url
 [run-rook] if iOS says the developer certificate is untrusted:
 [run-rook]   Settings -> General -> VPN & Device Management -> trust your developer app certificate
+EOF
+}
+
+build_ios_simulator_app() {
+  need_cmd xcodebuild
+  need_cmd xcrun
+  local app_dir="$1"
+  local derived_name="$2"
+  ensure_app_dir "$app_dir"
+
+  local sim
+  if ! sim="$(resolve_ios_simulator)"; then
+    die "no usable iPhone simulator found; open Xcode and install an iPhone simulator runtime"
+  fi
+  local sim_name sim_udid sim_state
+  IFS=$'\t' read -r sim_name sim_udid sim_state <<<"$sim"
+  log "using simulator: $sim_name ($sim_udid)"
+  if [[ "$sim_state" != "Booted" ]]; then
+    log "booting simulator $sim_name"
+    xcrun simctl boot "$sim_udid" >/dev/null 2>&1 || true
+  fi
+  open -a Simulator >/dev/null 2>&1 || true
+  xcrun simctl bootstatus "$sim_udid" -b >/dev/null
+
+  local proj="$app_dir/Rook.xcodeproj"
+  local derived="$BUILD_ROOT/$derived_name"
+  ensure_xcode_project "$app_dir" "$proj"
+  log "building Rook for simulator $sim_name"
+  local sim_build_log="$RUN_ROOT/${derived_name}-simulator-build.log"
+  if ! xcodebuild \
+    -project "$proj" \
+    -scheme Rook \
+    -configuration Debug \
+    -sdk iphonesimulator \
+    -destination "id=$sim_udid" \
+    -derivedDataPath "$derived" \
+    build >"$sim_build_log" 2>&1; then
+    tail -n 80 "$sim_build_log" >&2 || true
+    die "iPhone simulator build failed (full log: $sim_build_log)"
+  fi
+
+  local sim_app_path="$derived/Build/Products/Debug-iphonesimulator/Rook.app"
+  [[ -d "$sim_app_path" ]] || die "missing built app: $sim_app_path"
+  if (( RESET_PERMISSIONS )); then
+    log "uninstalling Rook on simulator $sim_name to reset its privacy permissions"
+    xcrun simctl uninstall "$sim_udid" "$DEFAULT_IOS_APP_BUNDLE_ID" >/dev/null 2>&1 || true
+  fi
+  log "installing Rook on simulator $sim_name"
+  xcrun simctl install "$sim_udid" "$sim_app_path" >/dev/null
+  local sim_url="${SERVER_URL:-http://127.0.0.1:${SERVER_PORT}}"
+  log "launching Rook on simulator $sim_name with ROOK_SERVER_BASE_URL=$sim_url"
+  SIMCTL_CHILD_ROOK_SERVER_BASE_URL="$sim_url" \
+  SIMCTL_CHILD_ROOK_AUTH_TOKEN="${SERVER_AUTH_TOKEN:-}" \
+  SIMCTL_CHILD_ROOK_SIMULATE_ARRIVAL="${SIMULATE_ARRIVAL:-}" \
+  xcrun simctl launch --terminate-running-process "$sim_udid" "$DEFAULT_IOS_APP_BUNDLE_ID" >/dev/null
+
+  cat <<EOF
+[run-rook] launched on simulator $sim_name
+[run-rook] server URL: $sim_url
 EOF
 }
 

--- a/scripts/lib/run-rook/iphone.sh
+++ b/scripts/lib/run-rook/iphone.sh
@@ -3,3 +3,7 @@
 run_rook_target_iphone() {
   build_iphone_app "$REPO_ROOT/clients/iphone" "Rook-iphone"
 }
+
+run_rook_target_sim() {
+  build_ios_simulator_app "$REPO_ROOT/clients/iphone" "Rook-iphone"
+}

--- a/scripts/run-rook.sh
+++ b/scripts/run-rook.sh
@@ -17,9 +17,9 @@ CURRENT_SERVER_PIDFILE="$RUN_ROOT/server.pid"
 SERVER_PORT="${ROOK_SERVER_PORT:-7665}"
 SERVER_BIND_HOST="127.0.0.1"
 SERVER_AUTH_TOKEN="${ROOK_AUTH_TOKEN:-}"
-DEFAULT_IOS_APP_BUNDLE_ID="com.rookery.Rook"
+DEFAULT_IOS_APP_BUNDLE_ID="com.rookkeeper.Rook"
 DEFAULT_IOS_WIDGET_BUNDLE_ID="${DEFAULT_IOS_APP_BUNDLE_ID}.RookWidgets"
-DEFAULT_IOS_TEST_BUNDLE_ID="com.rookery.RookTests"
+DEFAULT_IOS_TEST_BUNDLE_ID="com.rookkeeper.RookTests"
 
 mkdir -p "$RUN_ROOT" "$BUILD_ROOT"
 
@@ -37,7 +37,8 @@ usage() {
 Usage:
   ./scripts/run-rook.sh server
   ./scripts/run-rook.sh mac
-  ./scripts/run-rook.sh iphone [--device NAME_OR_UDID] [--team TEAM_ID] [--server-url URL] [--reset-permissions] [--simulate-arrival "LAT,LON"]
+  ./scripts/run-rook.sh iphone [--device NAME_OR_UDID] [--server-url URL] [--reset-permissions] [--simulate-arrival "LAT,LON"]
+  ./scripts/run-rook.sh sim [--device NAME_OR_UDID] [--server-url URL] [--reset-permissions] [--simulate-arrival "LAT,LON"]
   ./scripts/run-rook.sh android
   ./scripts/run-rook.sh server mac iphone
   ./scripts/run-rook.sh stop
@@ -52,24 +53,24 @@ Notes:
   - mac uses localhost by default
   - iphone uses ROOK_REMOTE_HOSTNAME, ROOK_BIND_IP, or a non-localhost
     ROOK_SERVER_HOST by default; pass --server-url to override
+  - sim uses localhost by default; pass --server-url to override
   - android is currently a placeholder target
   - the server always binds localhost; ROOK_BIND_IP adds a second remote listener
   - the server runs as a detached background process and logs to .var/run-rook/server.log
-  - pass --team / ROOK_IOS_DEVELOPMENT_TEAM for iPhone code signing when needed
+  - iphone signing now follows the Xcode project’s configured DEVELOPMENT_TEAM and bundle identifiers
   - stop shuts down the server, mac app(s), iphone app(s), and android app if present
 EOF
 }
 
 TARGETS=()
 DEVICE_FILTER=""
-TEAM_ID="${ROOK_IOS_DEVELOPMENT_TEAM:-}"
 RESET_PERMISSIONS=0
 SERVER_URL=""
 SIMULATE_ARRIVAL=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    server|mac|iphone|android|stop)
+    server|mac|iphone|sim|android|stop)
       TARGETS+=("$1")
       shift
       ;;
@@ -79,10 +80,6 @@ while [[ $# -gt 0 ]]; do
       ;;
     --device)
       DEVICE_FILTER="${2:-}"
-      shift 2
-      ;;
-    --team)
-      TEAM_ID="${2:-}"
       shift 2
       ;;
     --server-url)
@@ -109,11 +106,13 @@ HAS_SERVER_TARGET=0
 HAS_SERVER_NEXT_TARGET=0
 HAS_IPHONE_TARGET=0
 HAS_MAC_TARGET=0
+HAS_SIM_TARGET=0
 HAS_ANDROID_TARGET=0
 for target in "${TARGETS[@]}"; do
   case "$target" in
     server) HAS_SERVER_TARGET=1 ;;
     iphone) HAS_IPHONE_TARGET=1 ;;
+    sim) HAS_SIM_TARGET=1 ;;
     mac) HAS_MAC_TARGET=1 ;;
     android) HAS_ANDROID_TARGET=1 ;;
     stop) ;;
@@ -156,6 +155,9 @@ for TARGET in "${TARGETS[@]}"; do
       ;;
     iphone)
       run_rook_target_iphone
+      ;;
+    sim)
+      run_rook_target_sim
       ;;
     android)
       run_rook_target_android

--- a/server/README.md
+++ b/server/README.md
@@ -73,22 +73,26 @@ For current SQLite tables and persistence ownership, see [../AS-BUILT-ARCHITECTU
 
 - `GET /api/health` — service health
 - `GET /api/agent_runtimes` — configured runtime catalog (only explicitly declared entries)
+- `GET /api/sessions` — session list + running state
+- `GET /api/sessions/:sessionId/transcript` — normalized server-owned transcript hydration
 - `POST /api/session/environments` — enter/leave environments for a session
 - `POST /api/environments/register` — mark an environment available
 - `POST /api/environments/decision` — record accept/approve/ignore/reject
 - `GET /api/environments/preview` — bundle/file preview data
 - `GET /api/environments/list` — per-session environment list for client UI (`displayName`, `environmentId`, status, bundle counts)
 - `GET /api/diagnostics/environments` — active/recent environment diagnostics
-- `GET /api/ws` — connection-level ACP WebSocket facade (no session query parameter)
+- `GET /api/ws` — session-bound ACP WebSocket facade (`?sessionId=<public-session-id>` preferred)
 
 ### ACP WebSocket
 
-The facade at `/api/ws` is the primary client interface. It implements:
+The facade at `/api/ws` is the primary live-session interface. The intended shape is one websocket per session. A client typically discovers sessions via REST, then opens `/api/ws?sessionId=<id>` and runs `initialize`.
+
+It implements:
 
 - `initialize` — returns runtime catalog, default runtime, env-offer extension capability
-- `session/list` — unified cross-runtime session list with `_meta.runtimeId` and `_meta.startedAt`
-- `session/new` — creates session for a chosen runtime via `_meta.runtimeId` and `_meta.title`
-- `session/load`, `session/resume` — loads an existing session
+- `session/list` — legacy/unbound-only session list (REST is preferred)
+- `session/new` — creates session for a chosen runtime via `_meta.runtimeId` and `_meta.title` (unbound websocket only)
+- `session/load`, `session/resume` — loads an existing session; replay is requester-private, not broadcast to all watchers
 - `session/prompt`, `session/cancel` — standard prompt flow
 - `session/set_mode`, `session/set_config_option` — ACP controls
 - `session/close` — closes a session
@@ -101,6 +105,7 @@ The facade at `/api/ws` is the primary client interface. It implements:
 - Each session maps to `runtimeId` + runtime-local `runtimeSessionId` in SQLite
 - Sessions are a unified cross-runtime list ordered by `updatedAt` desc
 - Session-to-environment membership persists in `session_environments`
+- Transcript history persists in `session_transcript_events` so later viewers can hydrate from server state instead of forcing runtime replay
 
 ### Runtime management
 

--- a/server/src/server/acpFacade.test.ts
+++ b/server/src/server/acpFacade.test.ts
@@ -139,4 +139,39 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
   it.skip("resumes a session across connections", async () => {
     // TODO: reconnect test needs runtime serialization investigation.
   });
+
+  it("lists sessions via REST /api/sessions", async () => {
+    const ws = await connect();
+    await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+
+    // Create two sessions
+    const a = await request(ws, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "rest-test-a" },
+    });
+    const b = await request(ws, 3, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "rest-test-b" },
+    });
+
+    // Fetch via REST
+    const response = await fetch(`http://127.0.0.1:${PORT}/api/sessions`);
+    expect(response.status).toBe(200);
+    const body = await response.json() as { sessions: Array<Record<string, unknown>> };
+    expect(body.sessions.length).toBeGreaterThanOrEqual(2);
+
+    const titles = body.sessions.map((s) => s.title);
+    expect(titles).toContain("rest-test-a");
+    expect(titles).toContain("rest-test-b");
+
+    // running should be true for sessions with active runtimes
+    const sessionA = body.sessions.find((s) => s.title === "rest-test-a")!;
+    expect(sessionA.running).toBe(true);
+    expect(sessionA._meta).toBeDefined();
+    expect((sessionA._meta as Record<string, unknown>).runtimeId).toBe("MockAcpAgent");
+
+    ws.close();
+  });
 });

--- a/server/src/server/acpFacade.test.ts
+++ b/server/src/server/acpFacade.test.ts
@@ -4,9 +4,9 @@ import { buildServer } from "./index.js";
 
 const PORT = 18999;
 
-function connect(): Promise<WebSocket> {
+function connect(path = "/api/ws"): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
-    const socket = new WebSocket(`ws://127.0.0.1:${PORT}/api/ws`);
+    const socket = new WebSocket(`ws://127.0.0.1:${PORT}${path}`);
     socket.on("open", () => resolve(socket));
     socket.on("error", reject);
   });
@@ -23,6 +23,20 @@ function notify(ws: WebSocket, method: string, params: Record<string, unknown> =
 function recv(ws: WebSocket): Promise<Record<string, unknown>> {
   return new Promise((resolve) => {
     ws.once("message", (data) => resolve(JSON.parse(String(data))));
+  });
+}
+
+function recvWithTimeout(ws: WebSocket, timeoutMs: number): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      ws.off("message", onMessage);
+      resolve(null);
+    }, timeoutMs);
+    const onMessage = (data: unknown) => {
+      clearTimeout(timeout);
+      resolve(JSON.parse(String(data)));
+    };
+    ws.once("message", onMessage);
   });
 }
 
@@ -79,9 +93,9 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
     });
     expect(promptResult.stopReason).toBe("end_turn");
 
-    const list = await request(ws, 5, "session/list", {});
-    const sessions = list.sessions as Array<Record<string, unknown>>;
-    expect(sessions.some((session) => session.sessionId === sessionId)).toBe(true);
+    const listResponse = await fetch(`http://127.0.0.1:${PORT}/api/sessions`);
+    const list = await listResponse.json() as { sessions: Array<Record<string, unknown>> };
+    expect(list.sessions.some((session) => session.sessionId === sessionId)).toBe(true);
 
     await request(ws, 6, "session/close", { sessionId });
     ws.close();
@@ -134,6 +148,119 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
     await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
     await expect(request(ws, 2, "session/load", { sessionId: "00000000-0000-0000-0000-000000000000" })).rejects.toThrow("Unknown session");
     ws.close();
+  });
+
+  it("binds a websocket to one session and rejects cross-session use", async () => {
+    const control = await connect();
+    await request(control, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    const a = await request(control, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "bound-a" },
+    });
+    const b = await request(control, 3, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "bound-b" },
+    });
+    control.close();
+
+    const ws = await connect(`/api/ws?sessionId=${a.sessionId}`);
+    await request(ws, 4, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    await request(ws, 5, "session/load", { sessionId: a.sessionId });
+    await expect(request(ws, 6, "session/prompt", {
+      sessionId: b.sessionId,
+      prompt: [{ type: "text", text: "hi" }],
+    })).rejects.toThrow(`WebSocket is bound to session ${a.sessionId}`);
+    ws.close();
+  });
+
+  it("keeps session/load replay private to the requesting watcher", async () => {
+    const creator = await connect();
+    await request(creator, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "creator" } });
+    const created = await request(creator, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "private-replay" },
+    });
+    const sessionId = created.sessionId as string;
+    await request(creator, 3, "session/load", { sessionId });
+    await request(creator, 4, "session/prompt", {
+      sessionId,
+      prompt: [{ type: "text", text: "tell me a joke" }],
+    });
+
+    const watcherA = await connect(`/api/ws?sessionId=${sessionId}`);
+    await request(watcherA, 5, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "watcher-a" } });
+
+    const watcherB = await connect(`/api/ws?sessionId=${sessionId}`);
+    await request(watcherB, 7, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "watcher-b" } });
+    const loadB = request(watcherB, 8, "session/load", { sessionId });
+    const replayLeak = await recvWithTimeout(watcherA, 200);
+    await loadB;
+
+    expect(replayLeak).toBeNull();
+
+    creator.close();
+    watcherA.close();
+    watcherB.close();
+  });
+
+  it("keeps a running session alive with zero viewers and allows a clean reopen", async () => {
+    const ws = await connect();
+    await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    const created = await request(ws, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "zero-viewers" },
+    });
+    const sessionId = created.sessionId as string;
+    await request(ws, 3, "session/load", { sessionId });
+    send(ws, 4, "session/prompt", {
+      sessionId,
+      prompt: [{ type: "text", text: "run a long task" }],
+    });
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    ws.close();
+
+    const during = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((r) => r.json()) as { sessions: Array<Record<string, unknown>> };
+    expect(during.sessions.find((item) => item.sessionId === sessionId)?.running).toBe(true);
+
+    const transcript = await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionId}/transcript`).then((r) => r.json()) as { events: Array<Record<string, unknown>> };
+    expect(transcript.events.length).toBeGreaterThan(0);
+
+    const reopened = await connect(`/api/ws?sessionId=${sessionId}`);
+    await request(reopened, 5, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "reopen" } });
+    const after = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((r) => r.json()) as { sessions: Array<Record<string, unknown>> };
+    expect(after.sessions.find((item) => item.sessionId === sessionId)?.running).toBe(true);
+    reopened.close();
+  });
+
+  it("isolates updates between two simultaneously running sessions", async () => {
+    const control = await connect();
+    await request(control, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "control" } });
+    const a = await request(control, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "iso-a" },
+    });
+    const b = await request(control, 3, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "iso-b" },
+    });
+    control.close();
+
+    const watcherA = await connect(`/api/ws?sessionId=${a.sessionId}`);
+    const watcherB = await connect(`/api/ws?sessionId=${b.sessionId}`);
+    await request(watcherA, 4, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "a" } });
+    await request(watcherB, 5, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "b" } });
+    await request(watcherA, 6, "session/load", { sessionId: a.sessionId });
+    send(watcherA, 7, "session/prompt", { sessionId: a.sessionId, prompt: [{ type: "text", text: "tell me a joke" }] });
+    const leakedToB = await recvWithTimeout(watcherB, 120);
+    expect(leakedToB).toBeNull();
+    watcherA.close();
+    watcherB.close();
   });
 
   it.skip("resumes a session across connections", async () => {

--- a/server/src/server/index.ts
+++ b/server/src/server/index.ts
@@ -21,6 +21,7 @@ import { REPO_ROOT } from "./paths.js";
 import { registerEnvironmentRoutes } from "./routes/environmentRoutes.js";
 import { registerDiagnosticRoutes } from "./routes/diagnosticRoutes.js";
 import { registerRuntimeRoutes } from "./routes/runtimeRoutes.js";
+import { registerSessionRoutes } from "./routes/sessionRoutes.js";
 import { registerAcpFacadeRoute } from "./routes/acpFacadeRoute.js";
 import { ServerAuth } from "./auth.js";
 import { loadAgentRuntimes } from "./config/agentRuntimes.js";
@@ -112,6 +113,7 @@ export async function buildServer(options: BuildServerOptions = {}) {
 
   app.get("/api/health", async () => ({ ok: true, service: "rook" }));
   await registerRuntimeRoutes(app, runtimeManager);
+  await registerSessionRoutes(app, runtimeManager);
   await registerEnvironmentRoutes(app, environmentManager, environmentIdentifier, locationRegistrar, runtimeManager);
   await registerDiagnosticRoutes(app, environmentManager);
   await registerAcpFacadeRoute(app, runtimeManager, auth);

--- a/server/src/server/index.ts
+++ b/server/src/server/index.ts
@@ -28,6 +28,7 @@ import { loadAgentRuntimes } from "./config/agentRuntimes.js";
 import { RookDatastore } from "./datastore/RookDatastore.js";
 import { SqliteSessionRepository } from "./datastore/SqliteSessionRepository.js";
 import { AgentRuntimeManager } from "./services/AgentRuntimeManager.js";
+import { SessionTranscriptStore } from "./services/SessionTranscriptStore.js";
 import { startRemoteProxy } from "./remoteProxy.js";
 
 dotenv.config({ path: path.join(REPO_ROOT, ".env") });
@@ -96,7 +97,8 @@ export async function buildServer(options: BuildServerOptions = {}) {
   });
   const locationRegistrar = new LocationRegistrar(environmentManager, locationContextRepository);
   const sessionRepository = new SqliteSessionRepository(datastore);
-  const runtimeManager = new AgentRuntimeManager(loadAgentRuntimes(), sessionRepository, REPO_ROOT, environmentManager);
+  const transcriptStore = new SessionTranscriptStore(datastore);
+  const runtimeManager = new AgentRuntimeManager(loadAgentRuntimes(), sessionRepository, REPO_ROOT, environmentManager, transcriptStore);
   await app.register(websocket);
 
   app.addHook("onRequest", async (request, reply) => {
@@ -113,7 +115,7 @@ export async function buildServer(options: BuildServerOptions = {}) {
 
   app.get("/api/health", async () => ({ ok: true, service: "rook" }));
   await registerRuntimeRoutes(app, runtimeManager);
-  await registerSessionRoutes(app, runtimeManager);
+  await registerSessionRoutes(app, runtimeManager, transcriptStore);
   await registerEnvironmentRoutes(app, environmentManager, environmentIdentifier, locationRegistrar, runtimeManager);
   await registerDiagnosticRoutes(app, environmentManager);
   await registerAcpFacadeRoute(app, runtimeManager, auth);

--- a/server/src/server/routes/acpFacadeRoute.ts
+++ b/server/src/server/routes/acpFacadeRoute.ts
@@ -3,7 +3,7 @@ import type { JsonObject, JsonRpcMessage, RuntimeNotification } from "../runtime
 import type { AgentRuntimeManager } from "../services/AgentRuntimeManager.js";
 import type { ServerAuth } from "../auth.js";
 
-/** One connection-level, strictly ACP JSON-RPC WebSocket facade. */
+/** One session-bound ACP JSON-RPC WebSocket facade. */
 export async function registerAcpFacadeRoute(app: FastifyInstance, runtimes: AgentRuntimeManager, auth: ServerAuth): Promise<void> {
   app.get("/api/ws", { websocket: true }, (socket, request) => {
     const authorization = auth.authorizeRequest(request.raw);
@@ -14,15 +14,27 @@ export async function registerAcpFacadeRoute(app: FastifyInstance, runtimes: Age
     }
     const subscriptions = new Map<string, () => void>();
     let environmentOffers = false;
+    let boundSessionId = queryBoundSessionId(request.raw.url);
     const send: RuntimeNotification = (message) => {
       if (socket.readyState === socket.OPEN) socket.send(JSON.stringify(message));
     };
     const subscribe = (sessionId: string) => {
       if (!subscriptions.has(sessionId)) subscriptions.set(sessionId, runtimes.subscribe(sessionId, send, { environmentOffers }));
     };
+    if (boundSessionId) subscribe(boundSessionId);
 
     socket.on("message", (raw: unknown) => {
-      void handleMessage(String(raw), runtimes, send, subscribe, (supported) => { environmentOffers = supported; });
+      void handleMessage(String(raw), runtimes, send, subscribe, (supported) => { environmentOffers = supported; }, {
+        boundSessionId: () => boundSessionId,
+        bindSessionId: (sessionId) => {
+          if (!boundSessionId) {
+            boundSessionId = sessionId;
+            subscribe(sessionId);
+            return;
+          }
+          if (boundSessionId !== sessionId) throw new Error(`WebSocket is bound to session ${boundSessionId}`);
+        },
+      });
     });
     const close = () => {
       for (const unsubscribe of subscriptions.values()) unsubscribe();
@@ -33,7 +45,14 @@ export async function registerAcpFacadeRoute(app: FastifyInstance, runtimes: Age
   });
 }
 
-async function handleMessage(raw: string, runtimes: AgentRuntimeManager, send: RuntimeNotification, subscribe: (sessionId: string) => void, setEnvironmentOffers: (supported: boolean) => void): Promise<void> {
+async function handleMessage(
+  raw: string,
+  runtimes: AgentRuntimeManager,
+  send: RuntimeNotification,
+  subscribe: (sessionId: string) => void,
+  setEnvironmentOffers: (supported: boolean) => void,
+  binding: { boundSessionId(): string | undefined; bindSessionId(sessionId: string): void },
+): Promise<void> {
   let message: JsonRpcMessage;
   try {
     message = JSON.parse(raw) as JsonRpcMessage;
@@ -76,7 +95,7 @@ async function handleMessage(raw: string, runtimes: AgentRuntimeManager, send: R
       }
       case "_com.rookkeeper/environment_offer_resolve": {
         const params = object(message.params) ?? {};
-        const sessionId = requiredSessionId(params);
+        const sessionId = requiredBoundSessionId(params, binding);
         const environmentId = typeof params.environmentId === "string" ? params.environmentId : "";
         const bundleHash = typeof params.bundleHash === "string" ? params.bundleHash : "";
         const decision = params.decision;
@@ -86,9 +105,11 @@ async function handleMessage(raw: string, runtimes: AgentRuntimeManager, send: R
         return;
       }
       case "session/list":
+        if (binding.boundSessionId()) throw new Error("session/list is not available on a session-bound websocket; use GET /api/sessions instead.");
         send(success(requestId!, { sessions: (await runtimes.listSessions()).map((record) => ({ sessionId: record.sessionId, cwd: record.cwd, title: record.title, updatedAt: record.updatedAt, _meta: { runtimeId: record.runtimeId, startedAt: record.startedAt } })) }));
         return;
       case "session/new": {
+        if (binding.boundSessionId()) throw new Error("session/new is not available on a session-bound websocket.");
         const params = object(message.params) ?? {};
         const meta = object(params._meta);
         const runtimeId = typeof meta?.runtimeId === "string" ? meta.runtimeId : runtimes.defaultRuntimeId();
@@ -105,21 +126,24 @@ async function handleMessage(raw: string, runtimes: AgentRuntimeManager, send: R
       case "session/set_mode":
       case "session/set_config_option": {
         const params = object(message.params) ?? {};
-        const sessionId = requiredSessionId(params);
+        const sessionId = requiredBoundSessionId(params, binding);
         subscribe(sessionId);
-        send(success(requestId!, await runtimes.requestForSession(sessionId, message.method, withoutSessionId(params))));
+        const result = await runtimes.requestForSession(sessionId, message.method, withoutSessionId(params), {
+          ...(message.method === "session/load" || message.method === "session/resume" ? { privateReplayListener: send } : {}),
+        });
+        send(success(requestId!, result));
         return;
       }
       case "session/cancel": {
         const params = object(message.params) ?? {};
-        const sessionId = requiredSessionId(params);
+        const sessionId = requiredBoundSessionId(params, binding);
         subscribe(sessionId);
         await runtimes.notifyForSession(sessionId, "session/cancel", withoutSessionId(params));
         if (isRequest) send(success(requestId!, { ok: true }));
         return;
       }
       case "session/close": {
-        const sessionId = requiredSessionId(object(message.params) ?? {});
+        const sessionId = requiredBoundSessionId(object(message.params) ?? {}, binding);
         subscribe(sessionId);
         send(success(requestId!, await runtimes.closeSession(sessionId)));
         return;
@@ -139,6 +163,11 @@ function requiredSessionId(params: JsonObject): string {
   if (typeof params.sessionId !== "string" || !params.sessionId) throw new Error("Missing sessionId");
   return params.sessionId;
 }
+function requiredBoundSessionId(params: JsonObject, binding: { boundSessionId(): string | undefined; bindSessionId(sessionId: string): void }): string {
+  const sessionId = requiredSessionId(params);
+  binding.bindSessionId(sessionId);
+  return sessionId;
+}
 function withoutSessionId(params: JsonObject): JsonObject {
   const { sessionId: _sessionId, ...rest } = params;
   return rest;
@@ -146,6 +175,16 @@ function withoutSessionId(params: JsonObject): JsonObject {
 function withoutMeta(params: JsonObject): JsonObject {
   const { _meta: _meta, ...rest } = params;
   return rest;
+}
+function queryBoundSessionId(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url, "http://127.0.0.1");
+    const sessionId = parsed.searchParams.get("sessionId")?.trim();
+    return sessionId || undefined;
+  } catch {
+    return undefined;
+  }
 }
 function success(id: string | number, result: unknown): JsonRpcMessage { return { jsonrpc: "2.0", id, result }; }
 function failure(id: string | number | null, message: string, code = -32000): JsonRpcMessage { return { jsonrpc: "2.0", id, error: { code, message } }; }

--- a/server/src/server/routes/sessionRoutes.ts
+++ b/server/src/server/routes/sessionRoutes.ts
@@ -1,8 +1,9 @@
 import type { FastifyInstance } from "fastify";
 import type { AgentRuntimeManager } from "../services/AgentRuntimeManager.js";
+import type { SessionTranscriptStore } from "../services/SessionTranscriptStore.js";
 
 /** REST session listing — session discovery lives outside the ACP WebSocket. */
-export async function registerSessionRoutes(app: FastifyInstance, runtimeManager: AgentRuntimeManager): Promise<void> {
+export async function registerSessionRoutes(app: FastifyInstance, runtimeManager: AgentRuntimeManager, transcriptStore: SessionTranscriptStore): Promise<void> {
   app.get("/api/sessions", async () => {
     const records = await runtimeManager.listSessions();
     return {
@@ -17,6 +18,22 @@ export async function registerSessionRoutes(app: FastifyInstance, runtimeManager
           startedAt: record.startedAt,
         },
       })),
+    };
+  });
+
+  app.get<{ Params: { sessionId: string } }>("/api/sessions/:sessionId/transcript", async (request, reply) => {
+    const sessionId = request.params.sessionId;
+    const records = await runtimeManager.listSessions();
+    const record = records.find((item) => item.sessionId === sessionId);
+    if (!record) {
+      reply.code(404).send({ error: "Unknown session" });
+      return;
+    }
+    const events = await transcriptStore.list(sessionId);
+    return {
+      sessionId,
+      running: runtimeManager.sessionHasRuntime(sessionId),
+      events: events.map((item) => ({ sequence: item.sequence, createdAt: item.createdAt, ...item.event })),
     };
   });
 }

--- a/server/src/server/routes/sessionRoutes.ts
+++ b/server/src/server/routes/sessionRoutes.ts
@@ -1,0 +1,22 @@
+import type { FastifyInstance } from "fastify";
+import type { AgentRuntimeManager } from "../services/AgentRuntimeManager.js";
+
+/** REST session listing — session discovery lives outside the ACP WebSocket. */
+export async function registerSessionRoutes(app: FastifyInstance, runtimeManager: AgentRuntimeManager): Promise<void> {
+  app.get("/api/sessions", async () => {
+    const records = await runtimeManager.listSessions();
+    return {
+      sessions: records.map((record) => ({
+        sessionId: record.sessionId,
+        cwd: record.cwd,
+        title: record.title,
+        updatedAt: record.updatedAt,
+        running: runtimeManager.sessionHasRuntime(record.sessionId),
+        _meta: {
+          runtimeId: record.runtimeId,
+          startedAt: record.startedAt,
+        },
+      })),
+    };
+  });
+}

--- a/server/src/server/services/AgentRuntimeManager.ts
+++ b/server/src/server/services/AgentRuntimeManager.ts
@@ -4,6 +4,8 @@ import type { EnvironmentBundleOffer, EnvironmentEventListener, EnvironmentResol
 import type { SessionRecord, SessionRepository } from "../repositories/SessionRepository.js";
 import { SessionRuntime, type JsonObject, type JsonRpcMessage, type RuntimeNotification, type SessionRuntimeConfiguration } from "../runtime/SessionRuntime.js";
 import { runtimeLaunchPlan, runtimeSessionParams } from "../runtime/runtimeLaunchPlan.js";
+import { SessionTranscriptStore } from "./SessionTranscriptStore.js";
+import { normalizedEventsFromRuntimeMessage, runCompletedEvent, runFailedEvent } from "./sessionTranscriptEvents.js";
 
 /**
  * Owns the configured runtime catalog and lazily creates one isolated
@@ -21,12 +23,16 @@ export class AgentRuntimeManager {
   private readonly restoredEnvironmentMembership = new Set<string>();
   private readonly environmentSkillPaths = new Map<string, Map<string, string[]>>();
   private readonly environmentRestartQueues = new Map<string, Promise<void>>();
+  private readonly privateReplayTargets = new Map<string, Set<RuntimeNotification>>();
+  private readonly privateReplayIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly privateReplayWaiters = new Map<string, Set<() => void>>();
 
   constructor(
     profiles: AgentRuntimeProfile[],
     private readonly sessions: SessionRepository,
     private readonly repoRoot: string,
     private readonly environmentManager?: EnvironmentManager,
+    private readonly transcriptStore?: SessionTranscriptStore,
   ) {
     this.profilesById = new Map(profiles.map((profile) => [profile.id, profile]));
   }
@@ -76,7 +82,7 @@ export class AgentRuntimeManager {
     return record;
   }
 
-  async requestForSession(sessionId: string, method: string, params: JsonObject): Promise<unknown> {
+  async requestForSession(sessionId: string, method: string, params: JsonObject, options: { privateReplayListener?: RuntimeNotification } = {}): Promise<unknown> {
     const record = await this.requireSession(sessionId);
     await this.restoreEnvironmentMembership(record);
     const runtime = this.runtimeFor(record);
@@ -84,9 +90,24 @@ export class AgentRuntimeManager {
       method === "session/load" || method === "session/resume"
         ? { cwd: record.cwd, mcpServers: [], ...params, sessionId: record.runtimeSessionId }
         : { ...params, sessionId: record.runtimeSessionId };
-    const result = await runtime.request(method, runtimeSessionParams(runtime.profile, runtimeParams, runtime.configuration));
-    await this.sessions.touch(sessionId);
-    return rewriteResultSessionId(record, result);
+    const privateReplay = (method === "session/load" || method === "session/resume") && options.privateReplayListener;
+    if (privateReplay) this.beginPrivateReplay(sessionId, options.privateReplayListener!);
+    try {
+      const result = await runtime.request(method, runtimeSessionParams(runtime.profile, runtimeParams, runtime.configuration));
+      if (method === "session/prompt") {
+        const stopReason = typeof (result as JsonObject | undefined)?.stopReason === "string" ? String((result as JsonObject).stopReason) : "end_turn";
+        await this.transcriptStore?.append(sessionId, runCompletedEvent(stopReason));
+      }
+      await this.sessions.touch(sessionId);
+      return rewriteResultSessionId(record, result);
+    } catch (error) {
+      if (method === "session/prompt") {
+        await this.transcriptStore?.append(sessionId, runFailedEvent(error instanceof Error ? error.message : String(error)));
+      }
+      throw error;
+    } finally {
+      if (privateReplay) await this.endPrivateReplayAfterQuiet(sessionId);
+    }
   }
 
   async notifyForSession(sessionId: string, method: string, params: JsonObject): Promise<void> {
@@ -221,6 +242,13 @@ export class AgentRuntimeManager {
         this.inboundRequestRoutes.set(requestId, runtime);
         outbound = { ...outbound, id: requestId };
       }
+      const privateTargets = this.privateReplayTargets.get(sessionId);
+      if (privateTargets && privateTargets.size > 0) {
+        this.bumpPrivateReplayIdle(sessionId);
+        for (const listener of privateTargets) listener(outbound);
+        return;
+      }
+      void this.captureTranscriptEvents(sessionId, outbound);
       for (const listener of this.subscribers.get(sessionId)?.keys() ?? []) listener(outbound);
     }));
   }
@@ -237,6 +265,13 @@ export class AgentRuntimeManager {
     this.runtimeSubscriptions.delete(sessionId);
     this.sessionRuntimes.delete(sessionId);
     this.subscribers.delete(sessionId);
+    this.privateReplayTargets.delete(sessionId);
+    const timer = this.privateReplayIdleTimers.get(sessionId);
+    if (timer) clearTimeout(timer);
+    this.privateReplayIdleTimers.delete(sessionId);
+    const waiters = this.privateReplayWaiters.get(sessionId) ?? new Set<() => void>();
+    for (const waiter of waiters) waiter();
+    this.privateReplayWaiters.delete(sessionId);
     if (this.environmentManager && this.environmentSubscriptions.delete(sessionId)) this.environmentManager.unsubscribe(sessionId);
     this.environmentSkillPaths.delete(sessionId);
     this.environmentRestartQueues.delete(sessionId);
@@ -308,6 +343,46 @@ export class AgentRuntimeManager {
     const previous = this.environmentRestartQueues.get(sessionId) ?? Promise.resolve();
     const queued = previous.then(restart, restart);
     this.environmentRestartQueues.set(sessionId, queued);
+  }
+
+  private beginPrivateReplay(sessionId: string, listener: RuntimeNotification): void {
+    const listeners = this.privateReplayTargets.get(sessionId) ?? new Set<RuntimeNotification>();
+    listeners.add(listener);
+    this.privateReplayTargets.set(sessionId, listeners);
+    this.bumpPrivateReplayIdle(sessionId);
+  }
+
+  private bumpPrivateReplayIdle(sessionId: string): void {
+    const existing = this.privateReplayIdleTimers.get(sessionId);
+    if (existing) clearTimeout(existing);
+    this.privateReplayIdleTimers.set(sessionId, setTimeout(() => {
+      this.privateReplayTargets.delete(sessionId);
+      this.privateReplayIdleTimers.delete(sessionId);
+      const waiters = this.privateReplayWaiters.get(sessionId) ?? new Set<() => void>();
+      for (const waiter of waiters) waiter();
+      this.privateReplayWaiters.delete(sessionId);
+    }, 80));
+  }
+
+  private async endPrivateReplayAfterQuiet(sessionId: string): Promise<void> {
+    await new Promise<void>((resolve) => {
+      const waiters = this.privateReplayWaiters.get(sessionId) ?? new Set<() => void>();
+      waiters.add(resolve);
+      this.privateReplayWaiters.set(sessionId, waiters);
+      if (!this.privateReplayIdleTimers.has(sessionId)) {
+        this.privateReplayTargets.delete(sessionId);
+        this.privateReplayWaiters.delete(sessionId);
+        resolve();
+        return;
+      }
+      this.bumpPrivateReplayIdle(sessionId);
+    });
+  }
+
+  private async captureTranscriptEvents(sessionId: string, message: JsonRpcMessage): Promise<void> {
+    for (const event of normalizedEventsFromRuntimeMessage(message)) {
+      await this.transcriptStore?.append(sessionId, event);
+    }
   }
 
   private requireProfile(runtimeId: string): AgentRuntimeProfile {

--- a/server/src/server/services/AgentRuntimeManager.ts
+++ b/server/src/server/services/AgentRuntimeManager.ts
@@ -179,6 +179,10 @@ export class AgentRuntimeManager {
     };
   }
 
+  sessionHasRuntime(sessionId: string): boolean {
+    return this.sessionRuntimes.has(sessionId);
+  }
+
   async close(): Promise<void> {
     for (const unsubscribe of this.runtimeSubscriptions.values()) unsubscribe();
     this.runtimeSubscriptions.clear();

--- a/server/src/server/services/SessionTranscriptStore.ts
+++ b/server/src/server/services/SessionTranscriptStore.ts
@@ -1,0 +1,61 @@
+import type { DatabaseSync } from "node:sqlite";
+import type { RookDatastore } from "../datastore/RookDatastore.js";
+
+export interface TranscriptEventRecord {
+  sequence: number;
+  sessionId: string;
+  createdAt: string;
+  event: Record<string, unknown>;
+}
+
+/**
+ * Durable append-only store of normalized session transcript events.
+ * This is owned by the server, not the runtime, so second viewers can hydrate
+ * without asking the runtime to replay again.
+ */
+export class SessionTranscriptStore {
+  private readonly db: DatabaseSync;
+
+  constructor(datastore: RookDatastore) {
+    this.db = datastore.db;
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS session_transcript_events (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+        created_at TEXT NOT NULL,
+        event_json TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS session_transcript_events_session_idx
+        ON session_transcript_events(session_id, sequence ASC);
+    `);
+  }
+
+  async append(sessionId: string, event: Record<string, unknown>, createdAt = new Date().toISOString()): Promise<number> {
+    const result = this.db.prepare(`
+      INSERT INTO session_transcript_events (session_id, created_at, event_json)
+      VALUES (?, ?, ?)
+    `).run(sessionId, createdAt, JSON.stringify(event));
+    return Number(result.lastInsertRowid);
+  }
+
+  async list(sessionId: string): Promise<TranscriptEventRecord[]> {
+    return this.db.prepare(`
+      SELECT sequence, session_id, created_at, event_json
+      FROM session_transcript_events
+      WHERE session_id = ?
+      ORDER BY sequence ASC
+    `).all(sessionId).map((row) => {
+      const value = row as Record<string, unknown>;
+      return {
+        sequence: Number(value.sequence),
+        sessionId: String(value.session_id),
+        createdAt: String(value.created_at),
+        event: JSON.parse(String(value.event_json)) as Record<string, unknown>,
+      };
+    });
+  }
+
+  async clear(sessionId: string): Promise<void> {
+    this.db.prepare(`DELETE FROM session_transcript_events WHERE session_id = ?`).run(sessionId);
+  }
+}

--- a/server/src/server/services/sessionTranscriptEvents.ts
+++ b/server/src/server/services/sessionTranscriptEvents.ts
@@ -1,0 +1,78 @@
+import type { JsonObject, JsonRpcMessage } from "../runtime/SessionRuntime.js";
+
+export interface NormalizedTranscriptEvent extends Record<string, unknown> {
+  kind: string;
+}
+
+export function normalizedEventsFromRuntimeMessage(message: JsonRpcMessage): NormalizedTranscriptEvent[] {
+  const method = typeof message.method === "string" ? message.method : undefined;
+  if (method !== "session/update") return [];
+  const params = object(message.params);
+  const update = object(params?.update);
+  const sessionUpdate = typeof update?.sessionUpdate === "string" ? update.sessionUpdate : undefined;
+  if (!sessionUpdate) return [];
+
+  switch (sessionUpdate) {
+    case "user_message_chunk": {
+      const text = contentText(update?.content);
+      return text ? [{ kind: "user_message_chunk", text }] : [];
+    }
+    case "agent_message_chunk": {
+      const text = contentText(update?.content);
+      return text ? [{ kind: "agent_message_chunk", text }] : [];
+    }
+    case "agent_thought_chunk": {
+      const text = contentText(update?.content);
+      return text ? [{ kind: "agent_thought_chunk", text }] : [];
+    }
+    case "tool_call": {
+      const toolCallId = typeof update?.toolCallId === "string" ? update.toolCallId : undefined;
+      if (!toolCallId) return [];
+      return [{
+        kind: "tool_call",
+        toolCallId,
+        title: typeof update?.title === "string" ? update.title : "Tool",
+        toolKind: typeof update?.kind === "string" ? update.kind : "",
+        status: typeof update?.status === "string" ? update.status : "pending",
+        rawInput: update?.rawInput ?? null,
+      }];
+    }
+    case "tool_call_update": {
+      const toolCallId = typeof update?.toolCallId === "string" ? update.toolCallId : undefined;
+      if (!toolCallId) return [];
+      return [{
+        kind: "tool_call_update",
+        toolCallId,
+        status: typeof update?.status === "string" ? update.status : "",
+        toolName: typeof update?.toolName === "string" ? update.toolName : null,
+        rawOutput: update?.rawOutput ?? null,
+      }];
+    }
+    case "plan_update": {
+      const entries = Array.isArray(update?.entries) ? update.entries : [];
+      return [{ kind: "plan_update", entries }];
+    }
+    case "usage_update": {
+      return [{ kind: "usage_update", used: update?.used ?? null, size: update?.size ?? null, cost: update?.cost ?? null }];
+    }
+    default:
+      return [];
+  }
+}
+
+export function runCompletedEvent(stopReason: string): NormalizedTranscriptEvent {
+  return { kind: "run_completed", stopReason };
+}
+
+export function runFailedEvent(message: string): NormalizedTranscriptEvent {
+  return { kind: "run_failed", message };
+}
+
+function object(value: unknown): JsonObject | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as JsonObject : undefined;
+}
+
+function contentText(content: unknown): string | undefined {
+  const value = object(content);
+  return typeof value?.text === "string" ? value.text : undefined;
+}


### PR DESCRIPTION
## Summary

Fix session switching and second-viewer behavior by moving session discovery to REST, binding Apple client sockets to a single session, and hydrating already-running sessions from a server-owned transcript instead of replaying the runtime into every watcher. This keeps long-running sessions alive across view switches, removes cross-session leakage in Apple clients, and makes `run-rook.sh` line up with the actual iPhone-vs-simulator launch model.

## Problem / context

Rook’s server already models one runtime subprocess per public session, but the clients and websocket facade were still shaped like a more generic multi-session pipe. In practice that meant:

- switching sessions in Apple clients could trigger disruptive `session/load` behavior
- a second viewer joining a session could restream replay traffic into existing viewers
- session listing depended on ACP `session/list` instead of a cleaner REST surface
- iPhone launcher behavior had drifted: bundle IDs were being rewritten from signing state, and `iphone` had started acting like a simulator fallback instead of a physical-device target

## Why this matters

This is directly about Rook’s "goes with you everywhere" and environment-aware session model. If watching session B can disturb session A, or reopening a running session replays or interrupts work, then background/ambient agent behavior stops feeling trustworthy. The iPhone launcher fixes matter for the same reason: the phone client needs a stable, repeatable path for entering the same multi-session world as the Mac client, without code-signing surprises or silently changing bundle identities.

## Approaches considered

| Option | Summary | Why not (or chosen) |
|--------|---------|---------------------|
| Keep a generic multi-session websocket and try to special-case replay routing | Preserve the old facade shape and patch replay fanout | Rejected. It keeps the wrong mental model and makes per-session lifecycle harder to reason about in clients. |
| Bind one websocket per session, move discovery/hydration to REST, persist transcript events on the server | Match the server’s one-runtime-per-session model and separate private bootstrap from shared live updates | Chosen. Cleaner boundary, fixes the replay bug, and gives late joiners a stable hydration path. |

## Decision / approach taken

Rook now treats live agent interaction as a session-bound channel: discovery and hydration happen over REST, while each active Apple session owns one websocket bound to exactly one public session.

- Added `GET /api/sessions` and `GET /api/sessions/:id/transcript` so clients can discover sessions and hydrate already-running ones without runtime replay.
- Changed the server ACP facade so `/api/ws` is session-bound and `session/load` replay is requester-private rather than broadcast to all watchers.
- Persisted normalized transcript events server-side and used that store for second-viewer / reopen hydration.
- Moved shared Apple per-session logic into `RookKit` `SessionHandle`, so Mac and iPhone share the same no-reload-on-reselect behavior.
- Kept `iphone` as physical-device-only in `run-rook.sh`, added `sim` for simulator launches, and stopped rewriting bundle IDs from signing-team guesses.

## Product specification alignment

**Classification:** Implements

**Related PRODUCT/ docs:**
- `PRODUCT/goals-of-rook.md` — this fixes a concrete failure mode in “Rook goes with you everywhere” and in long-lived environment-aware agent presence.
- `PRODUCT/relationship-between-sessions-and-environments.md` — sessions remain distinct units that can independently enter environments without accidental cross-session behavior.
- `PRODUCT/agent-client-protocol.md` — continues the ACP-based client/runtime model while using cleaner boundaries around session-specific behavior.

**Documentation updates in this PR:**
- No PRODUCT/ updates — this work implements existing product intent rather than changing the product model.

**Notes:** The only notable behavior change is for hydration/replay semantics: additional viewers of a running session now hydrate from server-owned state instead of forcing shared runtime replay.

## Architecture alignment

**Classification:** Modifies

**Related docs / patterns:**
- `AS-BUILT-ARCHITECTURE/server.md` — websocket/session binding, transcript persistence, replay routing, new transcript REST endpoint
- `AS-BUILT-ARCHITECTURE/mac-client.md` — one handle / one websocket per session; transcript hydration for running sessions
- `AS-BUILT-ARCHITECTURE/iphone-client.md` — iPhone now mirrors the Mac per-session handle model
- `AS-BUILT-ARCHITECTURE/rookkit.md` — shared `SessionHandle` ownership and transcript hydration flow
- `server/README.md`, `clients/mac/README.md`, `clients/iphone/README.md`, `scripts/README.md` — updated launcher/discovery/hydration behavior

**Documentation updates in this PR:**
- [x] `AS-BUILT-ARCHITECTURE/README.md` — note REST transcript hydration + session-bound websocket shape
- [x] `AS-BUILT-ARCHITECTURE/server.md` — document session-bound `/api/ws`, private replay, transcript persistence
- [x] `AS-BUILT-ARCHITECTURE/mac-client.md` — document transcript hydration + per-session sockets
- [x] `AS-BUILT-ARCHITECTURE/iphone-client.md` — document iPhone parity with the shared session-handle model
- [x] `AS-BUILT-ARCHITECTURE/rookkit.md` — document `SessionHandle` as the shared Apple session boundary
- [x] `server/README.md`, `clients/mac/README.md`, `clients/iphone/README.md`, `scripts/README.md` — update user/developer workflow docs

**Notes:** The major architectural change is that `/api/ws` is no longer treated as a generic reusable multi-session ACP pipe for Apple clients. Session hydration and live traffic are now intentionally split.

## High-level technical footprint

- **Components:** `AgentRuntimeManager`, `SessionTranscriptStore`, ACP websocket facade, `RookKit` `SessionHandle`, Mac/iPhone session controllers, iPhone launcher helpers
- **APIs / protocols:** `GET /api/sessions`, `GET /api/sessions/:id/transcript`, session-bound `/api/ws`, ACP `session/load` replay routing
- **Data / events:** normalized `session_transcript_events`, requester-private replay/bootstrap traffic, shared live `session/update` traffic

## Test plan

- [x] Server tests cover late joiner replay isolation, zero-viewer reopen, and cross-session isolation
- [x] `swift build` for `clients/RookKit`
- [x] macOS client build succeeds
- [x] iPhone simulator build/launch succeeds via `./scripts/run-rook.sh sim`
- [x] physical iPhone build/install/launch succeeds via `./scripts/run-rook.sh iphone`
- [x] Docs updated to match the shipped websocket / launcher model
