### PR TITLE
Bind session/new sockets and speed up Pi startup

### DIFF
--- a/AS-BUILT-ARCHITECTURE/iphone-client.md
+++ b/AS-BUILT-ARCHITECTURE/iphone-client.md
@@ -93,11 +93,12 @@ Same shared contract as other clients:
 
 ### Chat flow
 1. session list is fetched via REST
-2. `RookModel` creates or retrieves a `SessionHandle` per session
-3. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
-4. the handle opens a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and reduces wire frames into `AcpClientEvent`s
-5. `RookModel` mirrors handle state into published chat/UI state and layers on voice / Live Activity behavior
-6. on reconnect the model reattaches to the current session handle and re-announces place state
+2. starting a new session opens an unbound WebSocket, sends ACP `session/new`, then keeps that same socket as the new session's `SessionHandle`
+3. resuming an existing session creates or retrieves a `SessionHandle`
+4. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
+5. resumed handles open a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and reduce wire frames into `AcpClientEvent`s
+6. `RookModel` mirrors handle state into published chat/UI state and layers on voice / Live Activity behavior
+7. on reconnect the model reattaches to the current session handle and re-announces place state
 
 ### Voice flow
 1. user starts listening

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -101,12 +101,13 @@ Via `RookKit`:
 
 ### Chat flow
 1. session list is fetched via REST, not the WebSocket
-2. tapping a session creates or retrieves a `SessionHandle`
-3. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
-4. the handle opens a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and runs `initialize`
-5. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
-6. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
-7. queued messages are delivered automatically once the agent goes idle
+2. starting a new session opens an unbound WebSocket, sends ACP `session/new`, then keeps that same socket as the new session's `SessionHandle`
+3. resuming an existing session creates or retrieves a `SessionHandle`
+4. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
+5. resumed handles open a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and run `initialize`
+6. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
+7. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
+8. queued messages are delivered automatically once the agent goes idle
 
 ### Foreground environment detection
 1. `ForegroundAppMonitor` detects app activation or window-title change

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -7,7 +7,7 @@
 ## Main components
 
 - `Net/AcpSocket.swift`
-  - session-bound ACP WebSocket client for `/api/ws?sessionId=...`
+  - ACP WebSocket client for `/api/ws`, optionally session-bound via `?sessionId=...`
   - owns request/response bookkeeping and event reduction
 - `Net/SessionHandle.swift`
   - shared per-session state container used by both Apple clients

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -53,11 +53,12 @@ See also: [database.md](./database.md)
 ### WebSocket ACP facade
 - route: `GET /api/ws`
 - websocket may be session-bound up front via `?sessionId=<public-session-id>`
+- a websocket that starts unbound becomes bound after a successful `session/new`
 - once bound, the websocket is restricted to that session only
 - client methods handled directly:
   - `initialize`
   - `session/list` (unbound websocket only; REST preferred)
-  - `session/new` (unbound websocket only)
+  - `session/new` (unbound websocket only; success binds that websocket to the new public session)
   - `session/load`
   - `session/resume`
   - `session/prompt`
@@ -147,11 +148,11 @@ Related tables:
 ## Main processes
 
 ### Session creation
-1. client sends `session/new` with runtime metadata
+1. client sends `session/new` with runtime metadata on an unbound websocket
 2. `AgentRuntimeManager` creates a `SessionRuntime`
 3. server calls runtime `session/new`
 4. server stores a public session record with a new public UUID
-5. later client `session/load`s the public session
+5. server returns that public session ID and binds the same websocket to it
 
 ### Prompt execution
 1. client sends ACP `session/prompt` on a session-bound websocket

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rook
 
-Rook is a local-first personal-agent runtime built around ACP (Agent Client Protocol). The repo contains the server, native clients, and supporting docs.
+Rook is a local-first personal-agent runtime built around ACP (Agent Client Protocol). The repo contains the server, native clients, and supporting docs. Session discovery is REST-backed, and live session interaction uses one ACP WebSocket per active session.
 
 ## Start here
 

--- a/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
@@ -12,6 +12,20 @@ public struct AgentDefinition: Codable, Equatable, Identifiable {
 
 /// Wraps the raw session record JSON so resume can send the record back to
 /// ACP session summaries plus Rook `_meta` fields, including fields this app doesn't model.
+public enum SessionSelectionStatus: String, Equatable {
+    case active
+    case on
+    case off
+
+    public var label: String {
+        switch self {
+        case .active: return "Active"
+        case .on: return "On"
+        case .off: return "Off"
+        }
+    }
+}
+
 public struct AgentSessionSummary: Equatable, Identifiable {
     public let raw: JSONValue
 
@@ -26,6 +40,13 @@ public struct AgentSessionSummary: Equatable, Identifiable {
     public var connectedClients: Int { Int(raw["connectedClients"]?.numberValue ?? 0) }
     public var updatedAtISO: String? { raw["updatedAt"]?.stringValue }
     public var startedAtISO: String? { raw["createdAt"]?.stringValue ?? raw["_meta"]?["startedAt"]?.stringValue }
+
+    public func selectionStatus(currentSessionId: String?) -> SessionSelectionStatus {
+        if running, currentSessionId == id {
+            return .active
+        }
+        return running ? .on : .off
+    }
 
     public var createdAt: Date? {
         guard let iso = startedAtISO else {

--- a/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
+++ b/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
@@ -91,7 +91,6 @@ public final class AcpSocket {
             throw SocketError.server("Server returned no sessionId")
         }
         currentSessionId = sessionId
-        _ = try await request(method: "session/load", params: ["sessionId": sessionId])
         return sessionId
     }
 

--- a/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
+++ b/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
@@ -17,7 +17,7 @@ public final class SessionHandle {
     public var onAgentTextChunk: ((String) -> Void)?
 
     private let api: RookAPI
-    private let socket = AcpSocket()
+    private let socket: AcpSocket
 
     // MARK: - Observable state (same shape ChatSessionController exposed)
     public private(set) var blocks: [ChatBlock] = [] { didSet { onStateChange?() } }
@@ -54,15 +54,18 @@ public final class SessionHandle {
     private var replayAssistantBuffer = ""
     private var replayThinkingBuffer = ""
 
-    public init(sessionId: String, api: RookAPI) {
+    public init(sessionId: String, api: RookAPI, socket: AcpSocket? = nil, isLoaded: Bool = false) {
         self.sessionId = sessionId
         self.api = api
-        socket.onEvent = { [weak self] event in
+        self.socket = socket ?? AcpSocket()
+        self.isLoaded = isLoaded
+        self.socket.onEvent = { [weak self] event in
             self?.handleSocketEvent(event)
         }
-        socket.onConnectionChange = { [weak self] connected in
+        self.socket.onConnectionChange = { [weak self] connected in
             self?.handleSocketConnectionChange(connected)
         }
+        self.socketConnected = self.socket.isConnected
     }
 
     // MARK: - Lifecycle
@@ -70,6 +73,7 @@ public final class SessionHandle {
     public func connectAndLoad(title: String, cwd: String) async throws {
         try await ensureSocketConnected()
         _ = try await socket.createSession(runtimeId: "", title: title, cwd: cwd)
+        isLoaded = true
     }
 
     public func load() async throws {

--- a/clients/android/app/src/main/java/com/rookery/rook/RookApp.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/RookApp.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.rookery.rook.ui.AgentPickerScreen
+import com.rookery.rook.ui.SessionsHomeScreen
 import com.rookery.rook.ui.ChatScreen
 import com.rookery.rook.ui.EnvironmentOfferSheet
 import com.rookery.rook.ui.EnvironmentsScreen
@@ -44,7 +44,7 @@ fun RookApp(viewModel: RookViewModel, simulateArrival: Pair<Double, Double>? = n
     ) {
         when {
             currentSession != null && chatVisible -> ChatScreen(viewModel)
-            else -> AgentPickerScreen(viewModel)
+            else -> SessionsHomeScreen(viewModel)
         }
     }
 

--- a/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
@@ -293,9 +293,23 @@ class RookViewModel(
             _startingSession.value = true
             try {
                 ensureSocketConnected()
-                val sessionId = socket.createSession(agentId, trimmedName.ifEmpty { "session" }, System.getProperty("user.dir") ?: ".")
-                _sessions.value = socket.sessionList().map(::AgentSessionSummary)
-                _sessions.value.firstOrNull { it.id == sessionId }?.let { enterChat(it, resumed = false) }
+                val title = trimmedName.ifEmpty { "session" }
+                val sessionId = socket.createSession(agentId, title, System.getProperty("user.dir") ?: ".")
+                val session = AgentSessionSummary(
+                    raw = buildJsonObject {
+                        put("sessionId", sessionId)
+                        put("title", title)
+                        put("updatedAt", java.time.Instant.now().toString())
+                        put("running", true)
+                        putJsonObject("_meta") {
+                            put("runtimeId", agentId)
+                            put("startedAt", java.time.Instant.now().toString())
+                        }
+                    }
+                )
+                enterChat(session, resumed = false)
+                _sessions.value = api.sessions().map(::AgentSessionSummary)
+                _sessions.value.firstOrNull { it.id == sessionId }?.let { _currentSession.value = it }
             } catch (e: Exception) {
                 _sessionsError.value = e.message ?: "Failed to start session"
             } finally {

--- a/clients/android/app/src/main/java/com/rookery/rook/model/ApiTypes.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/model/ApiTypes.kt
@@ -16,12 +16,24 @@ data class AgentDefinition(
     val parentId: String?
 )
 
+enum class SessionSelectionStatus(val label: String) {
+    ACTIVE("Active"),
+    ON("On"),
+    OFF("Off")
+}
+
 data class AgentSessionSummary(val raw: JsonObject) {
     val id: String get() = raw["id"]?.stringValue ?: raw["sessionId"]?.stringValue ?: ""
     val agent: String get() = raw["agent"]?.stringValue ?: raw["_meta"]?.jsonObject?.get("runtimeId")?.stringValue ?: ""
     val name: String get() = raw["name"]?.stringValue ?: raw["title"]?.stringValue ?: "default"
     val running: Boolean get() = raw["running"]?.boolValue ?: false
     val connectedClients: Int get() = (raw["connectedClients"]?.numberValue ?: 0.0).toInt()
+
+    fun selectionStatus(currentSessionId: String?): SessionSelectionStatus = when {
+        running && currentSessionId == id -> SessionSelectionStatus.ACTIVE
+        running -> SessionSelectionStatus.ON
+        else -> SessionSelectionStatus.OFF
+    }
 
     val createdAt: Instant?
         get() = parseInstant(raw["createdAt"]?.stringValue ?: raw["_meta"]?.jsonObject?.get("startedAt")?.stringValue)

--- a/clients/android/app/src/main/java/com/rookery/rook/net/AcpSocket.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/net/AcpSocket.kt
@@ -213,7 +213,7 @@ class AcpSocket(
             includeSessionId = false
         )
         val created = result["sessionId"]?.stringValue ?: throw SocketRequestException.Server("Server returned no sessionId")
-        loadSession(created)
+        sessionId = created
         return created
     }
 

--- a/clients/android/app/src/main/java/com/rookery/rook/ui/AgentPickerScreen.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/ui/AgentPickerScreen.kt
@@ -57,10 +57,11 @@ import com.rookery.rook.ServerState
 import com.rookery.rook.buildAgentTree
 import com.rookery.rook.model.AgentDefinition
 import com.rookery.rook.model.AgentSessionSummary
+import com.rookery.rook.model.SessionSelectionStatus
 import com.rookery.rook.ui.chat.PanelPalette
 
 @Composable
-fun AgentPickerScreen(viewModel: RookViewModel) {
+fun SessionsHomeScreen(viewModel: RookViewModel) {
     val serverState by viewModel.serverState.collectAsState()
     val agents by viewModel.agents.collectAsState()
     val agentsError by viewModel.agentsError.collectAsState()
@@ -128,7 +129,7 @@ fun AgentPickerScreen(viewModel: RookViewModel) {
                         Text("No sessions yet — start a new chat above.", fontSize = 14.sp, color = PanelPalette.textMuted, modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp))
                     } else {
                         sessions.forEachIndexed { index, session ->
-                            SessionRow(session = session, enabled = !startingSession, onClick = { viewModel.resumeSession(session) })
+                            SessionRow(session = session, currentSessionId = currentSession?.id, enabled = !startingSession, onClick = { viewModel.resumeSession(session) })
                             if (index < sessions.lastIndex) HorizontalDivider(color = PanelPalette.border)
                         }
                     }
@@ -200,7 +201,14 @@ private fun NewChatNameField(value: String, onValueChange: (String) -> Unit, onS
 }
 
 @Composable
-private fun SessionRow(session: AgentSessionSummary, enabled: Boolean, onClick: () -> Unit) {
+private fun SessionRow(session: AgentSessionSummary, currentSessionId: String?, enabled: Boolean, onClick: () -> Unit) {
+    val status = session.selectionStatus(currentSessionId)
+    val statusTint = when (status) {
+        SessionSelectionStatus.ACTIVE -> PanelPalette.warning
+        SessionSelectionStatus.ON -> PanelPalette.success
+        SessionSelectionStatus.OFF -> PanelPalette.textMuted
+    }
+
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth().clickable(enabled = enabled, onClick = onClick).padding(vertical = 9.dp)) {
         Box(modifier = Modifier.size(30.dp).clip(CircleShape).background(PanelPalette.info.copy(alpha = 0.14f)), contentAlignment = Alignment.Center) {
             Icon(Icons.Filled.AutoAwesome, contentDescription = null, tint = PanelPalette.info, modifier = Modifier.size(14.dp))
@@ -209,6 +217,9 @@ private fun SessionRow(session: AgentSessionSummary, enabled: Boolean, onClick: 
             Text(session.name, fontSize = 15.sp, fontWeight = FontWeight.Medium, color = PanelPalette.textNormal, maxLines = 1, overflow = TextOverflow.Ellipsis)
             Text(session.agent, fontSize = 12.sp, color = PanelPalette.textMuted, maxLines = 1)
             if (session.updatedAtLabel.isNotEmpty()) Text("Updated ${session.updatedAtLabel}", fontSize = 11.sp, color = PanelPalette.textMuted, maxLines = 1)
+        }
+        Box(modifier = Modifier.clip(RoundedCornerShape(999.dp)).background(statusTint.copy(alpha = 0.25f)).padding(horizontal = 8.dp, vertical = 3.dp)) {
+            Text(status.label, fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = Color.White.copy(alpha = 0.95f))
         }
         Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = PanelPalette.textMuted)
     }

--- a/clients/android/app/src/main/java/com/rookery/rook/ui/SessionsScreen.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/ui/SessionsScreen.kt
@@ -5,5 +5,5 @@ import com.rookery.rook.RookViewModel
 
 @Composable
 fun SessionsScreen(viewModel: RookViewModel) {
-    AgentPickerScreen(viewModel)
+    SessionsHomeScreen(viewModel)
 }

--- a/clients/cli/README.md
+++ b/clients/cli/README.md
@@ -2,7 +2,7 @@
 
 A tiny ACP-first command-line client for the real Rook server.
 
-It creates a new session for one configured runtime, sends prompts over ACP WebSocket, and prints colored output as events arrive.
+It creates a new session for one configured runtime, keeps the same ACP WebSocket after `session/new`, and prints events as they arrive.
 
 ## Install
 

--- a/clients/cli/src/client.mjs
+++ b/clients/cli/src/client.mjs
@@ -127,7 +127,6 @@ export class RookCliClient {
     this.createdSessionId = result?.sessionId;
     if (!this.createdSessionId) throw new Error("Server returned no sessionId");
     this.sessionId = this.createdSessionId;
-    await this.request("session/load", { sessionId: this.sessionId });
     if (!this.lastMessageOnly) printLine(COLORS.gray, `session: ${this.sessionId} (${this.runtimeId})`);
   }
 

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -83,7 +83,7 @@ Rook (iOS app target)                         RookWidgets (app-extension)
   ├─ Location/
   │   ├─ Place.swift          Place + PlaceStore (UserDefaults) + CLVisit suggestions
   │   └─ LocationProvider.swift   CLCircularRegion monitoring, CLVisit, Always auth
-  └─ Views/               RootView · AgentPickerScreen · ChatScreen · PlacesScreen · EnvironmentOfferSheet
+  └─ Views/               RootView · SessionsHomeScreen · ChatScreen · PlacesScreen · EnvironmentOfferSheet
             │
             ▼ depends on
         RookKit  ──── Models · Net (RookAPI/AcpSocket) · Design · Voice · LiveActivity

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -29,7 +29,7 @@ binding, and bearer-token auth, start with [docs/setup.md](../../docs/setup.md).
   contains, then decide with the same 2×2 choices as every other client.
   Leaving the region simply stops refreshing it from the phone; the server ages
   it out on its own.
-- **Full chat parity.** Agent picker, REST-backed session discovery, per-session websocket attach, transcript hydration for already-running sessions, and streaming ACP chat
+- **Full chat parity.** Agent picker, REST-backed session discovery, one-socket session creation (`session/new` binds the just-opened websocket), per-session websocket attach for resumed sessions, transcript hydration for already-running sessions, and streaming ACP chat
   (text, thinking, tool calls, plans, errors, context usage) — including
   auto-rendering well-formed JSON tool arguments as human-readable YAML and
   assistant markdown with native drag-selection, standard copy/paste behavior,

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -507,13 +507,36 @@ final class RookModel: ObservableObject {
         Task {
             defer { startingSession = false }
             do {
-                let tempSocket = AcpSocket()
-                _ = try await tempSocket.connect(request: api.webSocketRequest())
-                let sessionId = try await tempSocket.createSession(runtimeId: agentId, title: trimmed.isEmpty ? "session" : trimmed, cwd: FileManager.default.currentDirectoryPath)
-                tempSocket.disconnect()
+                let title = trimmed.isEmpty ? "session" : trimmed
+                let socket = AcpSocket()
+                _ = try await socket.connect(request: api.webSocketRequest())
+                let sessionId = try await socket.createSession(runtimeId: agentId, title: title, cwd: FileManager.default.currentDirectoryPath)
+                let now = ISO8601DateFormatter().string(from: Date())
+                let session = AgentSessionSummary(raw: .object([
+                    "sessionId": .string(sessionId),
+                    "title": .string(title),
+                    "updatedAt": .string(now),
+                    "running": .bool(true),
+                    "_meta": .object([
+                        "runtimeId": .string(agentId),
+                        "startedAt": .string(now),
+                    ]),
+                ]))
+                let handle = SessionHandle(sessionId: sessionId, api: api, socket: socket, isLoaded: true)
+                handles[sessionId] = handle
+                wireHandle(handle)
+                currentSession = session
+                syncChatState()
+                selectedAgentId = nil
+                chatVisible = true
+                enteredEnvironments = []
+                environmentListItems = []
+                updateLiveActivity()
+                refreshEnvironmentList()
                 await loadSessions()
-                if let session = sessions.first(where: { $0.id == sessionId }) {
-                    resumeSession(session)
+                if let refreshed = sessions.first(where: { $0.id == sessionId }) {
+                    currentSession = refreshed
+                    syncChatState()
                 }
             } catch {
                 sessionsError = error.localizedDescription

--- a/clients/iphone/Sources/Views/AgentPickerScreen.swift
+++ b/clients/iphone/Sources/Views/AgentPickerScreen.swift
@@ -1,7 +1,7 @@
 import RookKit
 import SwiftUI
 
-struct AgentPickerScreen: View {
+struct SessionsHomeScreen: View {
     @ObservedObject var model: RookModel
     @State private var showingSettings = false
     @State private var showingPlaces = false
@@ -124,7 +124,7 @@ struct AgentPickerScreen: View {
                 VStack(spacing: 0) {
                     ForEach(Array(model.sessions.enumerated()), id: \.element.id) { index, session in
                         Button { model.resumeSession(session) } label: {
-                            SessionRow(session: session)
+                            SessionRow(session: session, currentSessionId: model.currentSession?.id)
                         }
                         .buttonStyle(.plain)
                         .disabled(model.startingSession)
@@ -203,14 +203,15 @@ struct AgentPickerScreen: View {
 
 private struct SessionRow: View {
     let session: AgentSessionSummary
+    let currentSessionId: String?
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: "bubble.left.and.bubble.right")
+            Image(systemName: statusIcon)
                 .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(PanelPalette.info)
+                .foregroundStyle(statusTint)
                 .frame(width: 30, height: 30)
-                .background(Circle().fill(PanelPalette.info.opacity(0.14)))
+                .background(Circle().fill(statusTint.opacity(0.14)))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(session.name)
@@ -230,11 +231,39 @@ private struct SessionRow: View {
             }
 
             Spacer(minLength: 4)
+
+            Text(status.label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.white.opacity(0.95))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(Capsule().fill(statusTint.opacity(0.25)))
+
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .bold))
                 .foregroundStyle(PanelPalette.textMuted)
         }
         .padding(.vertical, 9)
         .contentShape(Rectangle())
+    }
+
+    private var status: SessionSelectionStatus {
+        session.selectionStatus(currentSessionId: currentSessionId)
+    }
+
+    private var statusTint: Color {
+        switch status {
+        case .active: return PanelPalette.warning
+        case .on: return PanelPalette.success
+        case .off: return PanelPalette.textMuted
+        }
+    }
+
+    private var statusIcon: String {
+        switch status {
+        case .active: return "waveform.and.mic"
+        case .on: return "bolt.fill"
+        case .off: return "moon.zzz"
+        }
     }
 }

--- a/clients/iphone/Sources/Views/RootView.swift
+++ b/clients/iphone/Sources/Views/RootView.swift
@@ -14,7 +14,7 @@ struct RootView: View {
             if model.currentSession != nil && model.chatVisible {
                 ChatScreen(model: model)
             } else {
-                AgentPickerScreen(model: model)
+                SessionsHomeScreen(model: model)
             }
         }
         .tint(PanelPalette.accent)

--- a/clients/iphone/Sources/Views/SessionsScreen.swift
+++ b/clients/iphone/Sources/Views/SessionsScreen.swift
@@ -136,7 +136,7 @@ struct SessionsScreen: View {
                         Button {
                             model.resumeSession(session)
                         } label: {
-                            SessionRow(session: session)
+                            SessionRow(session: session, currentSessionId: model.currentSession?.id)
                         }
                         .buttonStyle(.plain)
                         .disabled(model.startingSession)
@@ -161,15 +161,16 @@ struct SessionsScreen: View {
 
 private struct SessionRow: View {
     let session: AgentSessionSummary
+    let currentSessionId: String?
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: session.running ? "bolt.fill" : "moon.zzz")
+            Image(systemName: statusIcon)
                 .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(session.running ? PanelPalette.success : PanelPalette.textMuted)
+                .foregroundStyle(statusTint)
                 .frame(width: 30, height: 30)
                 .background(
-                    Circle().fill((session.running ? PanelPalette.success : PanelPalette.textMuted).opacity(0.14))
+                    Circle().fill(statusTint.opacity(0.14))
                 )
 
             VStack(alignment: .leading, spacing: 2) {
@@ -194,7 +195,7 @@ private struct SessionRow: View {
                 .padding(.horizontal, 8)
                 .padding(.vertical, 3)
                 .background(
-                    Capsule().fill((session.running ? PanelPalette.success : PanelPalette.textMuted).opacity(0.25))
+                    Capsule().fill(statusTint.opacity(0.25))
                 )
 
             Image(systemName: "chevron.right")
@@ -205,10 +206,27 @@ private struct SessionRow: View {
         .contentShape(Rectangle())
     }
 
-    private var statusLabel: String {
-        if session.running {
-            return session.connectedClients > 0 ? "\(session.connectedClients) live" : "Running"
+    private var status: SessionSelectionStatus {
+        session.selectionStatus(currentSessionId: currentSessionId)
+    }
+
+    private var statusTint: Color {
+        switch status {
+        case .active: return PanelPalette.warning
+        case .on: return PanelPalette.success
+        case .off: return PanelPalette.textMuted
         }
-        return "Stopped"
+    }
+
+    private var statusIcon: String {
+        switch status {
+        case .active: return "waveform.and.mic"
+        case .on: return "bolt.fill"
+        case .off: return "moon.zzz"
+        }
+    }
+
+    private var statusLabel: String {
+        status.label
     }
 }

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -12,7 +12,7 @@ WebSocket protocol. For repo-level setup, `.env`, binding, and auth, start with
 
 ## Features
 
-- **Agent picker** - unified Sessions home screen listing all sessions across runtimes, with a New Chat form that selects a configured runtime.
+- **Sessions home** - unified session-selection screen listing all sessions across runtimes, with a New Chat form that selects a configured runtime.
 - **Sessions** - session history ordered by most recently updated; resume any session by clicking it. Discovery is REST (`GET /api/sessions`). Live interaction is one session-bound WebSocket per session.
 - **Auto-resume** - on launch the app rejoins the most recent session; if it is already running, it hydrates from `GET /api/sessions/:id/transcript` instead of reloading the runtime.
 - **Streaming chat** — `session/prompt` over `ws://127.0.0.1:7665/api/ws?sessionId=...`;

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -13,7 +13,7 @@ WebSocket protocol. For repo-level setup, `.env`, binding, and auth, start with
 ## Features
 
 - **Sessions home** - unified session-selection screen listing all sessions across runtimes, with a New Chat form that selects a configured runtime.
-- **Sessions** - session history ordered by most recently updated; resume any session by clicking it. Discovery is REST (`GET /api/sessions`). Live interaction is one session-bound WebSocket per session.
+- **Sessions** - session history ordered by most recently updated; resume any session by clicking it. Discovery is REST (`GET /api/sessions`). New chats start on one unbound WebSocket that becomes session-bound after `session/new`; thereafter live interaction is one session WebSocket per session.
 - **Auto-resume** - on launch the app rejoins the most recent session; if it is already running, it hydrates from `GET /api/sessions/:id/transcript` instead of reloading the runtime.
 - **Streaming chat** — `session/prompt` over `ws://127.0.0.1:7665/api/ws?sessionId=...`;
   renders agent text, thinking (collapsible), tool calls with normalized raw

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 import RookKit
 
 /// Session lifecycle and registry.  One `SessionHandle` per session, each
@@ -6,6 +7,8 @@ import RookKit
 /// observes — background sessions keep running.
 @MainActor
 final class ChatSessionController {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.rookery.Rook", category: "ChatSessionController")
+    private static let timingLogsEnabled = ProcessInfo.processInfo.environment["ROOK_SESSION_TIMING_LOGS"] == "1"
     var onStateChange: (() -> Void)?
     var onCurrentSessionChange: ((AgentSessionSummary?) -> Void)?
     var onEnvironmentOffered: ((EnvironmentOffer) -> Void)?
@@ -90,14 +93,19 @@ final class ChatSessionController {
         startingSession = true
         Task {
             defer { self.startingSession = false; completion?() }
+            let startedAt = Date().timeIntervalSinceReferenceDate
             do {
                 let socket = AcpSocket()
+                let connectStartedAt = Date().timeIntervalSinceReferenceDate
                 _ = try await socket.connect(request: api.webSocketRequest())
+                Self.timingLog("connect complete", elapsedMs: Date().timeIntervalSinceReferenceDate - connectStartedAt, runtimeId: agentId)
+                let createStartedAt = Date().timeIntervalSinceReferenceDate
                 let sessionId = try await socket.createSession(
                     runtimeId: agentId,
                     title: title,
                     cwd: FileManager.default.currentDirectoryPath
                 )
+                Self.timingLog("session/new complete", elapsedMs: Date().timeIntervalSinceReferenceDate - createStartedAt, runtimeId: agentId, sessionId: sessionId)
 
                 let summary = AgentSessionSummary(raw: .object([
                     "sessionId": .string(sessionId),
@@ -113,11 +121,15 @@ final class ChatSessionController {
                 handles[sessionId] = handle
                 wireHandle(handle)
                 currentSession = summary
+                let refreshStartedAt = Date().timeIntervalSinceReferenceDate
                 await loadSessions()
+                Self.timingLog("loadSessions complete", elapsedMs: Date().timeIntervalSinceReferenceDate - refreshStartedAt, runtimeId: agentId, sessionId: sessionId)
                 if let refreshed = sessions.first(where: { $0.id == sessionId }) {
                     currentSession = refreshed
                 }
+                Self.timingLog("startNewSession complete", elapsedMs: Date().timeIntervalSinceReferenceDate - startedAt, runtimeId: agentId, sessionId: sessionId)
             } catch {
+                Self.timingLog("startNewSession failed", elapsedMs: Date().timeIntervalSinceReferenceDate - startedAt, runtimeId: agentId, error: error.localizedDescription)
                 sessionsError = error.localizedDescription
             }
         }
@@ -178,5 +190,19 @@ final class ChatSessionController {
         handle.onEnvironmentOfferResolved = { [weak self] in self?.onEnvironmentOfferResolved?($0, $1) }
         handle.onEnvironmentEntered = { [weak self] in self?.onEnvironmentEntered?($0) }
         handle.onEnvironmentExited = { [weak self] in self?.onEnvironmentExited?($0, $1) }
+    }
+
+    private static func timingLog(_ message: String, elapsedMs: CFTimeInterval, runtimeId: String, sessionId: String? = nil, error: String? = nil) {
+        guard timingLogsEnabled else { return }
+        let rounded = (elapsedMs * 1000).rounded() / 1000
+        if let sessionId, let error {
+            logger.info("timing \(message, privacy: .public) runtime=\(runtimeId, privacy: .public) session=\(sessionId, privacy: .public) elapsedMs=\(rounded, privacy: .public) error=\(error, privacy: .public)")
+        } else if let sessionId {
+            logger.info("timing \(message, privacy: .public) runtime=\(runtimeId, privacy: .public) session=\(sessionId, privacy: .public) elapsedMs=\(rounded, privacy: .public)")
+        } else if let error {
+            logger.info("timing \(message, privacy: .public) runtime=\(runtimeId, privacy: .public) elapsedMs=\(rounded, privacy: .public) error=\(error, privacy: .public)")
+        } else {
+            logger.info("timing \(message, privacy: .public) runtime=\(runtimeId, privacy: .public) elapsedMs=\(rounded, privacy: .public)")
+        }
     }
 }

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -91,25 +91,32 @@ final class ChatSessionController {
         Task {
             defer { self.startingSession = false; completion?() }
             do {
-                // Create the session via a temporary socket, then hand off
-                // to a permanent handle that loads it on its own WebSocket.
-                let tempSocket = AcpSocket()
-                _ = try await tempSocket.connect(request: api.webSocketRequest())
-                let sessionId = try await tempSocket.createSession(
+                let socket = AcpSocket()
+                _ = try await socket.connect(request: api.webSocketRequest())
+                let sessionId = try await socket.createSession(
                     runtimeId: agentId,
                     title: title,
                     cwd: FileManager.default.currentDirectoryPath
                 )
-                tempSocket.disconnect()
 
+                let summary = AgentSessionSummary(raw: .object([
+                    "sessionId": .string(sessionId),
+                    "title": .string(title),
+                    "updatedAt": .string(ISO8601DateFormatter().string(from: Date())),
+                    "running": .bool(true),
+                    "_meta": .object([
+                        "runtimeId": .string(agentId),
+                        "startedAt": .string(ISO8601DateFormatter().string(from: Date())),
+                    ]),
+                ]))
+                let handle = SessionHandle(sessionId: sessionId, api: api, socket: socket, isLoaded: true)
+                handles[sessionId] = handle
+                wireHandle(handle)
+                currentSession = summary
                 await loadSessions()
-                let summary = sessions.first(where: { $0.id == sessionId })
-                    ?? AgentSessionSummary(raw: .object([
-                        "sessionId": .string(sessionId),
-                        "title": .string(title),
-                        "_meta": .object(["runtimeId": .string(agentId)]),
-                    ]))
-                resumeSession(summary)
+                if let refreshed = sessions.first(where: { $0.id == sessionId }) {
+                    currentSession = refreshed
+                }
             } catch {
                 sessionsError = error.localizedDescription
             }

--- a/clients/mac/Sources/Views/RookView.swift
+++ b/clients/mac/Sources/Views/RookView.swift
@@ -542,7 +542,7 @@ private struct HomeContent: View {
                             Button {
                                 model.resumeSession(session)
                             } label: {
-                                SessionHomeRow(session: session)
+                                SessionHomeRow(session: session, currentSessionId: model.currentSession?.id)
                             }
                             .buttonStyle(.plain)
                             .pointingHandOnHover()
@@ -625,6 +625,7 @@ private struct HomeContent: View {
 
 private struct SessionHomeRow: View {
     var session: AgentSessionSummary
+    var currentSessionId: String?
 
     var body: some View {
         HStack(spacing: 9) {
@@ -653,6 +654,17 @@ private struct SessionHomeRow: View {
 
             Spacer(minLength: 4)
 
+            Text(status.label)
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .foregroundColor(.white.opacity(0.96))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    Capsule()
+                        .fill(statusTint.opacity(0.25))
+                )
+
             Image(systemName: "chevron.right")
                 .font(.system(size: 10, weight: .bold))
                 .foregroundStyle(.secondary)
@@ -661,6 +673,18 @@ private struct SessionHomeRow: View {
         .padding(.horizontal, 6)
         .contentShape(Rectangle())
         .hoverRowBackground()
+    }
+
+    private var status: SessionSelectionStatus {
+        session.selectionStatus(currentSessionId: currentSessionId)
+    }
+
+    private var statusTint: Color {
+        switch status {
+        case .active: return PanelPalette.warning
+        case .on: return PanelPalette.success
+        case .off: return PanelPalette.secondaryText
+        }
     }
 }
 
@@ -774,7 +798,7 @@ private struct SessionsDetail: View {
                             Button {
                                 model.resumeSession(session)
                             } label: {
-                                SessionRow(session: session)
+                                SessionRow(session: session, currentSessionId: model.currentSession?.id)
                             }
                             .buttonStyle(.plain)
                             .help("Resume this session")
@@ -804,16 +828,17 @@ private struct SessionsDetail: View {
 
 private struct SessionRow: View {
     var session: AgentSessionSummary
+    var currentSessionId: String?
 
     var body: some View {
         HStack(alignment: .center, spacing: 9) {
-            Image(systemName: session.running ? "bolt.fill" : "moon.zzz")
+            Image(systemName: statusIcon)
                 .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(session.running ? PanelPalette.success : PanelPalette.secondaryText)
+                .foregroundStyle(statusTint)
                 .frame(width: 22, height: 22)
                 .background(
                     Circle()
-                        .fill((session.running ? PanelPalette.success : PanelPalette.secondaryText).opacity(0.14))
+                        .fill(statusTint.opacity(0.14))
                 )
 
             VStack(alignment: .leading, spacing: 2) {
@@ -839,7 +864,7 @@ private struct SessionRow: View {
                 .padding(.vertical, 2)
                 .background(
                     Capsule()
-                        .fill((session.running ? PanelPalette.success : PanelPalette.secondaryText).opacity(0.25))
+                        .fill(statusTint.opacity(0.25))
                 )
         }
         .padding(.vertical, 7)
@@ -848,10 +873,27 @@ private struct SessionRow: View {
         .hoverRowBackground()
     }
 
-    private var statusLabel: String {
-        if session.running {
-            return session.connectedClients > 0 ? "\(session.connectedClients) connected" : "Running"
+    private var status: SessionSelectionStatus {
+        session.selectionStatus(currentSessionId: currentSessionId)
+    }
+
+    private var statusTint: Color {
+        switch status {
+        case .active: return PanelPalette.warning
+        case .on: return PanelPalette.success
+        case .off: return PanelPalette.secondaryText
         }
-        return "Stopped"
+    }
+
+    private var statusIcon: String {
+        switch status {
+        case .active: return "waveform.and.mic"
+        case .on: return "bolt.fill"
+        case .off: return "moon.zzz"
+        }
+    }
+
+    private var statusLabel: String {
+        status.label
     }
 }

--- a/server/README.md
+++ b/server/README.md
@@ -91,7 +91,7 @@ It implements:
 
 - `initialize` — returns runtime catalog, default runtime, env-offer extension capability
 - `session/list` — legacy/unbound-only session list (REST is preferred)
-- `session/new` — creates session for a chosen runtime via `_meta.runtimeId` and `_meta.title` (unbound websocket only)
+- `session/new` — creates session for a chosen runtime via `_meta.runtimeId` and `_meta.title` on an unbound websocket; on success that same websocket becomes bound to the new public session
 - `session/load`, `session/resume` — loads an existing session; replay is requester-private, not broadcast to all watchers
 - `session/prompt`, `session/cancel` — standard prompt flow
 - `session/set_mode`, `session/set_config_option` — ACP controls

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -16,7 +16,7 @@
         "dotenv": "^17.4.2",
         "fastify": "^5.6.2",
         "h3-js": "^4.4.0",
-        "pi-acp": "github:arcturus-labs/pi-acp#5bd448f",
+        "pi-acp": "^0.0.32",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
         "react-markdown": "^10.1.0",
@@ -101,9 +101,9 @@
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.12.0.tgz",
-      "integrity": "sha512-V8uH/KK1t7utqyJmTA7y7DzKu6+jKFIXM+ZVouz8E55j8Ej2RV42rEvPKn3/PpBJlliI5crcGk1qQhZ7VwaepA==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.26.0.tgz",
+      "integrity": "sha512-ialrcI+RzKOYe+fw+TfpyTdRmEoqIkXLlwbTi6XgaXXfdhNcdod7TmE1VsTnG3yTlox8TMTSMQgWbLLbz3r86Q==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -5284,11 +5284,12 @@
       "license": "MIT"
     },
     "node_modules/pi-acp": {
-      "version": "0.0.28",
-      "resolved": "git+ssh://git@github.com/arcturus-labs/pi-acp.git#5bd448f65b8a22443be4ee47439b1c5f0a10e052",
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/pi-acp/-/pi-acp-0.0.32.tgz",
+      "integrity": "sha512-2/0dfoVhkDTHDQ0R8wwb1ykwlSJm46VEoUyMllzc9hNbEuzUleZXqUwzGScf6+GvepU/4qA4v7hRgGTLgFp5Mw==",
       "license": "MIT",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.12.0",
+        "@agentclientprotocol/sdk": "^0.26.0",
         "zod": "^3.25.0"
       },
       "bin": {

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
     "dotenv": "^17.4.2",
     "fastify": "^5.6.2",
     "h3-js": "^4.4.0",
-    "pi-acp": "github:arcturus-labs/pi-acp#5bd448f",
+    "pi-acp": "^0.0.32",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",

--- a/server/src/server/acpFacade.test.ts
+++ b/server/src/server/acpFacade.test.ts
@@ -73,7 +73,7 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
     ws.close();
   });
 
-  it("creates, loads, prompts, and closes a session", async () => {
+  it("creates, prompts, and closes a session on the same websocket", async () => {
     const ws = await connect();
     await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
 
@@ -85,7 +85,7 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
     const sessionId = created.sessionId as string;
     expect(typeof sessionId).toBe("string");
 
-    await request(ws, 3, "session/load", { sessionId });
+    await expect(request(ws, 3, "session/list", {})).rejects.toThrow("session/list is not available on a session-bound websocket");
 
     const promptResult = await request(ws, 4, "session/prompt", {
       sessionId,
@@ -111,7 +111,6 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
       _meta: { runtimeId: "MockAcpAgent", title: "cancel-test" },
     });
     const sessionId = created.sessionId as string;
-    await request(ws, 3, "session/load", { sessionId });
 
     send(ws, 4, "session/prompt", {
       sessionId,
@@ -151,19 +150,23 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
   });
 
   it("binds a websocket to one session and rejects cross-session use", async () => {
-    const control = await connect();
-    await request(control, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
-    const a = await request(control, 2, "session/new", {
+    const controlA = await connect();
+    await request(controlA, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    const a = await request(controlA, 2, "session/new", {
       cwd: "/tmp",
       mcpServers: [],
       _meta: { runtimeId: "MockAcpAgent", title: "bound-a" },
     });
-    const b = await request(control, 3, "session/new", {
+    controlA.close();
+
+    const controlB = await connect();
+    await request(controlB, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    const b = await request(controlB, 2, "session/new", {
       cwd: "/tmp",
       mcpServers: [],
       _meta: { runtimeId: "MockAcpAgent", title: "bound-b" },
     });
-    control.close();
+    controlB.close();
 
     const ws = await connect(`/api/ws?sessionId=${a.sessionId}`);
     await request(ws, 4, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
@@ -184,7 +187,6 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
       _meta: { runtimeId: "MockAcpAgent", title: "private-replay" },
     });
     const sessionId = created.sessionId as string;
-    await request(creator, 3, "session/load", { sessionId });
     await request(creator, 4, "session/prompt", {
       sessionId,
       prompt: [{ type: "text", text: "tell me a joke" }],
@@ -215,7 +217,6 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
       _meta: { runtimeId: "MockAcpAgent", title: "zero-viewers" },
     });
     const sessionId = created.sessionId as string;
-    await request(ws, 3, "session/load", { sessionId });
     send(ws, 4, "session/prompt", {
       sessionId,
       prompt: [{ type: "text", text: "run a long task" }],
@@ -237,19 +238,23 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
   });
 
   it("isolates updates between two simultaneously running sessions", async () => {
-    const control = await connect();
-    await request(control, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "control" } });
-    const a = await request(control, 2, "session/new", {
+    const controlA = await connect();
+    await request(controlA, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "control-a" } });
+    const a = await request(controlA, 2, "session/new", {
       cwd: "/tmp",
       mcpServers: [],
       _meta: { runtimeId: "MockAcpAgent", title: "iso-a" },
     });
-    const b = await request(control, 3, "session/new", {
+    controlA.close();
+
+    const controlB = await connect();
+    await request(controlB, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "control-b" } });
+    const b = await request(controlB, 2, "session/new", {
       cwd: "/tmp",
       mcpServers: [],
       _meta: { runtimeId: "MockAcpAgent", title: "iso-b" },
     });
-    control.close();
+    controlB.close();
 
     const watcherA = await connect(`/api/ws?sessionId=${a.sessionId}`);
     const watcherB = await connect(`/api/ws?sessionId=${b.sessionId}`);
@@ -268,22 +273,22 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
   });
 
   it("lists sessions via REST /api/sessions", async () => {
-    const ws = await connect();
-    await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
-
-    // Create two sessions
-    const a = await request(ws, 2, "session/new", {
+    const wsA = await connect();
+    await request(wsA, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test-a" } });
+    await request(wsA, 2, "session/new", {
       cwd: "/tmp",
       mcpServers: [],
       _meta: { runtimeId: "MockAcpAgent", title: "rest-test-a" },
     });
-    const b = await request(ws, 3, "session/new", {
+
+    const wsB = await connect();
+    await request(wsB, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test-b" } });
+    await request(wsB, 2, "session/new", {
       cwd: "/tmp",
       mcpServers: [],
       _meta: { runtimeId: "MockAcpAgent", title: "rest-test-b" },
     });
 
-    // Fetch via REST
     const response = await fetch(`http://127.0.0.1:${PORT}/api/sessions`);
     expect(response.status).toBe(200);
     const body = await response.json() as { sessions: Array<Record<string, unknown>> };
@@ -293,12 +298,12 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
     expect(titles).toContain("rest-test-a");
     expect(titles).toContain("rest-test-b");
 
-    // running should be true for sessions with active runtimes
     const sessionA = body.sessions.find((s) => s.title === "rest-test-a")!;
     expect(sessionA.running).toBe(true);
     expect(sessionA._meta).toBeDefined();
     expect((sessionA._meta as Record<string, unknown>).runtimeId).toBe("MockAcpAgent");
 
-    ws.close();
+    wsA.close();
+    wsB.close();
   });
 });

--- a/server/src/server/index.ts
+++ b/server/src/server/index.ts
@@ -98,7 +98,7 @@ export async function buildServer(options: BuildServerOptions = {}) {
   const locationRegistrar = new LocationRegistrar(environmentManager, locationContextRepository);
   const sessionRepository = new SqliteSessionRepository(datastore);
   const transcriptStore = new SessionTranscriptStore(datastore);
-  const runtimeManager = new AgentRuntimeManager(loadAgentRuntimes(), sessionRepository, REPO_ROOT, environmentManager, transcriptStore);
+  const runtimeManager = new AgentRuntimeManager(loadAgentRuntimes(), sessionRepository, REPO_ROOT, environmentManager, transcriptStore, app.log);
   await app.register(websocket);
 
   app.addHook("onRequest", async (request, reply) => {

--- a/server/src/server/routes/acpFacadeRoute.ts
+++ b/server/src/server/routes/acpFacadeRoute.ts
@@ -116,7 +116,7 @@ async function handleMessage(
         if (!runtimeId) throw new Error("No configured runtimes are available");
         const title = typeof meta?.title === "string" && meta.title.trim() ? meta.title.trim() : "session";
         const record = await runtimes.createSession(runtimeId, withoutMeta(params), title);
-        subscribe(record.sessionId);
+        binding.bindSessionId(record.sessionId);
         send(success(requestId!, { sessionId: record.sessionId }));
         return;
       }

--- a/server/src/server/runtime/SessionRuntime.ts
+++ b/server/src/server/runtime/SessionRuntime.ts
@@ -42,17 +42,19 @@ export class SessionRuntime {
   private readonly decoder = new StringDecoder("utf8");
   private buffered = "";
   private requestIndex = 0;
+  private readonly timingLogsEnabled = process.env.ROOK_SESSION_TIMING_LOGS === "1";
 
   constructor(
     readonly profile: AgentRuntimeProfile,
     private readonly repoRoot: string,
     private readonly launchPlanner: RuntimeLaunchPlanner,
     readonly configuration: SessionRuntimeConfiguration = emptyConfiguration(),
+    private readonly logger: { info: (obj: Record<string, unknown>, msg?: string) => void; error?: (obj: Record<string, unknown>, msg?: string) => void } = console,
   ) {}
 
   /** Builds an unstarted replacement carrying new session-only environment state. */
   replacement(configuration: SessionRuntimeConfiguration): SessionRuntime {
-    return new SessionRuntime(this.profile, this.repoRoot, this.launchPlanner, configuration);
+    return new SessionRuntime(this.profile, this.repoRoot, this.launchPlanner, configuration, this.logger);
   }
 
   async initialize(): Promise<void> {
@@ -94,6 +96,13 @@ export class SessionRuntime {
 
   private async start(): Promise<void> {
     const plan = this.launchPlanner(this.profile, this.repoRoot, this.configuration);
+    const startedAt = performance.now();
+    this.timingLog("runtime_start_begin", {
+      runtimeId: this.profile.id,
+      command: plan.command,
+      args: plan.args,
+      cwd: plan.cwd,
+    });
     const child = spawn(plan.command, plan.args, {
       cwd: plan.cwd,
       env: { ...process.env, ...(plan.env ?? {}) },
@@ -120,6 +129,10 @@ export class SessionRuntime {
       protocolVersion: 1,
       clientCapabilities: {},
       clientInfo: { name: "rook-server", title: "Rook", version: "0.1.0" },
+    });
+    this.timingLog("runtime_start_complete", {
+      runtimeId: this.profile.id,
+      elapsedMs: Math.round((performance.now() - startedAt) * 100) / 100,
     });
   }
 
@@ -181,6 +194,11 @@ export class SessionRuntime {
   private rejectPending(error: Error): void {
     for (const request of this.pending.values()) request.reject(error);
     this.pending.clear();
+  }
+
+  private timingLog(event: string, details: Record<string, unknown>): void {
+    if (!this.timingLogsEnabled) return;
+    this.logger.info({ component: "SessionRuntime", event, ...details }, "session timing");
   }
 }
 

--- a/server/src/server/services/AgentRuntimeManager.ts
+++ b/server/src/server/services/AgentRuntimeManager.ts
@@ -26,6 +26,7 @@ export class AgentRuntimeManager {
   private readonly privateReplayTargets = new Map<string, Set<RuntimeNotification>>();
   private readonly privateReplayIdleTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly privateReplayWaiters = new Map<string, Set<() => void>>();
+  private readonly timingLogsEnabled = process.env.ROOK_SESSION_TIMING_LOGS === "1";
 
   constructor(
     profiles: AgentRuntimeProfile[],
@@ -33,6 +34,7 @@ export class AgentRuntimeManager {
     private readonly repoRoot: string,
     private readonly environmentManager?: EnvironmentManager,
     private readonly transcriptStore?: SessionTranscriptStore,
+    private readonly logger: { info: (obj: Record<string, unknown>, msg?: string) => void } = console,
   ) {
     this.profilesById = new Map(profiles.map((profile) => [profile.id, profile]));
   }
@@ -62,8 +64,11 @@ export class AgentRuntimeManager {
   }
 
   async createSession(runtimeId: string, params: JsonObject, title: string): Promise<SessionRecord> {
+    const startedAt = performance.now();
     const profile = this.requireProfile(runtimeId);
+    this.timingLog("create_session_begin", { runtimeId, title, cwd: typeof params.cwd === "string" ? params.cwd : this.repoRoot });
     const runtime = this.createSessionRuntime(profile);
+    const beforeRuntimeSessionNew = performance.now();
     const result = await runtime.request("session/new", runtimeSessionParams(profile, params, runtime.configuration));
     const runtimeSessionId = sessionIdFromResult(result);
     const now = new Date().toISOString();
@@ -79,10 +84,18 @@ export class AgentRuntimeManager {
     await this.sessions.save(record);
     this.attachSessionRuntime(record.sessionId, runtime);
     this.subscribeToEnvironments(record.sessionId);
+    this.timingLog("create_session_complete", {
+      runtimeId,
+      sessionId: record.sessionId,
+      runtimeSessionId,
+      runtimeSessionNewMs: roundMs(performance.now() - beforeRuntimeSessionNew),
+      totalMs: roundMs(performance.now() - startedAt),
+    });
     return record;
   }
 
   async requestForSession(sessionId: string, method: string, params: JsonObject, options: { privateReplayListener?: RuntimeNotification } = {}): Promise<unknown> {
+    const startedAt = performance.now();
     const record = await this.requireSession(sessionId);
     await this.restoreEnvironmentMembership(record);
     const runtime = this.runtimeFor(record);
@@ -99,11 +112,24 @@ export class AgentRuntimeManager {
         await this.transcriptStore?.append(sessionId, runCompletedEvent(stopReason));
       }
       await this.sessions.touch(sessionId);
+      this.timingLog("request_complete", {
+        method,
+        sessionId,
+        runtimeId: record.runtimeId,
+        elapsedMs: roundMs(performance.now() - startedAt),
+      });
       return rewriteResultSessionId(record, result);
     } catch (error) {
       if (method === "session/prompt") {
         await this.transcriptStore?.append(sessionId, runFailedEvent(error instanceof Error ? error.message : String(error)));
       }
+      this.timingLog("request_failed", {
+        method,
+        sessionId,
+        runtimeId: record.runtimeId,
+        elapsedMs: roundMs(performance.now() - startedAt),
+        error: error instanceof Error ? error.message : String(error),
+      });
       throw error;
     } finally {
       if (privateReplay) await this.endPrivateReplayAfterQuiet(sessionId);
@@ -229,7 +255,7 @@ export class AgentRuntimeManager {
   }
 
   private createSessionRuntime(profile: AgentRuntimeProfile): SessionRuntime {
-    return new SessionRuntime(profile, this.repoRoot, runtimeLaunchPlan);
+    return new SessionRuntime(profile, this.repoRoot, runtimeLaunchPlan, undefined, this.logger);
   }
 
   private attachSessionRuntime(sessionId: string, runtime: SessionRuntime): void {
@@ -396,6 +422,15 @@ export class AgentRuntimeManager {
     if (!record) throw new Error(`Unknown session: ${sessionId}`);
     return record;
   }
+
+  private timingLog(event: string, details: Record<string, unknown>): void {
+    if (!this.timingLogsEnabled) return;
+    this.logger.info({ component: "AgentRuntimeManager", event, ...details }, "session timing");
+  }
+}
+
+function roundMs(value: number): number {
+  return Math.round(value * 100) / 100;
 }
 
 function sessionIdFromResult(value: unknown): string {


### PR DESCRIPTION
## Summary
This updates Rook's new-session flow so a client can create a session on an unbound ACP websocket and keep using that same socket after `session/new` succeeds. It removes the client-side bootstrap/reconnect dance, updates the session architecture docs to reflect the simpler binding model, and upgrades `pi-acp` to `0.0.32`, which materially improves Pi session startup time. It also adds timing logs so we can measure where session startup latency is coming from in the server and Mac client.

## Problem / context
New session creation was doing extra choreography on the client side: create on one websocket, throw it away, reconnect on a second websocket, and perform redundant `session/load` steps. That was a poor fit for a multi-client architecture because every client had to know the same workaround. At the same time, real Pi-backed sessions still felt much slower than expected, so we needed better visibility into startup timing and a current `pi-acp` baseline.

## Why this matters
This makes the session model cleaner and more portable across Mac, iPhone, Android, and CLI clients: `session/new` now behaves like a proper session bootstrap that hands back a public Rook session id and leaves the connection ready to use. It also reduces user-visible startup latency and gives us structured timing data so we can distinguish Rook overhead from Pi / `pi-acp` overhead.

## Approaches considered
| Option | Summary | Why not (or chosen) |
|--------|---------|---------------------|
| Keep the current bootstrap/reconnect pattern | Let each client keep creating on one socket and chatting on another | Rejected because it bakes a Rook-specific trick into every client and adds redundant loads/reconnects |
| Add a REST `POST /api/session` entry point | Move runtime selection / session creation out of client ACP entirely | Still interesting, but not chosen here because the existing ACP `session/new` flow can support one-socket creation without inventing a second control path |
| Bind the same websocket after `session/new` | Let the server transition an unbound socket into a session-bound socket after creation | Chosen because it simplifies clients while preserving the ACP-shaped creation flow |

## Decision / approach taken
Use the existing ACP `session/new` flow as the session bootstrap, and have the server bind the same websocket to the newly created public Rook session when creation succeeds.

- The ACP facade now binds an unbound websocket after successful `session/new` and treats later requests on that socket as session-bound.
- The CLI, Apple clients, and Android client stop doing the immediate extra `session/load` / reconnect handoff after `session/new`.
- The repo now depends on `pi-acp@0.0.32`, which substantially improves Pi session creation time in shell timing tests.
- Structured timing logs were added on the server and Mac client so session startup latency can be measured without ad hoc print debugging.

## Product specification alignment
**Classification:** Extends

**Related PRODUCT/ docs:**
- [`PRODUCT/agent-client-protocol.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/PRODUCT/agent-client-protocol.md) — keeps the client/server boundary ACP-shaped while reducing Rook-specific client ceremony
- [`PRODUCT/goals-of-rook.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/PRODUCT/goals-of-rook.md) — supports the bring-your-own-agent and multi-surface goals by making session startup less client-specific
- [`PRODUCT/relationship-between-sessions-and-environments.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/PRODUCT/relationship-between-sessions-and-environments.md) — preserves the model of a public Rook session id that sessions and environment membership hang off of

**Documentation updates in this PR:**
- No PRODUCT/ updates — this changes session bootstrapping mechanics and performance instrumentation, but does not change the high-level product model described in PRODUCT/

**Notes:** This keeps open the future option of moving creation to REST (`POST /api/session`) if we later decide runtime selection should be outside ACP.

## Architecture alignment
**Classification:** Modifies

**Related docs / patterns:**
- [`AS-BUILT-ARCHITECTURE/server.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/AS-BUILT-ARCHITECTURE/server.md) — websocket binding semantics and session creation flow changed
- [`AS-BUILT-ARCHITECTURE/mac-client.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/AS-BUILT-ARCHITECTURE/mac-client.md) — new-session flow no longer uses a temporary socket handoff
- [`AS-BUILT-ARCHITECTURE/iphone-client.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/AS-BUILT-ARCHITECTURE/iphone-client.md) — same one-socket creation pattern as Mac
- [`AS-BUILT-ARCHITECTURE/rookkit.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/AS-BUILT-ARCHITECTURE/rookkit.md) — shared socket/client description now reflects optional unbound creation followed by bound use
- [`server/README.md`](zed://file//Users/johnberryman/projects/github/rookkeeper/_worktrees/issue-99-session-create/server/README.md) — ACP websocket behavior updated

**Documentation updates in this PR:**
- [x] `AS-BUILT-ARCHITECTURE/server.md` — document post-`session/new` websocket binding
- [x] `AS-BUILT-ARCHITECTURE/mac-client.md` — document one-socket new-session flow
- [x] `AS-BUILT-ARCHITECTURE/iphone-client.md` — document one-socket new-session flow
- [x] `AS-BUILT-ARCHITECTURE/rookkit.md` — document shared socket semantics
- [x] `server/README.md`, `clients/mac/README.md`, `clients/iphone/README.md`, `clients/cli/README.md`, `README.md` — refresh client/server workflow descriptions

**Notes:** Public↔runtime session id translation is unchanged; this PR changes socket binding and client flow, not the core session mapping model.

## High-level technical footprint
- **Components:** ACP facade route, `AgentRuntimeManager`, `SessionRuntime`, shared `AcpSocket` / `SessionHandle`, Mac/iPhone/Android/CLI session-start flows
- **APIs / protocols:** ACP `session/new` now leaves the same websocket bound to the created public session; `pi-acp` dependency bumped to `0.0.32`
- **Data / events:** No schema change; structured timing log events added for runtime startup and session request timing

## Test plan
- [x] `cd server && npm test -- src/server/acpFacade.test.ts`
- [x] `cd clients/RookKit && swift test`
- [x] `xcodebuild -project clients/mac/Rook.xcodeproj -scheme Rook -sdk macosx -configuration Debug build`
- [x] `xcodebuild -project clients/iphone/Rook.xcodeproj -scheme Rook -sdk iphonesimulator -configuration Debug build`
- [x] Shell timing check against `pi-acp@0.0.32` confirmed materially better `session/new` / `session/load` times than the previously pinned fork
- [ ] Android compile (not run locally because this machine does not currently have a Java runtime)
