### PR TITLE
Simplify environment registration and local context detection

### DIFF
--- a/AS-BUILT-ARCHITECTURE/android-client.md
+++ b/AS-BUILT-ARCHITECTURE/android-client.md
@@ -23,7 +23,6 @@ The Android client is a native Kotlin + Jetpack Compose app that mirrors the iPh
   - persisted place/suggestion state
 - Compose UI screens
   - agent picker, chat, settings, places, environments, environment offer sheet
-  - `EnvironmentsScreen` mirrors the Apple behavior by suppressing URL-like secondary `sourceName` rows for `web:` environments
 
 ## Main interfaces
 

--- a/AS-BUILT-ARCHITECTURE/iphone-client.md
+++ b/AS-BUILT-ARCHITECTURE/iphone-client.md
@@ -60,7 +60,6 @@ Same shared contract as other clients:
 - `blocks: [ChatBlock]`
 - pending environment offer
 - environment list items
-  - `EnvironmentsScreen` uses `EnvironmentListPresentation.shouldDisplaySourceName(...)` so web rows no longer show the raw page URL as a secondary label
 - current place name / `placeEnvironmentId`
 - `placeSkillStatus[slug] -> Bool`
 - `nearbyCandidates: [EnvironmentCandidate]`

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -19,7 +19,6 @@ The macOS client is a native SwiftUI menu bar app with a regular app window. It 
   - proxies current-session UI state from the active handle
 - `EnvironmentsDetailView`
   - renders the environment-memory list
-  - uses `RookKit.EnvironmentListPresentation` for shared presentation rules, including hiding raw URL `sourceName` rows for `web:` environments
 - `AcpSocket` and `RookAPI` from `RookKit`
   - ACP WebSocket transport and REST client
 - `ForegroundAppMonitor`
@@ -61,7 +60,7 @@ The client derives and registers:
 - `mac:<bundleId>/<context>` for richer app-specific contexts like Obsidian vaults, Slack workspaces/channels, OBS scene collections, Descript projects, and Discord servers/channels
 - exact `dir:/absolute/path` environments from Finder specialist detection of browsed folders
 - `mac:<bundleId>/_plugin/<plugin-id>` for app-specific plugin capabilities such as enabled Obsidian community plugins
-- exact `dir:/absolute/path` directory environments from generic Accessibility document signals
+- meaningful `dir:/absolute/path` project-like or agentic directory environments derived from generic Accessibility document signals
 - hierarchical `web:<host>` and `web:<host>/<path...>` IDs from generic Accessibility web/document signals
 
 ## Core data schemas
@@ -117,7 +116,7 @@ Via `RookKit`:
 1. `ForegroundAppMonitor` detects app activation or window-title change
 2. `AppEnvironmentProvider` always emits the base `mac:<bundleId>` app environment after a short dwell delay
 3. `AppEnvironmentProvider` activates either a bundle-id-specific specialist or the generic fallback provider
-4. `GenericEnvironmentProvider` polls every 5 seconds while active, reads Accessibility document and web signals, and emits `dir:` / `web:` candidates only when the normalized environment-id set is stable across two polls
+4. `GenericEnvironmentProvider` polls every 5 seconds while active, reads Accessibility document and web signals, inspects observed paths under `/Users/<username>`, and emits only project-like / agentic `dir:` candidates plus `web:` candidates when the normalized environment-id set is stable across two polls
 5. Specialist providers are selected by bundle-id from an explicit registry and currently include Obsidian, Slack, OBS Studio, Descript, Discord, and Finder
 6. `ObsidianEnvironmentProvider` polls local data every 5 seconds, reads `~/Library/Application Support/obsidian/obsidian.json`, emits open vault environments, and emits enabled community-plugin environments
 7. `SlackEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits workspace plus channel environments when the title exposes a stable channel context

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -28,7 +28,6 @@
   - iOS-only shared ActivityKit attributes
 - support utilities
   - `KeychainStore`, `EnvironmentListPresentation`, `ToolPayloadFormatting`, `Clipboard`
-    - `EnvironmentListPresentation` now owns shared environment-list presentation rules used by Apple clients, including whether a secondary `sourceName` should be shown (for example, hiding raw URL rows for `web:` environments while still showing useful non-web source context)
 
 ## Main interfaces
 
@@ -54,7 +53,7 @@
 - `sessions()` — session list over REST (replaces the old WebSocket `session/list`)
 - `sessionTranscript(sessionId:)` — normalized transcript hydration for second viewers / running sessions
 - `environmentPreview(environmentId:)`
-- `registerEnvironment(id:sourceName:metadata:)`
+- `registerEnvironment(candidate)`
 - `identifyEnvironments(_:)`
 - `registerLocation(_:)`
 - `decideEnvironment(...)`
@@ -109,7 +108,7 @@
 1. `SessionHandle` (or app-specific reducers around it) constructs `ChatBlock`s from transcript hydration + live ACP events
 2. RookKit design views render the block list consistently across macOS and iOS
 3. markdown/tool payload helpers normalize output for display
-4. `EnvironmentListPresentation` applies shared list-refresh behavior and shared row-level display rules for environment metadata
+4. `EnvironmentListPresentation` applies shared list-refresh behavior for environment metadata
 
 ## Notable architectural characteristics
 

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -132,7 +132,7 @@ Related tables:
   - `skills[]`, `mcpServers[]`, `apps[]`, `errors[]`
 - `EnvironmentBundleOffer`
   - `environmentId`, `bundleId`, `bundleHash`
-  - `displayName`, `sourceName`, `canonicalSourceUrl`
+  - `displayName`
   - `skills[]`, `mcpServers[]`, `apps[]`
 
 ### Location identification
@@ -164,11 +164,12 @@ Related tables:
 7. server rewrites session IDs back to the public ID and forwards live notifications to subscribed watchers of that same session
 
 ### Environment offer and approval
-1. a provider registers an environment with `POST /api/environments/register`
-2. `EnvironmentManager` resolves matching bundles and hashes them
-3. undecided bundles are offered to subscribed sessions
-4. client resolves via REST decision or ACP extension resolution
-5. approved skill paths are attached to that session's launch configuration
+1. a provider registers an environment candidate with `POST /api/environments/register`
+2. the server finalizes it asynchronously, checking exact ids plus observed-path / observed-URL implied ids through `EnvironmentRepository`
+3. finalized environments resolve matching bundles and hash them
+4. undecided bundles are offered to subscribed sessions when that session enters the finalized environment
+5. client resolves via REST decision or ACP extension resolution
+6. approved skill paths are attached to that session's launch configuration
 
 ### Environment-driven runtime restart
 1. session enters or exits an environment

--- a/PRODUCT/environment-local-authoring.md
+++ b/PRODUCT/environment-local-authoring.md
@@ -28,7 +28,7 @@ When you enter an environment, Rook's system message is extended with three sect
 
 **2. Authoring instructions.** For each entered environment, Rook sees the exact paths where it can write skills, AGENTS.md, and MCP servers. It also sees what skills already exist.
 
-**3. Environment metadata.** Each entered environment dumps its metadata (app name, URL, window title, latitude/longitude, etc.) so Rook has context for what you're doing.
+**3. Environment metadata.** Each entered environment dumps its metadata (display name, app name, observed paths/URLs, window title, latitude/longitude, etc.) so Rook has context for what you're doing.
 
 Because Rook may be in several environments at once, the instructions remind Rook to clarify which environment a skill or instruction belongs to before writing anything.
 

--- a/PRODUCT/relationship-between-environments-skills-and-agent.md
+++ b/PRODUCT/relationship-between-environments-skills-and-agent.md
@@ -15,7 +15,7 @@ Current top-level environment kinds are:
 - `android`
 - `windows`
 
-IDs are hierarchical; narrower IDs may imply broader ones (`web:reddit.com/r/foo` ⊂ `web:reddit.com`). Multiple overlapping envs can be active at once. Skills and state can be associated w/ any level of environment.
+Environment ids may still look hierarchical (`web:reddit.com/r/foo`, `dir:/Users/john/...`), but registration and entry are literal. Rook can still use observed paths/URLs to discover other known environments with attached capabilities, but it should not implicitly expand every path segment into an active environment. Multiple overlapping envs can be active at once. Skills and state can be associated w/ any explicit environment id.
 
 For some terminology, there are many "known" environments (ones that are available in an environment repository somewhere). The "available" environments are the ones that the Rook can currently choose to enter (like if you're at Home Depot, then `location:homedepot.com/store-4321` will be available; if you're using Obsidian on the Mac, then `mac:md.obsidian/HomeProjects/ToDos` could be available; if you're browsing the Rook repo in Finder, then `dir:/Users/johnberryman/projects/github/rookkeeper/rook` could be available). And an environment is "entered" if the current session has loaded its skills and is accepting its state changes. (Though it is also possible to request to enter environments that aren't available - like if you want the Rook to know how to navigate a Home Depot even though you're not there. Implementation and UX TBD)
 
@@ -48,7 +48,7 @@ And environment repository needs to be searchable so that you can find environme
 
 Runtime coordinator that serves as a connection between Rook agents, the environments, and the skills. It also remembers skill choices.
 
-When a new environment becomes available, then the environment manager offers it to the running agents (which are currently represented as SessionRooms - but this might change). And the user can review the skills of that environment and "allow once", "allow always", "reject", "ignore".
+When a new environment candidate becomes available, the environment manager can finalize it into one or more real environments by checking known repository-backed capabilities (including exact ids plus path/url-implied known environments). Then the user can review the skills of any finalized environment and "allow once", "allow always", "reject", "ignore".
 
 - If "allow once" or "allow always", the skills are injected into the running session.
 - If "reject" or "ignore", then the skills are not injected.

--- a/PRODUCT/relationship-between-sessions-and-environments.md
+++ b/PRODUCT/relationship-between-sessions-and-environments.md
@@ -24,7 +24,7 @@ This means:
 The product doc previously considered per-session decisions to avoid cross-contamination (e.g., Lowe's skills leaking into a coding session). The resolution is:
 
 1. Sessions don't auto-enter environments from mere availability — they only enter environments the user or agent explicitly joins.
-2. Entering a hierarchical child environment implicitly enters its active parent environments too (for example entering `mac:md.obsidian/Rooknanigans` also enters `mac:md.obsidian`).
+2. Entering an environment is literal — joining `mac:md.obsidian/Rooknanigans` does not implicitly join `mac:md.obsidian`.
 3. The agent can help decide whether to enter an environment based on the current session's context.
 4. The UI provides affordances to see and manage which environments are active for a session.
 

--- a/clients/RookKit/Sources/RookKit/EnvironmentListPresentation.swift
+++ b/clients/RookKit/Sources/RookKit/EnvironmentListPresentation.swift
@@ -37,12 +37,4 @@ public enum EnvironmentListPresentation {
         }
     }
 
-    public static func shouldDisplaySourceName(for item: EnvironmentListItem) -> Bool {
-        guard let sourceName = item.sourceName,
-              sourceName != item.displayName,
-              sourceName != item.environmentId else { return false }
-        if item.environmentId.hasPrefix("web:") { return false }
-        let lower = sourceName.lowercased()
-        return !(lower.hasPrefix("http://") || lower.hasPrefix("https://"))
-    }
 }

--- a/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
@@ -275,19 +275,15 @@ public struct EnvironmentOffer: Equatable {
     public let displayName: String?
     public let bundleId: String
     public let bundleHash: String
-    public let sourceName: String?
-    public let canonicalSourceUrl: String?
     public let skills: [String]
     public let mcpServers: [String]
     public let apps: [String]
 
-    public init(environmentId: String, displayName: String?, bundleId: String, bundleHash: String, sourceName: String?, canonicalSourceUrl: String?, skills: [String], mcpServers: [String], apps: [String]) {
+    public init(environmentId: String, displayName: String?, bundleId: String, bundleHash: String, skills: [String], mcpServers: [String], apps: [String]) {
         self.environmentId = environmentId
         self.displayName = displayName
         self.bundleId = bundleId
         self.bundleHash = bundleHash
-        self.sourceName = sourceName
-        self.canonicalSourceUrl = canonicalSourceUrl
         self.skills = skills
         self.mcpServers = mcpServers
         self.apps = apps
@@ -297,7 +293,6 @@ public struct EnvironmentOffer: Equatable {
 public struct EnvironmentListItem: Codable, Equatable, Identifiable {
     public let environmentId: String
     public let displayName: String
-    public let sourceName: String?
     public let status: String
     public let lastTouchedAt: String
     public let entered: Bool
@@ -306,10 +301,9 @@ public struct EnvironmentListItem: Codable, Equatable, Identifiable {
 
     public var id: String { environmentId }
 
-    public init(environmentId: String, displayName: String, sourceName: String?, status: String, lastTouchedAt: String, entered: Bool, bundleCount: Int, approvedBundleCount: Int) {
+    public init(environmentId: String, displayName: String, status: String, lastTouchedAt: String, entered: Bool, bundleCount: Int, approvedBundleCount: Int) {
         self.environmentId = environmentId
         self.displayName = displayName
-        self.sourceName = sourceName
         self.status = status
         self.lastTouchedAt = lastTouchedAt
         self.entered = entered

--- a/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
+++ b/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
@@ -335,8 +335,6 @@ public final class AcpSocket {
             displayName: params["displayName"] as? String,
             bundleId: bundleId,
             bundleHash: bundleHash,
-            sourceName: params["sourceName"] as? String,
-            canonicalSourceUrl: params["canonicalSourceUrl"] as? String,
             skills: params["skills"] as? [String] ?? [],
             mcpServers: params["mcpServers"] as? [String] ?? [],
             apps: params["apps"] as? [String] ?? []

--- a/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
+++ b/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
@@ -181,8 +181,6 @@ final class ApiTypesTests: XCTestCase {
             displayName: "Test Place",
             bundleId: "bundle-1",
             bundleHash: "hash",
-            sourceName: "TestSource",
-            canonicalSourceUrl: "https://example.com",
             skills: ["s1", "s2"],
             mcpServers: ["m1"],
             apps: ["a1"]

--- a/clients/RookKit/Tests/RookKitTests/EnvironmentListPresentationTests.swift
+++ b/clients/RookKit/Tests/RookKitTests/EnvironmentListPresentationTests.swift
@@ -3,48 +3,21 @@ import XCTest
 
 @MainActor
 final class EnvironmentListPresentationTests: XCTestCase {
-    func testShouldDisplaySourceNameHidesWebUrls() {
-        let item = EnvironmentListItem(
-            environmentId: "web:github.com/the-rooks-nest/rook",
-            displayName: "the-rooks-nest / rook",
-            sourceName: "https://github.com/the-rooks-nest/rook",
-            status: "active",
-            lastTouchedAt: "2026-07-23T00:00:00Z",
-            entered: false,
-            bundleCount: 1,
-            approvedBundleCount: 1
-        )
+    func testApplyReplacesItems() {
+        var current: [EnvironmentListItem] = []
+        let refreshed = [
+            EnvironmentListItem(
+                environmentId: "web:github.com/the-rooks-nest/rook",
+                displayName: "rook",
+                status: "active",
+                lastTouchedAt: "2026-07-23T00:00:00Z",
+                entered: false,
+                bundleCount: 1,
+                approvedBundleCount: 1
+            )
+        ]
 
-        XCTAssertFalse(EnvironmentListPresentation.shouldDisplaySourceName(for: item))
-    }
-
-    func testShouldDisplaySourceNameShowsNonWebSourceName() {
-        let item = EnvironmentListItem(
-            environmentId: "mac:md.obsidian/MyVault",
-            displayName: "Obsidian · MyVault",
-            sourceName: "Daily Note - Work Vault - Obsidian",
-            status: "active",
-            lastTouchedAt: "2026-07-23T00:00:00Z",
-            entered: false,
-            bundleCount: 1,
-            approvedBundleCount: 1
-        )
-
-        XCTAssertTrue(EnvironmentListPresentation.shouldDisplaySourceName(for: item))
-    }
-
-    func testShouldDisplaySourceNameHidesDuplicateSourceName() {
-        let item = EnvironmentListItem(
-            environmentId: "mac:md.obsidian/MyVault",
-            displayName: "Obsidian",
-            sourceName: "Obsidian",
-            status: "active",
-            lastTouchedAt: "2026-07-23T00:00:00Z",
-            entered: false,
-            bundleCount: 1,
-            approvedBundleCount: 1
-        )
-
-        XCTAssertFalse(EnvironmentListPresentation.shouldDisplaySourceName(for: item))
+        EnvironmentListPresentation.apply(refreshed, to: &current)
+        XCTAssertEqual(current, refreshed)
     }
 }

--- a/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
@@ -842,7 +842,7 @@ class RookViewModel(
                 put("latitude", place.latitude)
                 put("longitude", place.longitude)
                 put("radiusMeters", place.radius)
-                put("sourceName", place.name)
+                put("displayName", place.name)
             }
             runCatching { api.registerEnvironment(CandidateEnvironmentRecord(envId, metadata)) }
         }
@@ -858,7 +858,7 @@ class RookViewModel(
                 put("latitude", place.latitude)
                 put("longitude", place.longitude)
                 put("radiusMeters", place.radius)
-                put("sourceName", place.name)
+                put("displayName", place.name)
             }
             runCatching { api.registerEnvironment(CandidateEnvironmentRecord(envId, metadata)) }
         }

--- a/clients/android/app/src/main/java/com/rookery/rook/model/ApiTypes.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/model/ApiTypes.kt
@@ -151,8 +151,6 @@ data class EnvironmentOffer(
     val displayName: String?,
     val bundleId: String,
     val bundleHash: String,
-    val sourceName: String?,
-    val canonicalSourceUrl: String?,
     val skills: List<String>,
     val mcpServers: List<String>,
     val apps: List<String>
@@ -163,7 +161,6 @@ data class EnvironmentOffer(
 data class EnvironmentListItem(
     val environmentId: String,
     val displayName: String,
-    val sourceName: String? = null,
     val status: String,
     val lastTouchedAt: String,
     val entered: Boolean,

--- a/clients/android/app/src/main/java/com/rookery/rook/net/AcpSocket.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/net/AcpSocket.kt
@@ -344,7 +344,7 @@ class AcpSocket(
             val bundleId = params?.get("bundleId")?.stringValue
             val bundleHash = params?.get("bundleHash")?.stringValue
             if (params != null && environmentId != null && bundleId != null && bundleHash != null) {
-                emit(AcpClientEvent.EnvironmentOffered(EnvironmentOffer(environmentId, params["displayName"]?.stringValue, bundleId, bundleHash, params["sourceName"]?.stringValue, params["canonicalSourceUrl"]?.stringValue, stringList(params["skills"]), stringList(params["mcpServers"]), stringList(params["apps"]))))
+                emit(AcpClientEvent.EnvironmentOffered(EnvironmentOffer(environmentId, params["displayName"]?.stringValue, bundleId, bundleHash, stringList(params["skills"]), stringList(params["mcpServers"]), stringList(params["apps"]))))
                 return
             }
         }
@@ -514,8 +514,6 @@ class AcpSocket(
                             displayName = payload["displayName"]?.stringValue,
                             bundleId = bundleId,
                             bundleHash = bundleHash,
-                            sourceName = payload["sourceName"]?.stringValue,
-                            canonicalSourceUrl = payload["canonicalSourceUrl"]?.stringValue,
                             skills = stringList(payload["skills"]),
                             mcpServers = stringList(payload["mcpServers"]),
                             apps = stringList(payload["apps"])

--- a/clients/android/app/src/main/java/com/rookery/rook/ui/EnvironmentOfferSheet.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/ui/EnvironmentOfferSheet.kt
@@ -45,7 +45,7 @@ fun EnvironmentOfferSheet(viewModel: RookViewModel) {
                 }
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
                     Text(
-                        text = current.displayName ?: current.sourceName ?: current.environmentId,
+                        text = current.displayName ?: current.environmentId,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.SemiBold,
                         color = PanelPalette.textNormal
@@ -61,13 +61,6 @@ fun EnvironmentOfferSheet(viewModel: RookViewModel) {
                         fontFamily = FontFamily.Monospace,
                         color = PanelPalette.textMuted
                     )
-                    if (current.sourceName != null && current.sourceName != current.displayName && current.sourceName != current.environmentId) {
-                        Text(
-                            text = current.sourceName,
-                            fontSize = 11.sp,
-                            color = PanelPalette.textMuted
-                        )
-                    }
                 }
             }
         }

--- a/clients/android/app/src/main/java/com/rookery/rook/ui/EnvironmentsScreen.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/ui/EnvironmentsScreen.kt
@@ -27,14 +27,6 @@ import com.rookery.rook.ui.chat.PanelCard
 import com.rookery.rook.ui.chat.PanelPalette
 import com.rookery.rook.ui.chat.StatusDot
 
-private fun shouldShowSourceName(item: EnvironmentListItem): Boolean {
-    val sourceName = item.sourceName ?: return false
-    if (sourceName == item.displayName || sourceName == item.environmentId) return false
-    if (item.environmentId.startsWith("web:")) return false
-    val lower = sourceName.lowercase()
-    return !lower.startsWith("http://") && !lower.startsWith("https://")
-}
-
 @Composable
 fun EnvironmentsScreen(viewModel: RookViewModel) {
     val loading by viewModel.environmentsLoading.collectAsState()
@@ -73,15 +65,6 @@ private fun EnvironmentRow(item: EnvironmentListItem, viewModel: RookViewModel) 
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                if (shouldShowSourceName(item)) {
-                    Text(
-                        text = item.sourceName.orEmpty(),
-                        fontSize = 11.sp,
-                        color = PanelPalette.textMuted,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                }
                 Text(
                     text = "${if (item.status == "active") "Active" else "Recent"} • ${item.approvedBundleCount}/${item.bundleCount} bundles",
                     fontSize = 11.sp,

--- a/clients/android/app/src/test/java/com/rookery/rook/RookViewModelReduceTest.kt
+++ b/clients/android/app/src/test/java/com/rookery/rook/RookViewModelReduceTest.kt
@@ -136,7 +136,7 @@ class RookViewModelReduceTest {
     // MARK: - Environment reducer branches (location/skills phase)
 
     private fun offer(envId: String, bundleId: String = "b1", hash: String = "hash1") =
-        EnvironmentOffer(envId, "Store", bundleId, hash, "Store", null, emptyList(), emptyList(), emptyList())
+        EnvironmentOffer(envId, "Store", bundleId, hash, emptyList(), emptyList(), emptyList())
 
     @Test
     fun environmentOfferedSetsPendingOfferAndIgnoresDuplicate() {

--- a/clients/android/app/src/test/java/com/rookery/rook/model/ApiTypesSerializationTest.kt
+++ b/clients/android/app/src/test/java/com/rookery/rook/model/ApiTypesSerializationTest.kt
@@ -36,7 +36,7 @@ class ApiTypesSerializationTest {
     }
 
     @Test
-    fun environmentListItemDecodesMissingSourceNameAsNull() {
+    fun environmentListItemDecodesWithoutLegacyFields() {
         val item = json.decodeFromString<EnvironmentListItem>(
             """
             {
@@ -51,7 +51,6 @@ class ApiTypesSerializationTest {
             """.trimIndent()
         )
 
-        assertNull(item.sourceName)
         assertEquals("web:github.com/the-rooks-nest/rook", item.environmentId)
     }
 }

--- a/clients/android/app/src/test/java/com/rookery/rook/net/AcpReduceTest.kt
+++ b/clients/android/app/src/test/java/com/rookery/rook/net/AcpReduceTest.kt
@@ -230,7 +230,6 @@ class AcpReduceTest {
                     put("displayName", "Store")
                     put("bundleId", "bundle-1")
                     put("bundleHash", "hash-1")
-                    put("sourceName", "Store")
                     putJsonArray("skills") { }
                     putJsonArray("mcpServers") { }
                     putJsonArray("apps") { }

--- a/clients/cli/src/commands/environments.mjs
+++ b/clients/cli/src/commands/environments.mjs
@@ -17,8 +17,8 @@ export async function runEnvironmentsCommand(args) {
       const id = env.environmentId || "?";
       const status = env.status || "?";
       const bundles = Array.isArray(env.bundles) ? env.bundles.length : (env.bundleIds?.length ?? 0);
-      const sourceName = env.record?.sourceName || env.info?.sourceName || "";
-      console.log(`${id}  ${status}  bundles:${bundles}  ${sourceName}`);
+      const displayName = env.record?.metadata?.displayName || env.info?.displayName || "";
+      console.log(`${id}  ${status}  bundles:${bundles}  ${displayName}`);
     }
     if (environments.length > limit) console.log(`... and ${environments.length - limit} more (use --limit to adjust)`);
   }

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -354,7 +354,7 @@ final class RookModel: ObservableObject {
                 "latitude": .number(place.latitude),
                 "longitude": .number(place.longitude),
                 "radiusMeters": .number(place.radius),
-                "sourceName": .string(place.name),
+                "displayName": .string(place.name),
             ]
             try? await api.registerEnvironment(CandidateEnvironmentRecord(id: envId, metadata: metadata))
         }
@@ -370,7 +370,7 @@ final class RookModel: ObservableObject {
                 "latitude": .number(place.latitude),
                 "longitude": .number(place.longitude),
                 "radiusMeters": .number(place.radius),
-                "sourceName": .string(place.name),
+                "displayName": .string(place.name),
             ]
             try? await api.registerEnvironment(CandidateEnvironmentRecord(id: envId, metadata: metadata))
         }

--- a/clients/iphone/Sources/Views/EnvironmentOfferSheet.swift
+++ b/clients/iphone/Sources/Views/EnvironmentOfferSheet.swift
@@ -42,7 +42,7 @@ struct EnvironmentOfferSheet: View {
                     .frame(width: 30, height: 30)
                     .background(Circle().fill(PanelPalette.accent.opacity(0.18)))
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(model.pendingOffer?.displayName ?? model.pendingOffer?.sourceName ?? model.pendingOffer?.environmentId ?? "")
+                    Text(model.pendingOffer?.displayName ?? model.pendingOffer?.environmentId ?? "")
                         .font(.headline)
                         .foregroundStyle(PanelPalette.textNormal)
                     Text("wants to load bundle \(model.pendingOffer?.bundleId ?? "") into this session")
@@ -51,13 +51,6 @@ struct EnvironmentOfferSheet: View {
                     if let environmentId = model.pendingOffer?.environmentId {
                         Text(environmentId)
                             .font(.caption2.monospaced())
-                            .foregroundStyle(PanelPalette.textMuted)
-                    }
-                    if let sourceName = model.pendingOffer?.sourceName,
-                       sourceName != model.pendingOffer?.displayName,
-                       sourceName != model.pendingOffer?.environmentId {
-                        Text(sourceName)
-                            .font(.caption2)
                             .foregroundStyle(PanelPalette.textMuted)
                     }
                 }

--- a/clients/iphone/Sources/Views/EnvironmentsScreen.swift
+++ b/clients/iphone/Sources/Views/EnvironmentsScreen.swift
@@ -72,12 +72,6 @@ struct EnvironmentsScreen: View {
                         .font(.caption2.monospaced())
                         .foregroundStyle(PanelPalette.textMuted)
                         .lineLimit(1)
-                    if EnvironmentListPresentation.shouldDisplaySourceName(for: item), let sourceName = item.sourceName {
-                        Text(sourceName)
-                            .font(.caption2)
-                            .foregroundStyle(PanelPalette.textMuted)
-                            .lineLimit(1)
-                    }
                     HStack(spacing: 6) {
                         Text(item.status == "active" ? "Active" : "Recent")
                             .font(.caption2)

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -38,7 +38,7 @@ WebSocket protocol. For repo-level setup, `.env`, binding, and auth, start with
   (`~/Library/Logs/Rook/server.log`).
 - **Mac environment provider** - the app immediately registers newly seen
   user-visible environments, keeps them alive with periodic re-registration,
-  and forgets them locally after 4m45s without renewed user-visible focus.
+  and forgets them locally after 4m45s without renewed user-visible focus. Generic path-derived registration is now conservative: it only emits project-like or agentic `dir:/...` environments under `/Users/<username>` rather than every observed path segment.
 
 ## Voice (hands-free)
 

--- a/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
@@ -116,7 +116,7 @@ final class AppEnvironmentProvider {
 
     private func updateBaseEnvironment(for app: ForegroundApp, title: String?) {
         var metadata = CandidateMetadata.base(app: app, title: title)
-        metadata["sourceName"] = .string(app.name)
+        metadata["displayName"] = .string(app.name)
         let candidate = EnvironmentCandidate(
             id: "mac:\(app.bundleId)",
             metadata: metadata

--- a/clients/mac/Sources/Models/EnvironmentProviders/DescriptEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/DescriptEnvironmentProvider.swift
@@ -95,7 +95,7 @@ final class DescriptEnvironmentProvider: SpecializedEnvironmentProvider {
 
         var metadata = CandidateMetadata.base(app: app, title: title)
         metadata["projectName"] = .string(projectName)
-        metadata["sourceName"] = .string("\(app.name) · \(projectName)")
+        metadata["displayName"] = .string("\(app.name) · \(projectName)")
 
         if let route = focusedRoute(from: configURL) {
             metadata["route"] = .string(route)

--- a/clients/mac/Sources/Models/EnvironmentProviders/DiscordEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/DiscordEnvironmentProvider.swift
@@ -83,12 +83,12 @@ final class DiscordEnvironmentProvider: SpecializedEnvironmentProvider {
         case let .serverChannel(serverName, channelName):
             var serverMetadata = CandidateMetadata.base(app: app, title: title)
             serverMetadata["serverName"] = .string(serverName)
-            serverMetadata["sourceName"] = .string("\(app.name) · \(serverName)")
+            serverMetadata["displayName"] = .string("\(app.name) · \(serverName)")
             let serverId = serverEnvironmentId(bundleId: app.bundleId, serverName: serverName)
 
             var channelMetadata = serverMetadata
             channelMetadata["channelName"] = .string(channelName)
-            channelMetadata["sourceName"] = .string("\(app.name) · \(serverName) · #\(channelName)")
+            channelMetadata["displayName"] = .string("\(app.name) · \(serverName) · #\(channelName)")
             let channelId = channelEnvironmentId(bundleId: app.bundleId, serverName: serverName, channelName: channelName)
 
             return [
@@ -99,7 +99,7 @@ final class DiscordEnvironmentProvider: SpecializedEnvironmentProvider {
         case let .directMessage(name):
             var metadata = CandidateMetadata.base(app: app, title: title)
             metadata["dmName"] = .string(name)
-            metadata["sourceName"] = .string("\(app.name) · \(name)")
+            metadata["displayName"] = .string("\(app.name) · \(name)")
             return [
                 EnvironmentCandidate(
                     id: directMessageEnvironmentId(bundleId: app.bundleId, name: name),

--- a/clients/mac/Sources/Models/EnvironmentProviders/FinderEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/FinderEnvironmentProvider.swift
@@ -92,7 +92,7 @@ final class FinderEnvironmentProvider: SpecializedEnvironmentProvider {
         observation.allDirectoryPaths.map { path in
             var metadata = CandidateMetadata.base(app: app, title: title)
             metadata["directoryPath"] = .string(path)
-            metadata["sourceName"] = .string("\(app.name) · \(displayName(for: path))")
+            metadata["displayName"] = .string("\(app.name) · \(displayName(for: path))")
             if path == observation.currentDirectoryPath {
                 metadata["finderCurrent"] = .bool(true)
             }

--- a/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
@@ -5,6 +5,7 @@ import RookKit
 private struct GenericEnvironmentObservation {
     let candidates: [EnvironmentCandidate]
     let normalizedIds: [String]
+    let deepestDirEnvironmentId: String?
     let deepestWebEnvironmentId: String?
 }
 
@@ -12,6 +13,31 @@ private struct GenericEnvironmentObservation {
 final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     private static let pollInterval: TimeInterval = 5
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.rookery.rook", category: "GenericEnvironmentProvider")
+    private static let fileManager = FileManager.default
+    private static let projectRootFileMarkers = [
+        ".git",
+        "Cargo.toml",
+        "go.mod",
+        "pyproject.toml",
+        "Package.swift",
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        "WORKSPACE",
+        "WORKSPACE.bazel",
+        "MODULE.bazel",
+        "CMakeLists.txt",
+    ]
+    private static let projectRootDirectorySuffixes = [".xcodeproj", ".xcworkspace"]
+    private static let projectRootFileSuffixes = [".sln"]
+    private static let skillDirectoryMarkers = [
+        ".agents/skills",
+        ".claude/skills",
+        ".codex/skills",
+        ".cursor/skills",
+        ".github/skills",
+    ]
+    private static let agentsMdMarker = "AGENTS.md"
 
     let supportedBundleIds: [String] = []
     var onStateChange: (() -> Void)?
@@ -77,6 +103,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         let observation = Self.observation(for: app, title: title)
         defer {
             previousNormalizedIds = observation.normalizedIds
+            currentAppEnvironmentId = observation.deepestDirEnvironmentId
             currentSiteEnvironmentId = observation.deepestWebEnvironmentId
             onStateChange?()
         }
@@ -91,11 +118,15 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         let webURL = AXReader.activeTabURL(pid: app.pid)
         var candidatesById: [String: EnvironmentCandidate] = [:]
         var deepestWebEnvironmentId: String?
+        var deepestDirEnvironmentId: String?
 
         for rawValue in documentValues {
             if let normalizedPath = normalizedAbsolutePath(from: rawValue) {
-                let candidate = directoryCandidate(path: normalizedPath, app: app, title: title, rawValue: rawValue)
-                candidatesById[candidate.id] = candidate
+                let dirCandidates = directoryCandidates(fromObservedPath: normalizedPath, app: app, title: title, rawValue: rawValue)
+                deepestDirEnvironmentId = dirCandidates.last?.id ?? deepestDirEnvironmentId
+                for candidate in dirCandidates {
+                    candidatesById[candidate.id] = candidate
+                }
                 continue
             }
             let webCandidates = webCandidates(from: rawValue, app: app, title: title)
@@ -123,26 +154,87 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         return GenericEnvironmentObservation(
             candidates: candidates,
             normalizedIds: candidates.map(\.id),
+            deepestDirEnvironmentId: deepestDirEnvironmentId,
             deepestWebEnvironmentId: deepestWebEnvironmentId
         )
     }
 
-    private static func directoryCandidate(path: String, app: ForegroundApp, title: String?, rawValue: String) -> EnvironmentCandidate {
-        var metadata = CandidateMetadata.base(app: app, title: title)
-        metadata["directoryPath"] = .string(path)
-        metadata["axDocument"] = .string(rawValue)
-        metadata["sourceName"] = .string(path)
-        return EnvironmentCandidate(id: "dir:\(path)", metadata: metadata)
+    private static func directoryCandidates(fromObservedPath observedPath: String, app: ForegroundApp, title: String?, rawValue: String) -> [EnvironmentCandidate] {
+        let directories = candidateDirectories(forObservedPath: observedPath)
+        return directories.compactMap { directoryPath in
+            let detection = detectDirectorySignals(at: directoryPath)
+            guard detection.isProjectLike || detection.isAgentic else { return nil }
+
+            var metadata = CandidateMetadata.base(app: app, title: title)
+            metadata["directoryPath"] = .string(directoryPath)
+            metadata["axDocument"] = .string(rawValue)
+            metadata["displayName"] = .string((directoryPath as NSString).lastPathComponent)
+            metadata["observedPaths"] = .array([.string(observedPath)])
+            if !detection.detectedSkillPaths.isEmpty {
+                metadata["detectedSkillPaths"] = .array(detection.detectedSkillPaths.map { .string($0) })
+            }
+            if !detection.detectedAgentsMdPaths.isEmpty {
+                metadata["detectedAgentsMdPaths"] = .array(detection.detectedAgentsMdPaths.map { .string($0) })
+            }
+            metadata["editableSkillPath"] = .string(detection.editableSkillPath)
+            metadata["editableAgentMdPath"] = .string(detection.editableAgentMdPath)
+            return EnvironmentCandidate(id: "dir:\(directoryPath)", metadata: metadata)
+        }
     }
 
     private static func webCandidates(from rawURL: String, app: ForegroundApp, title: String?) -> [EnvironmentCandidate] {
         let ids = webEnvironmentIds(from: rawURL)
         guard !ids.isEmpty else { return [] }
-        var metadata = CandidateMetadata.base(app: app, title: title)
-        metadata["url"] = .string(rawURL)
-        metadata["sourceName"] = .string(rawURL)
-        metadata["canonicalSourceUrl"] = .string(rawURL)
-        return ids.map { EnvironmentCandidate(id: $0, metadata: metadata) }
+        return ids.map { environmentId in
+            var metadata = CandidateMetadata.base(app: app, title: title)
+            metadata["url"] = .string(rawURL)
+            metadata["displayName"] = .string(webDisplayName(for: environmentId))
+            metadata["observedUrls"] = .array([.string(rawURL)])
+            return EnvironmentCandidate(id: environmentId, metadata: metadata)
+        }
+    }
+
+    private static func candidateDirectories(forObservedPath observedPath: String) -> [String] {
+        let homeDir = URL(fileURLWithPath: NSHomeDirectory()).standardizedFileURL.path
+        guard observedPath.hasPrefix(homeDir + "/") else { return [] }
+
+        var isDirectory: ObjCBool = false
+        let exists = fileManager.fileExists(atPath: observedPath, isDirectory: &isDirectory)
+        var current = exists && isDirectory.boolValue ? observedPath : (observedPath as NSString).deletingLastPathComponent
+        var result: [String] = []
+        while current.hasPrefix(homeDir + "/") && current != homeDir {
+            result.append(current)
+            let parent = (current as NSString).deletingLastPathComponent
+            if parent == current || parent.count < homeDir.count { break }
+            current = parent
+        }
+        return result.reversed()
+    }
+
+    private static func detectDirectorySignals(at directoryPath: String) -> DirectorySignalDetection {
+        let entries = (try? fileManager.contentsOfDirectory(atPath: directoryPath)) ?? []
+        let entrySet = Set(entries)
+
+        let hasProjectMarker = projectRootFileMarkers.contains(where: entrySet.contains)
+            || projectRootDirectorySuffixes.contains(where: { suffix in entries.contains(where: { $0.hasSuffix(suffix) }) })
+            || projectRootFileSuffixes.contains(where: { suffix in entries.contains(where: { $0.hasSuffix(suffix) }) })
+
+        let detectedAgentsMdPaths = entrySet.contains(agentsMdMarker) ? [directoryPath + "/" + agentsMdMarker] : []
+        let detectedSkillPaths = skillDirectoryMarkers
+            .map { directoryPath + "/" + $0 }
+            .filter { fileManager.fileExists(atPath: $0) }
+
+        let editableSkillPath = detectedSkillPaths.first ?? (directoryPath + "/.agents/skills")
+        let editableAgentMdPath = detectedAgentsMdPaths.first ?? (directoryPath + "/AGENTS.md")
+
+        return DirectorySignalDetection(
+            isProjectLike: hasProjectMarker,
+            isAgentic: !detectedAgentsMdPaths.isEmpty || !detectedSkillPaths.isEmpty,
+            detectedSkillPaths: detectedSkillPaths,
+            detectedAgentsMdPaths: detectedAgentsMdPaths,
+            editableSkillPath: editableSkillPath,
+            editableAgentMdPath: editableAgentMdPath
+        )
     }
 
     static func normalizedAbsolutePath(from rawValue: String) -> String? {
@@ -177,7 +269,24 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         return ids
     }
 
+    private static func webDisplayName(for environmentId: String) -> String {
+        let path = environmentId.replacingOccurrences(of: "web:", with: "")
+        let parts = path.split(separator: "/").map(String.init)
+        guard let first = parts.first else { return environmentId }
+        if parts.count == 1 { return first }
+        return ([first] + parts.dropFirst()).joined(separator: " / ")
+    }
+
     static func warningForNonAbsoluteDirectoryCandidate(rawValue: String, app: ForegroundApp) {
         logger.warning("Skipping non-absolute directory candidate for bundleId=\(app.bundleId, privacy: .public): \(rawValue, privacy: .public)")
     }
+}
+
+private struct DirectorySignalDetection {
+    let isProjectLike: Bool
+    let isAgentic: Bool
+    let detectedSkillPaths: [String]
+    let detectedAgentsMdPaths: [String]
+    let editableSkillPath: String
+    let editableAgentMdPath: String
 }

--- a/clients/mac/Sources/Models/EnvironmentProviders/OBSStudioEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/OBSStudioEnvironmentProvider.swift
@@ -81,7 +81,7 @@ final class OBSStudioEnvironmentProvider: SpecializedEnvironmentProvider {
         var metadata = CandidateMetadata.base(app: app, title: title)
         metadata["sceneCollectionName"] = .string(context.sceneCollectionName)
         metadata["profileName"] = .string(context.profileName)
-        metadata["sourceName"] = .string("\(app.name) · \(context.sceneCollectionName)")
+        metadata["displayName"] = .string("\(app.name) · \(context.sceneCollectionName)")
 
         let sceneCollectionPath = configRoot
             .appendingPathComponent("scenes")

--- a/clients/mac/Sources/Models/EnvironmentProviders/ObsidianEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/ObsidianEnvironmentProvider.swift
@@ -109,7 +109,7 @@ final class ObsidianEnvironmentProvider: SpecializedEnvironmentProvider {
             var vaultMetadata = CandidateMetadata.base(app: app, title: title)
             vaultMetadata["vaultName"] = .string(vaultName)
             vaultMetadata["vaultPath"] = .string(vaultPath)
-            vaultMetadata["sourceName"] = .string("\(app.name) · \(vaultName)")
+            vaultMetadata["displayName"] = .string("\(app.name) · \(vaultName)")
             let vaultCandidate = EnvironmentCandidate(
                 id: "mac:\(app.bundleId)/\(EnvironmentIDEncoding.encodePathComponent(vaultName))",
                 metadata: vaultMetadata
@@ -119,7 +119,7 @@ final class ObsidianEnvironmentProvider: SpecializedEnvironmentProvider {
             for pluginId in enabledCommunityPlugins(vaultPath: vaultPath) {
                 var pluginMetadata = CandidateMetadata.base(app: app, title: title)
                 pluginMetadata["pluginId"] = .string(pluginId)
-                pluginMetadata["sourceName"] = .string("\(app.name) Plugin · \(pluginId)")
+                pluginMetadata["displayName"] = .string("\(app.name) Plugin · \(pluginId)")
                 let pluginCandidate = EnvironmentCandidate(
                     id: "mac:\(app.bundleId)/_plugin/\(EnvironmentIDEncoding.encodePathComponent(pluginId))",
                     metadata: pluginMetadata

--- a/clients/mac/Sources/Models/EnvironmentProviders/SlackEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/SlackEnvironmentProvider.swift
@@ -82,14 +82,14 @@ final class SlackEnvironmentProvider: SpecializedEnvironmentProvider {
         var candidates: [EnvironmentCandidate] = []
         var workspaceMetadata = CandidateMetadata.base(app: app, title: title)
         workspaceMetadata["workspaceName"] = .string(context.workspaceName)
-        workspaceMetadata["sourceName"] = .string("\(app.name) · \(context.workspaceName)")
+        workspaceMetadata["displayName"] = .string("\(app.name) · \(context.workspaceName)")
         let workspaceId = teamEnvironmentId(bundleId: app.bundleId, workspaceName: context.workspaceName)
         candidates.append(EnvironmentCandidate(id: workspaceId, metadata: workspaceMetadata))
 
         if let channelName = context.channelName {
             var channelMetadata = workspaceMetadata
             channelMetadata["channelName"] = .string(channelName)
-            channelMetadata["sourceName"] = .string("\(app.name) · \(context.workspaceName) · #\(channelName)")
+            channelMetadata["displayName"] = .string("\(app.name) · \(context.workspaceName) · #\(channelName)")
             let channelId = channelEnvironmentId(bundleId: app.bundleId, workspaceName: context.workspaceName, channelName: channelName)
             candidates.append(EnvironmentCandidate(id: channelId, metadata: channelMetadata))
         }

--- a/clients/mac/Sources/Views/EnvironmentOfferView.swift
+++ b/clients/mac/Sources/Views/EnvironmentOfferView.swift
@@ -38,7 +38,7 @@ struct EnvironmentOfferDetail: View {
             HStack(alignment: .top, spacing: 10) {
                 StatusGlyph(systemImage: "shippingbox.fill", tint: PanelPalette.warning, size: 28)
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(offer.displayName ?? offer.sourceName ?? offer.environmentId)
+                    Text(offer.displayName ?? offer.environmentId)
                         .font(.subheadline)
                         .fontWeight(.semibold)
                     Text("wants to load bundle \(offer.bundleId) into this agent session")
@@ -49,22 +49,6 @@ struct EnvironmentOfferDetail: View {
                         .foregroundStyle(PanelPalette.secondaryText)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                    if let sourceName = offer.sourceName,
-                       sourceName != offer.displayName,
-                       sourceName != offer.environmentId {
-                        Text(sourceName)
-                            .font(.caption2)
-                            .foregroundStyle(PanelPalette.secondaryText)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
-                    if let url = offer.canonicalSourceUrl, !url.isEmpty {
-                        Text(url)
-                            .font(.caption2)
-                            .foregroundStyle(PanelPalette.secondaryText)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
                 }
             }
         }

--- a/clients/mac/Sources/Views/EnvironmentsDetailView.swift
+++ b/clients/mac/Sources/Views/EnvironmentsDetailView.swift
@@ -81,13 +81,6 @@ struct EnvironmentsDetail: View {
                         .foregroundStyle(PanelPalette.textMuted)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                    if EnvironmentListPresentation.shouldDisplaySourceName(for: item), let sourceName = item.sourceName {
-                        Text(sourceName)
-                            .font(.caption2)
-                            .foregroundStyle(PanelPalette.textMuted)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                    }
                     HStack(spacing: 8) {
                         Text(item.status == "active" ? "Active" : "Recent")
                             .font(.caption2)

--- a/clients/mac/Tests/DiscordEnvironmentProviderTests.swift
+++ b/clients/mac/Tests/DiscordEnvironmentProviderTests.swift
@@ -21,7 +21,7 @@ final class DiscordEnvironmentProviderTests: XCTestCase {
         ])
         XCTAssertEqual(candidates.last?.metadata["serverName"], .string("Build With AI"))
         XCTAssertEqual(candidates.last?.metadata["channelName"], .string("self-promotion"))
-        XCTAssertEqual(candidates.last?.metadata["sourceName"], .string("Discord · Build With AI · #self-promotion"))
+        XCTAssertEqual(candidates.last?.metadata["displayName"], .string("Discord · Build With AI · #self-promotion"))
     }
 
     func testTitleContextParsesDirectMessage() {

--- a/clients/mac/Tests/EnvironmentOfferControllerTests.swift
+++ b/clients/mac/Tests/EnvironmentOfferControllerTests.swift
@@ -108,8 +108,6 @@ final class EnvironmentOfferControllerTests: XCTestCase {
             displayName: "Obsidian",
             bundleId: "default",
             bundleHash: bundleHash,
-            sourceName: "Obsidian",
-            canonicalSourceUrl: nil,
             skills: [],
             mcpServers: [],
             apps: []

--- a/clients/mac/Tests/FinderEnvironmentProviderTests.swift
+++ b/clients/mac/Tests/FinderEnvironmentProviderTests.swift
@@ -35,7 +35,7 @@ final class FinderEnvironmentProviderTests: XCTestCase {
             "dir:/Users/johnberryman/projects/github/rookkeeper",
         ])
         XCTAssertEqual(candidates.last?.metadata["finderCurrent"], .bool(true))
-        XCTAssertEqual(candidates.last?.metadata["sourceName"], .string("Finder · rookkeeper"))
+        XCTAssertEqual(candidates.last?.metadata["displayName"], .string("Finder · rookkeeper"))
     }
 
     func testProviderTracksCurrentDirectoryEnvironmentId() {

--- a/clients/mac/Tests/ObsidianEnvironmentProviderTests.swift
+++ b/clients/mac/Tests/ObsidianEnvironmentProviderTests.swift
@@ -50,7 +50,7 @@ final class ObsidianEnvironmentProviderTests: XCTestCase {
             "mac:md.obsidian/_plugin/chat-with-agent",
             "mac:md.obsidian/_plugin/obsidian-todos-extension",
         ]))
-        XCTAssertEqual(candidates.first?.metadata["sourceName"], .string("Obsidian · Work Vault"))
+        XCTAssertEqual(candidates.first?.metadata["displayName"], .string("Obsidian · Work Vault"))
         XCTAssertEqual(candidates.first?.metadata["vaultName"], .string("Work Vault"))
         XCTAssertEqual(candidates.first?.metadata["windowTitle"], .string("Daily Note - Work Vault - Obsidian"))
     }

--- a/server/README.md
+++ b/server/README.md
@@ -115,7 +115,7 @@ On environment change, only the affected session's runtime is restarted — the 
 
 ### Environment system
 
-The environment system (registration, decision store, repository) continues to work through its existing HTTP API. `AgentRuntimeManager` subscribes per-session to `EnvironmentManager` and applies skill paths to runtime launch configuration. Environment offers use the negotiated `com.rookkeeper` ACP extension rather than proprietary session updates.
+The environment system (registration, decision store, repository) continues to work through its existing HTTP API. `/api/environments/register` is treated as candidate registration: the server finalizes candidates asynchronously, can inspect observed path/URL implied environment ids through `EnvironmentRepository`, and only finalized environments participate in offers / approvals / runtime updates. `AgentRuntimeManager` subscribes per-session to `EnvironmentManager` and applies skill paths to runtime launch configuration. Environment offers use the negotiated `com.rookkeeper` ACP extension rather than proprietary session updates.
 
 ### Key source files
 

--- a/server/src/server/environment/EnvironmentManager.test.ts
+++ b/server/src/server/environment/EnvironmentManager.test.ts
@@ -27,6 +27,24 @@ function mockListener(): EnvironmentEventListener {
   };
 }
 
+function resolvedBundle(environmentId: string, bundleId = "default") {
+  return [{
+    bundle: {
+      id: `${environmentId}#${bundleId}`,
+      bundleId,
+      environmentId,
+      repository: "/repo",
+      bundlePath: `/repo/${environmentId.replace(":", "/")}/.bundles/${bundleId}`,
+      skills: [],
+      mcpServers: [],
+      apps: [],
+      valid: true,
+      errors: [],
+    },
+    bundleHash: `hash-${environmentId}-${bundleId}`,
+  }] as any;
+}
+
 describe("EnvironmentManager", () => {
   let decisions: EnvironmentDecisionStore;
   let nowMs: number;
@@ -54,8 +72,8 @@ describe("EnvironmentManager", () => {
     return new JsonlEnvironmentMetadataCaptureSink(captureDir);
   }
 
-  function newManager(activeWindowMs = 6 * 60_000, recentRetentionMs = 30 * 60_000): EnvironmentManager {
-    return new EnvironmentManager(mockRepositoryService(), decisions, {
+  function newManager(repositoryService = mockRepositoryService(), activeWindowMs = 6 * 60_000, recentRetentionMs = 30 * 60_000): EnvironmentManager {
+    return new EnvironmentManager(repositoryService, decisions, {
       activeEnvironmentWindowMs: activeWindowMs,
       recentEnvironmentRetentionMs: recentRetentionMs,
       logger: { info: vi.fn() },
@@ -67,123 +85,81 @@ describe("EnvironmentManager", () => {
   it("keeps a registered environment active in memory", async () => {
     const manager = newManager();
 
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
+    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { displayName: "Example" });
 
     expect(manager.isAvailable("web:example.com")).toBe(true);
   });
 
-  it("creates IGNORED/environment_metadata_captures and appends environment metadata captures as jsonl", async () => {
+  it("captures registration metadata as jsonl", async () => {
     const manager = newManager();
 
     await manager.registerAvailableEnvironment(
-      { id: "web:example.com/docs", metadata: { title: "Docs", tags: ["api"] } },
-      { sourceName: "Example Docs", canonicalSourceUrl: "https://example.com/docs" },
-    );
-    await manager.registerAvailableEnvironment(
-      { id: "web:example.com/docs", metadata: { title: "Docs 2" } },
-      { sourceName: "Example Docs" },
+      { id: "web:example.com/docs", metadata: { displayName: "Docs", observedUrls: ["https://example.com/docs"] } },
+      { displayName: "Docs" },
     );
 
     const filePath = path.join(captureDir, "web-example.com--docs.jsonl");
-    expect(existsSync(path.join(tempHome, "IGNORED"))).toBe(true);
-    expect(existsSync(captureDir)).toBe(true);
     expect(existsSync(filePath)).toBe(true);
 
     const lines = readFileSync(filePath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toMatchObject({
-      capturedAt: "2026-07-02T12:00:00.000Z",
-      environmentId: "web:example.com/docs",
-      sourceName: "Example Docs",
-      canonicalSourceUrl: "https://example.com/docs",
-      metadata: { title: "Docs", tags: ["api"] },
-    });
-    expect(lines[1]).toMatchObject({
-      capturedAt: "2026-07-02T12:00:00.000Z",
-      environmentId: "web:example.com/docs",
-      sourceName: "Example Docs",
-      metadata: { title: "Docs 2" },
-    });
+    expect(lines).toEqual([
+      {
+        capturedAt: "2026-07-02T12:00:00.000Z",
+        environmentId: "web:example.com/docs",
+        metadata: { displayName: "Docs", observedUrls: ["https://example.com/docs"] },
+      },
+    ]);
   });
 
-  it("registerCandidateEnvironment captures the full web candidate but only registers the domain by default", async () => {
-    const repositoryService = mockRepositoryService();
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-      registrationCaptureSink: captureSink(),
-    });
+  it("registers the literal candidate environment id", async () => {
+    const manager = newManager();
 
     await manager.registerCandidateEnvironment({
       id: "web:docs.google.com/document/d/abc/edit",
-      metadata: {
-        sourceName: "https://docs.google.com/document/d/abc/edit",
-        canonicalSourceUrl: "https://docs.google.com/document/d/abc/edit",
-        appName: "Google Chrome",
-      },
+      metadata: { displayName: "edit", observedUrls: ["https://docs.google.com/document/d/abc/edit"] },
     });
 
-    expect(manager.isAvailable("web:docs.google.com")).toBe(true);
-    expect(manager.isAvailable("web:docs.google.com/document")).toBe(false);
-    expect(manager.isAvailable("web:docs.google.com/document/d")).toBe(false);
-    expect(manager.isAvailable("web:docs.google.com/document/d/abc")).toBe(false);
-    expect(manager.isAvailable("web:docs.google.com/document/d/abc/edit")).toBe(false);
-
-    const filePath = path.join(captureDir, "web-docs.google.com--document--d--abc--edit.jsonl");
-    expect(existsSync(filePath)).toBe(true);
-    const lines = readFileSync(filePath, "utf8").trim().split("\n").map((line) => JSON.parse(line));
-    expect(lines.at(-1)).toMatchObject({
-      environmentId: "web:docs.google.com/document/d/abc/edit",
-      sourceName: "https://docs.google.com/document/d/abc/edit",
-      canonicalSourceUrl: "https://docs.google.com/document/d/abc/edit",
-    });
+    expect(manager.isAvailable("web:docs.google.com/document/d/abc/edit")).toBe(true);
+    expect(manager.isAvailable("web:docs.google.com")).toBe(false);
   });
 
-  it("registerCandidateEnvironment registers bundle-backed web ancestors", async () => {
+  it("finalizes additional repository-backed environments discovered from observed urls", async () => {
     const repositoryService = mockRepositoryService();
     vi.mocked(repositoryService.getResolvedBundles).mockImplementation(async (environmentId: string) => {
-      if (environmentId === "web:docs.google.com/document" || environmentId === "web:docs.google.com/document/d/abc") {
-        return [{
-          bundle: {
-            id: `${environmentId}#default`,
-            bundleId: "default",
-            environmentId,
-            repository: "/repo",
-            bundlePath: `/repo/${environmentId.replace(":", "/")}/.bundles/default`,
-            skills: [],
-            mcpServers: [],
-            apps: [],
-            valid: true,
-            errors: [],
-          },
-          bundleHash: `hash-${environmentId}`,
-        }] as any;
-      }
+      if (environmentId === "web:docs.google.com/document") return resolvedBundle(environmentId);
       return [];
     });
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
+    const manager = newManager(repositoryService);
 
     await manager.registerCandidateEnvironment({
       id: "web:docs.google.com/document/d/abc/edit",
-      metadata: { sourceName: "https://docs.google.com/document/d/abc/edit" },
+      metadata: { displayName: "edit", observedUrls: ["https://docs.google.com/document/d/abc/edit"] },
     });
 
-    expect(manager.isAvailable("web:docs.google.com")).toBe(true);
+    expect(manager.isAvailable("web:docs.google.com/document/d/abc/edit")).toBe(true);
     expect(manager.isAvailable("web:docs.google.com/document")).toBe(true);
-    expect(manager.isAvailable("web:docs.google.com/document/d")).toBe(false);
-    expect(manager.isAvailable("web:docs.google.com/document/d/abc")).toBe(true);
-    expect(manager.isAvailable("web:docs.google.com/document/d/abc/edit")).toBe(false);
+    expect(manager.isAvailable("web:docs.google.com")).toBe(false);
+  });
+
+  it("finalizes additional repository-backed dir environments discovered from observed paths", async () => {
+    const repositoryService = mockRepositoryService();
+    vi.mocked(repositoryService.getResolvedBundles).mockImplementation(async (environmentId: string) => {
+      if (environmentId === "dir:/Users/john/project") return resolvedBundle(environmentId);
+      return [];
+    });
+    const manager = newManager(repositoryService);
+
+    await manager.registerCandidateEnvironment({
+      id: "dir:/Users/john/project/src",
+      metadata: { displayName: "src", observedPaths: ["/Users/john/project/src/main.cpp"] },
+    });
+
+    expect(manager.isAvailable("dir:/Users/john/project/src")).toBe(true);
+    expect(manager.isAvailable("dir:/Users/john/project")).toBe(true);
   });
 
   it("moves an active environment to recent after the active window", async () => {
-    const manager = newManager(1_000, 10_000);
+    const manager = newManager(mockRepositoryService(), 1_000, 10_000);
     await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
 
     nowMs += 1_001;
@@ -192,870 +168,82 @@ describe("EnvironmentManager", () => {
   });
 
   it("forgets recent environments after the recent retention window", async () => {
-    const manager = newManager(1_000, 2_000);
+    const manager = newManager(mockRepositoryService(), 1_000, 2_000);
     await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
 
     nowMs += 1_001;
     expect(manager.isAvailable("web:example.com")).toBe(false);
 
     nowMs += 2_001;
-    expect(manager.isAvailable("web:example.com")).toBe(false);
     expect(manager.diagnosticSnapshot()).toEqual([]);
   });
 
-  it("promotes a recent environment back to active when registered again", async () => {
-    const manager = newManager(1_000, 10_000);
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-
-    nowMs += 1_001;
-    expect(manager.isAvailable("web:example.com")).toBe(false);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    expect(manager.isAvailable("web:example.com")).toBe(true);
-  });
-
-  it("keeps registeredAt stable when an already-active environment is re-registered", async () => {
-    const manager = newManager(10_000, 20_000);
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    const first = manager.diagnosticSnapshot()[0];
-
-    nowMs += 2_000;
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    const second = manager.diagnosticSnapshot()[0];
-
-    expect(second.registeredAt).toBe(first.registeredAt);
-    expect(second.record.metadata.registeredAt).toBe(first.record.metadata.registeredAt);
-    expect(second.lastTouchedAt).not.toBe(first.lastTouchedAt);
-    expect(second.activeUntil).not.toBe(first.activeUntil);
-  });
-
-  it("resets registeredAt when a recent environment becomes active again", async () => {
-    const manager = newManager(1_000, 10_000);
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    const first = manager.diagnosticSnapshot()[0];
-
-    nowMs += 1_001;
-    expect(manager.isAvailable("web:example.com")).toBe(false);
-
-    nowMs += 2_000;
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    const second = manager.diagnosticSnapshot()[0];
-
-    expect(second.registeredAt).not.toBe(first.registeredAt);
-    expect(second.record.metadata.registeredAt).not.toBe(first.record.metadata.registeredAt);
-    expect(second.lastTouchedAt).toBe(second.registeredAt);
-  });
-
-  it("retains permanent decisions and session-scoped decisions", () => {
+  it("uses candidate displayName for environment list entries", async () => {
     const manager = newManager();
+    manager.subscribe("s1", mockListener());
 
-    // Permanent approve: no sessionId needed, stored in DB.
-    manager.decideEnvironment("web:example.com", "approve");
-    expect(manager.effectiveDecision("web:example.com")).toBe("approve");
+    await manager.registerCandidateEnvironment({
+      id: "dir:/Users/john/project-x",
+      metadata: { displayName: "Project X", observedPaths: ["/Users/john/project-x/main.cpp"] },
+    });
 
-    // Session-scoped ignore: requires sessionId, in-memory only.
-    manager.decideEnvironment("web:example.com", "ignore", undefined, "s1");
-    expect(manager.effectiveDecision("web:example.com", "s1")).toBe("ignore");
-    // Other sessions don't see it.
-    expect(manager.effectiveDecision("web:example.com", "s2")).toBe("approve");
+    expect(manager.environmentList("s1")[0]).toMatchObject({
+      environmentId: "dir:/Users/john/project-x",
+      displayName: "Project X",
+    });
   });
 
-  it("stores environment_id and bundle_id when approving a bundle by hash", async () => {
+  it("falls back to the last environment-id segment when displayName is absent", async () => {
     const manager = newManager();
+    manager.subscribe("s1", mockListener());
 
-    // Simulate an environment with bundles in memory so decideEnvironment can
-    // look up the bundle metadata.
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#my-bundle",
-          bundleId: "my-bundle",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/my-bundle",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-abc",
-      },
-    ] as any);
-    const bundleManager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
+    await manager.registerAvailableEnvironment({ id: "web:example.com/docs", metadata: {} });
+
+    expect(manager.environmentList("s1")[0]).toMatchObject({
+      displayName: "docs",
     });
-
-    // Register to get the bundle into remembered state.
-    await bundleManager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
-
-    // Approve the bundle by hash.
-    bundleManager.decideEnvironment("web:example.com", "approve", "hash-abc");
-
-    // effectiveDecision by hash should return approve.
-    expect(bundleManager.effectiveDecision("hash-abc")).toBe("approve");
-    // The DB entry should be findable.
-    expect(decisions.getDecision("hash-abc")).toBe("approve");
   });
 
-  it("shows per-bundle effectiveDecision in diagnostic snapshot", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#my-bundle",
-          bundleId: "my-bundle",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/my-bundle",
-          skills: [{ id: "talk", files: {} }],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-abc",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
-    manager.decideEnvironment("web:example.com", "accept", "hash-abc", "s1");
-
-    const snapshot = manager.diagnosticSnapshot("s1");
-    expect(snapshot).toHaveLength(1);
-    // Per-bundle decision should be "accept" from s1's perspective.
-    expect(snapshot[0].bundles[0].effectiveDecision).toBe("accept");
-    // Without sessionId, the session decision is invisible (only permanent shows).
-    expect(manager.diagnosticSnapshot()[0].bundles[0].effectiveDecision).toBe("undecided");
-    // The top-level (environment-keyed) decision won't match the bundle hash.
-  });
-
-  it("ephemeral accept is forgotten when the environment expires", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#my-bundle",
-          bundleId: "my-bundle",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/my-bundle",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-abc",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 1_000,
-      recentEnvironmentRetentionMs: 30_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    manager.decideEnvironment("web:example.com", "accept", "hash-abc", "s1");
-    expect(manager.effectiveDecision("hash-abc", "s1")).toBe("accept");
-
-    // Advance past the active window — environment moves to recent, session-scoped accept is forgotten.
-    nowMs += 1_001;
-    expect(manager.effectiveDecision("hash-abc", "s1")).toBe("undecided");
-  });
-
-  it("approve persists across environment expiry", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#my-bundle",
-          bundleId: "my-bundle",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/my-bundle",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-abc",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 1_000,
-      recentEnvironmentRetentionMs: 30_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    manager.decideEnvironment("web:example.com", "approve", "hash-abc");
-    expect(manager.effectiveDecision("hash-abc")).toBe("approve");
-
-    // Advance past the active window — environment expires, but approve is in DB.
-    nowMs += 1_001;
-    expect(manager.effectiveDecision("hash-abc")).toBe("approve");
-  });
-
-  it("does not broadcast offers on registration — offers are deferred to enter", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [{ id: "consult", files: {} }],
-          mcpServers: [{ id: "crm", files: {} }],
-          apps: [{ id: "slack", files: {} }],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
-
-    // Registration should NOT broadcast offers.
-    expect(listener.onEnvironmentOffered).not.toHaveBeenCalled();
-    expect(listener.onEnvironmentEntered).not.toHaveBeenCalled();
-    expect(manager.enteredEnvironments("s1")).toEqual([]);
-  });
-
-  it("remembers discovered bundle paths with the environment", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
-
-    expect(manager.diagnosticSnapshot()).toEqual([
-      expect.objectContaining({
-        environmentId: "web:example.com",
-        bundleIds: ["testing"],
-        bundleCollectionPaths: ["/repo/web/example.com/.bundles"],
-        bundles: [expect.objectContaining({ bundleId: "testing", bundleHash: "hash-1" })],
-      }),
-    ]);
-  });
-
-  it("enters an environment and calls onEnvironmentEntered with approved skill paths", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [{ id: "consult", files: {} }],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    // Approve the bundle before entering so skills are included.
-    manager.decideEnvironment("web:example.com", "approve", "hash-1");
-
-    const entered = manager.enterEnvironment("s1", "web:example.com");
-
-    expect(entered).toEqual(["web:example.com"]);
-    expect(manager.enteredEnvironments("s1")).toEqual(["web:example.com"]);
-    expect(listener.onEnvironmentEntered).toHaveBeenCalledWith(
-      "web:example.com",
-      ["/repo/web/example.com/.bundles/testing/skills/consult"],
-      undefined,
-    );
-    // No offers for already-approved bundles.
-    expect(listener.onEnvironmentOffered).not.toHaveBeenCalled();
-
-    const personalSkillsDir = path.join(tempHome, ".rook", "environment-repository", "web", "example.com", ".bundles", "personal", "skills");
-    expect(existsSync(personalSkillsDir)).toBe(true);
-  });
-
-  it("allows entering a recent environment from the environment list", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          agentsMd: "# Environment Instructions\n\nBe helpful.",
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 1_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    nowMs += 2_000;
-
-    const entered = manager.enterEnvironment("s1", "web:example.com");
-
-    expect(entered).toEqual(["web:example.com"]);
-    expect(manager.enteredEnvironments("s1")).toEqual(["web:example.com"]);
-    expect(listener.onEnvironmentEntered).toHaveBeenCalledWith("web:example.com", [], undefined);
-    expect(listener.onEnvironmentOffered).toHaveBeenCalledWith(expect.objectContaining({
-      environmentId: "web:example.com",
-      bundleId: "testing",
-      bundleHash: "hash-1",
-    }));
-  });
-
-  it("exits an environment and calls onEnvironmentExited", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    manager.enterEnvironment("s1", "web:example.com");
-
-    const remaining = manager.exitEnvironment("s1", "web:example.com");
-
-    expect(remaining).toEqual([]);
-    expect(manager.enteredEnvironments("s1")).toEqual([]);
-    expect(listener.onEnvironmentExited).toHaveBeenCalledWith("web:example.com");
-  });
-
-  it("session decisions are cleared when exiting an environment", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    manager.enterEnvironment("s1", "web:example.com");
-
-    // Accept the bundle for session s1.
-    manager.decideEnvironment("web:example.com", "accept", "hash-1", "s1");
-    expect(manager.effectiveDecision("hash-1", "s1")).toBe("accept");
-
-    // Exit the environment — session decisions should be cleared.
-    manager.exitEnvironment("s1", "web:example.com");
-    expect(manager.effectiveDecision("hash-1", "s1")).toBe("undecided");
-  });
-
-  it("session decisions are isolated across sessions", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [{ id: "consult", files: {} }],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const l1 = mockListener();
-    const l2 = mockListener();
-    manager.subscribe("s1", l1);
-    manager.subscribe("s2", l2);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
-
-    // Session 1 enters and accepts.
-    manager.enterEnvironment("s1", "web:example.com");
-    manager.decideEnvironment("web:example.com", "accept", "hash-1", "s1");
-    expect(manager.effectiveDecision("hash-1", "s1")).toBe("accept");
-
-    // Session 2 enters — should get its own fresh offer, not affected by s1's decision.
-    vi.mocked(l2.onEnvironmentOffered).mockClear();
-    manager.enterEnvironment("s2", "web:example.com");
-    expect(l2.onEnvironmentOffered).toHaveBeenCalledWith(
-      expect.objectContaining({
-        environmentId: "web:example.com",
-        bundleId: "testing",
-        bundleHash: "hash-1",
-        displayName: "example.com",
-        sourceName: "Example",
-      }),
-    );
-    // s2's onEnvironmentEntered should have empty skills (bundle still undecided from s2's perspective).
-    expect(l2.onEnvironmentEntered).toHaveBeenCalledWith("web:example.com", [], undefined);
-  });
-
-  it("entering a child environment also enters its active parents", async () => {
+  it("entering a child environment does not implicitly enter its parent", async () => {
     const manager = newManager();
     const listener = mockListener();
     manager.subscribe("s1", listener);
 
-    await manager.registerAvailableEnvironment({ id: "mac:md.obsidian", metadata: { bundleId: "md.obsidian" } }, { sourceName: "Obsidian" });
-    await manager.registerAvailableEnvironment({ id: "mac:md.obsidian/Rooknanigans", metadata: { vaultName: "Rooknanigans" } }, { sourceName: "Obsidian · Rooknanigans" });
+    await manager.registerAvailableEnvironment({ id: "mac:md.obsidian", metadata: { displayName: "Obsidian" } }, { displayName: "Obsidian" });
+    await manager.registerAvailableEnvironment({ id: "mac:md.obsidian/Rooknanigans", metadata: { displayName: "Rooknanigans" } }, { displayName: "Rooknanigans" });
 
     const entered = manager.enterEnvironment("s1", "mac:md.obsidian/Rooknanigans");
 
-    expect(entered).toEqual(["mac:md.obsidian", "mac:md.obsidian/Rooknanigans"]);
-    expect(manager.enteredEnvironments("s1")).toEqual(["mac:md.obsidian", "mac:md.obsidian/Rooknanigans"]);
-    expect(listener.onEnvironmentEntered).toHaveBeenNthCalledWith(1, "mac:md.obsidian", [], undefined);
-    expect(listener.onEnvironmentEntered).toHaveBeenNthCalledWith(2, "mac:md.obsidian/Rooknanigans", [], undefined);
-  });
-
-  it("leaving a child environment also leaves inherited parent entries when no longer needed", async () => {
-    const manager = newManager();
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "mac:md.obsidian", metadata: {} });
-    await manager.registerAvailableEnvironment({ id: "mac:md.obsidian/Rooknanigans", metadata: {} });
-
-    manager.enterEnvironment("s1", "mac:md.obsidian/Rooknanigans");
-    vi.mocked(listener.onEnvironmentExited).mockClear();
-
-    const remaining = manager.exitEnvironment("s1", "mac:md.obsidian/Rooknanigans");
-
-    expect(remaining).toEqual([]);
-    expect(manager.enteredEnvironments("s1")).toEqual([]);
-    expect(listener.onEnvironmentExited).toHaveBeenNthCalledWith(1, "mac:md.obsidian");
-    expect(listener.onEnvironmentExited).toHaveBeenNthCalledWith(2, "mac:md.obsidian/Rooknanigans");
-  });
-
-  it("environmentList sorts entered first, then active by recency", async () => {
-    const manager = newManager();
-
-    // Register two environments at different times.
-    await manager.registerAvailableEnvironment({ id: "web:a.com", metadata: {} }, { sourceName: "A" });
-    nowMs += 1_000;
-    await manager.registerAvailableEnvironment({ id: "web:b.com", metadata: {} }, { sourceName: "B" });
-
-    // Subscribe and enter the older one.
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-    manager.enterEnvironment("s1", "web:a.com");
-
-    const list = manager.environmentList("s1");
-
-    // Entered first (web:a.com), then active by recency (web:b.com more recent).
-    expect(list[0].environmentId).toBe("web:a.com");
-    expect(list[0].entered).toBe(true);
-    expect(list[1].environmentId).toBe("web:b.com");
-    expect(list[1].entered).toBe(false);
-  });
-
-  it("environmentList derives display names by environment kind", async () => {
-    const manager = newManager();
-
-    await manager.registerAvailableEnvironment(
-      {
-        id: "web:example.com/docs",
-        metadata: {
-          appName: "Google Chrome",
-          windowTitle: "Example Docs - Google Chrome - John",
-          url: "https://example.com/docs",
-        },
-      },
-      { sourceName: "https://example.com/docs" },
-    );
-    await manager.registerAvailableEnvironment(
-      {
-        id: "mac:md.obsidian/Peeps",
-        metadata: {
-          appName: "Obsidian",
-          vaultName: "Peeps",
-        },
-      },
-      { sourceName: "Obsidian · Peeps" },
-    );
-    await manager.registerAvailableEnvironment(
-      {
-        id: "dir:/Users/john/project",
-        metadata: {
-          directoryPath: "/Users/john/project",
-        },
-      },
-      { sourceName: "/Users/john/project" },
-    );
-    await manager.registerAvailableEnvironment(
-      {
-        id: "location:target.com/123-main-st-springfield-il",
-        metadata: {
-          displayName: "Target",
-          address: "123 Main St, Springfield, IL",
-        },
-      },
-      { sourceName: "Target" },
-    );
-
-    const list = manager.environmentList("s1");
-    const byId = new Map(list.map((item) => [item.environmentId, item]));
-
-    expect(byId.get("web:example.com/docs")).toMatchObject({
-      displayName: "example.com / docs",
-      sourceName: "https://example.com/docs",
-    });
-    expect(byId.get("mac:md.obsidian/Peeps")).toMatchObject({
-      displayName: "Obsidian · Peeps",
-      sourceName: "Obsidian · Peeps",
-    });
-    expect(byId.get("dir:/Users/john/project")).toMatchObject({
-      displayName: "/Users/john/project",
-      sourceName: "/Users/john/project",
-    });
-    expect(byId.get("location:target.com/123-main-st-springfield-il")).toMatchObject({
-      displayName: "Target",
-      sourceName: "Target",
-    });
-  });
-
-  it("enterEnvironment does nothing for an unsubscribed session", async () => {
-    const manager = newManager();
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-
-    const entered = manager.enterEnvironment("nonexistent", "web:example.com");
-    expect(entered).toEqual([]);
-  });
-
-  it("registerCandidateEnvironment keeps dir environments exact-only with no parents", async () => {
-    const manager = newManager();
-
-    await manager.registerCandidateEnvironment({
-      id: "dir:/Users/john/project/subdir",
-      metadata: { directoryPath: "/Users/john/project/subdir" },
-    });
-
-    expect(manager.isAvailable("dir:/Users/john/project/subdir")).toBe(true);
-    expect(manager.isAvailable("dir:/Users/john/project")).toBe(false);
-    expect(manager.isAvailable("dir:/Users/john")).toBe(false);
-  });
-
-  it("enters only the exact dir environment", async () => {
-    const manager = newManager();
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerCandidateEnvironment({
-      id: "dir:/Users/john/project/subdir",
-      metadata: { directoryPath: "/Users/john/project/subdir" },
-    });
-
-    const entered = manager.enterEnvironment("s1", "dir:/Users/john/project/subdir");
-    expect(entered).toEqual(["dir:/Users/john/project/subdir"]);
+    expect(entered).toEqual(["mac:md.obsidian/Rooknanigans"]);
+    expect(manager.enteredEnvironments("s1")).toEqual(["mac:md.obsidian/Rooknanigans"]);
     expect(listener.onEnvironmentEntered).toHaveBeenCalledTimes(1);
-    expect(listener.onEnvironmentEntered).toHaveBeenCalledWith("dir:/Users/john/project/subdir", [], undefined);
+    expect(listener.onEnvironmentEntered).toHaveBeenCalledWith("mac:md.obsidian/Rooknanigans", []);
   });
 
-  it("renders environment binding instructions for all entered environments", async () => {
-    const manager = newManager();
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment(
-      {
-        id: "web:example.com",
-        metadata: { title: "Example" },
-      },
-      { sourceName: "Arc", canonicalSourceUrl: "https://example.com" },
-    );
-    await manager.registerAvailableEnvironment(
-      {
-        id: "web:example.com/stuff",
-        metadata: { title: "Stuff", tags: ["docs", "support"] },
-      },
-      { sourceName: "Arc", canonicalSourceUrl: "https://example.com/stuff" },
-      "The user is reading the support docs.",
-    );
-    await manager.registerAvailableEnvironment(
-      {
-        id: "mac:md.obsidian",
-        metadata: { bundleId: "md.obsidian" },
-      },
-      { sourceName: "Obsidian" },
-    );
-    await manager.registerAvailableEnvironment(
-      {
-        id: "mac:md.obsidian/WorkVault",
-        metadata: { vault: "WorkVault" },
-      },
-      { sourceName: "Obsidian" },
-    );
-
-    manager.enterEnvironment("s1", "web:example.com/stuff");
-    manager.enterEnvironment("s1", "mac:md.obsidian/WorkVault");
-
-    const instructions = manager.runtimeInstructionsForSession("s1");
-    // Rook identity prompt is included.
-    expect(instructions).toContain("You are Rook");
-    // Environment prompt.
-    expect(instructions).toContain("Attaching memories");
-    expect(instructions).toContain("`web:example.com`");
-    expect(instructions).toContain("`web:example.com/stuff`");
-    expect(instructions).toContain("`mac:md.obsidian`");
-    expect(instructions).toContain("`mac:md.obsidian/WorkVault`");
-    expect(instructions).toContain(path.join(tempHome, ".rook", "environment-repository", "web", "example.com", ".bundles", "personal", "skills"));
-    expect(instructions).toContain(path.join(tempHome, ".rook", "environment-repository", "web", "example.com", "stuff", ".bundles", "personal", "skills"));
-    expect(instructions).toContain(path.join(tempHome, ".rook", "environment-repository", "mac", "md.obsidian", ".bundles", "personal", "skills"));
-    expect(instructions).toContain(path.join(tempHome, ".rook", "environment-repository", "mac", "md.obsidian", "WorkVault", ".bundles", "personal", "skills"));
-    expect(instructions).toContain("https://example.com/stuff");
-    expect(instructions).toContain("The user is reading the support docs.");
-    expect(instructions).toContain('"vault": "WorkVault"');
-  });
-
-  it("injects AGENTS.md content into the runtime prompt", async () => {
+  it("offers undecided bundles with displayName only", async () => {
     const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#default",
-          bundleId: "default",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/default",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          agentsMd: "# Example Instructions\n\nAlways be polite.",
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
+    vi.mocked(repositoryService.getResolvedBundles).mockImplementation(async (environmentId: string) => {
+      if (environmentId === "web:example.com") return resolvedBundle(environmentId, "testing");
+      return [];
     });
+    const manager = newManager(repositoryService);
     const listener = mockListener();
     manager.subscribe("s1", listener);
 
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
+    await manager.registerCandidateEnvironment({
+      id: "web:example.com",
+      metadata: { displayName: "Example" },
+    });
     manager.enterEnvironment("s1", "web:example.com");
 
-    const instructions = manager.runtimeInstructionsForSession("s1");
-    expect(instructions).toContain("#### Environment instructions");
-    expect(instructions).toContain("# Example Instructions");
-    expect(instructions).toContain("Always be polite.");
-  });
-
-  it("omits AGENTS.md section when no bundles have it", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#default",
-          bundleId: "default",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/default",
-          skills: [],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} });
-    manager.enterEnvironment("s1", "web:example.com");
-
-    const instructions = manager.runtimeInstructionsForSession("s1");
-    expect(instructions).not.toContain("#### Environment instructions");
-  });
-
-  it("offers undecided bundles when entering, and loads skills after approval", async () => {
-    const repositoryService = mockRepositoryService();
-    vi.mocked(repositoryService.getResolvedBundles).mockResolvedValue([
-      {
-        bundle: {
-          id: "web:example.com#testing",
-          bundleId: "testing",
-          environmentId: "web:example.com",
-          repository: "/repo",
-          bundlePath: "/repo/web/example.com/.bundles/testing",
-          skills: [{ id: "consult", files: {} }],
-          mcpServers: [],
-          apps: [],
-          valid: true,
-          errors: [],
-        },
-        bundleHash: "hash-1",
-      },
-    ] as any);
-    const manager = new EnvironmentManager(repositoryService, decisions, {
-      activeEnvironmentWindowMs: 6 * 60_000,
-      recentEnvironmentRetentionMs: 30 * 60_000,
-      logger: { info: vi.fn() },
-      now: () => nowMs,
-    });
-    const listener = mockListener();
-    manager.subscribe("s1", listener);
-
-    await manager.registerAvailableEnvironment({ id: "web:example.com", metadata: {} }, { sourceName: "Example" });
-
-    // Enter with an undecided bundle — it should be offered but not loaded.
-    manager.enterEnvironment("s1", "web:example.com");
-
-    expect(manager.enteredEnvironments("s1")).toEqual(["web:example.com"]);
-    // onEnvironmentEntered called with empty skills (bundle is undecided).
-    expect(listener.onEnvironmentEntered).toHaveBeenCalledWith(
-      "web:example.com",
-      [],
-      undefined,
-    );
-    // Offer emitted for the undecided bundle.
     expect(listener.onEnvironmentOffered).toHaveBeenCalledWith({
       environmentId: "web:example.com",
+      displayName: "Example",
       bundleId: "testing",
-      bundleHash: "hash-1",
-      displayName: "example.com",
-      sourceName: "Example",
-      canonicalSourceUrl: undefined,
-      skills: ["consult"],
+      bundleHash: "hash-web:example.com-testing",
+      skills: [],
       mcpServers: [],
       apps: [],
     });
-
-    // Now accept for this session — should trigger a re-enter with skills.
-    vi.mocked(listener.onEnvironmentEntered).mockClear();
-    manager.decideEnvironment("web:example.com", "accept", "hash-1", "s1");
-
-    expect(listener.onEnvironmentEntered).toHaveBeenCalledWith(
-      "web:example.com",
-      ["/repo/web/example.com/.bundles/testing/skills/consult"],
-      undefined,
-    );
   });
 });

--- a/server/src/server/environment/EnvironmentManager.ts
+++ b/server/src/server/environment/EnvironmentManager.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import type { EnvironmentDecisionStore } from "./EnvironmentDecisionStore.js";
-import type { EnvironmentPreview } from "../../shared/environment.js";
+import type { CandidateEnvironmentMetadata, EnvironmentPreview } from "../../shared/environment.js";
 import type { EnvironmentRepositoryService } from "./EnvironmentRepositoryService.js";
 import { ensurePersonalEnvironmentBinding } from "./EnvironmentBinding.js";
 import {
@@ -37,7 +37,6 @@ interface RememberedEnvironmentEntry {
   lastTouchedAt: string;
   activeUntil?: string;
   status: "active" | "recent";
-  contextText?: string;
   bundles: RememberedBundleEntry[];
   bundleIds: string[];
   bundleCollectionPaths: string[];
@@ -51,7 +50,6 @@ export interface DiagnosticEnvironmentEntry {
   registeredAt?: string;
   lastTouchedAt: string;
   activeUntil?: string;
-  contextText?: string;
   bundles: Array<RememberedBundleEntry & { effectiveDecision: EffectiveDecision }>;
   bundleIds: string[];
   bundleCollectionPaths: string[];
@@ -66,45 +64,21 @@ export interface EnvironmentManagerOptions {
   registrationCaptureSink?: EnvironmentRegistrationCaptureSink;
 }
 
-/**
- * Environment manager.
- *
- * Decision model (the 2×2):
- *   positive × permanent = "approve" → SQLite, survives restarts
- *   positive × session   = "accept"  → in-memory per-session, cleared on exit/expiry
- *   negative × session   = "ignore"  → in-memory per-session, cleared on exit/expiry
- *   negative × permanent = "reject"  → SQLite, survives restarts
- *
- * Behavior:
- * - keep environments in memory as either active or recent
- * - on registration, resolve any valid bundles and remember their exact-content hashes
- * - bundle offers are only issued when a session enters an environment, not on registration
- * - session decisions (accept/ignore) are per-session — session 2 entering the same env
- *   sees its own fresh offers regardless of what session 1 decided
- * - when a session exits an environment, its session decisions for that env are cleared
- * - when a user approves/accepts, any session already inside the env gets skills reloaded
- */
-function environmentHierarchy(environmentId: string): string[] {
-  const separator = environmentId.indexOf(":");
-  if (separator === -1) return [environmentId];
-
-  const kind = environmentId.slice(0, separator);
-  if (kind === "dir") return [environmentId];
-
-  const prefix = environmentId.slice(0, separator + 1);
-  const rest = environmentId.slice(separator + 1);
-  if (!rest) return [environmentId];
-
-  const parts = rest.split("/").filter(Boolean);
-  if (parts.length === 0) return [environmentId];
-
-  return parts.map((_, index) => `${prefix}${parts.slice(0, index + 1).join("/")}`);
-}
-
 function environmentKind(environmentId: string): string | undefined {
   const separator = environmentId.indexOf(":");
   if (separator === -1) return undefined;
   return environmentId.slice(0, separator);
+}
+
+function environmentPath(environmentId: string): string {
+  const separator = environmentId.indexOf(":");
+  return separator === -1 ? environmentId : environmentId.slice(separator + 1);
+}
+
+function lastEnvironmentSegment(environmentId: string): string {
+  const raw = environmentPath(environmentId);
+  const parts = raw.split("/").filter(Boolean);
+  return (parts.at(-1) ?? raw) || environmentId;
 }
 
 function stringMetadata(metadata: Record<string, unknown>, key: string): string | undefined {
@@ -112,43 +86,57 @@ function stringMetadata(metadata: Record<string, unknown>, key: string): string 
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
+function stringArrayMetadata(metadata: Record<string, unknown>, key: string): string[] {
+  const value = metadata[key];
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0).map((item) => item.trim());
+}
+
 function observationInfoFromMetadata(metadata: Record<string, unknown>): EnvironmentOfferInfo {
-  const sourceName = stringMetadata(metadata, "sourceName");
-  const canonicalSourceUrl = stringMetadata(metadata, "canonicalSourceUrl");
-  return {
-    ...(sourceName ? { sourceName } : {}),
-    ...(canonicalSourceUrl ? { canonicalSourceUrl } : {}),
-  };
+  const displayName = stringMetadata(metadata, "displayName");
+  return displayName ? { displayName } : {};
 }
 
-function webEnvironmentDisplayName(environmentId: string): string {
-  const separator = environmentId.indexOf(":");
-  if (separator === -1) return environmentId;
-  const rest = environmentId.slice(separator + 1);
-  if (!rest) return environmentId;
-  const parts = rest.split("/").filter(Boolean);
-  if (parts.length <= 1) return rest;
-  return `${parts[0]} / ${parts.slice(1).join(" / ")}`;
+function deriveEnvironmentDisplayName(environmentId: string, metadata: Record<string, unknown>, info?: EnvironmentOfferInfo): string {
+  return info?.displayName ?? stringMetadata(metadata, "displayName") ?? lastEnvironmentSegment(environmentId);
 }
 
-function deriveEnvironmentDisplayName(environmentId: string, sourceName: string | undefined, metadata: Record<string, unknown>): string {
-  const kind = environmentKind(environmentId);
-  switch (kind) {
-    case "web": {
-      return webEnvironmentDisplayName(environmentId);
-    }
-    case "mac": {
-      return sourceName || stringMetadata(metadata, "appName") || environmentId;
-    }
-    case "dir": {
-      return sourceName || environmentId.slice(environmentId.indexOf(":") + 1) || environmentId;
-    }
-    case "location": {
-      return sourceName || stringMetadata(metadata, "displayName") || environmentId;
-    }
-    default:
-      return sourceName || environmentId;
+function metadataWithoutDisplayName(metadata: CandidateEnvironmentMetadata): CandidateEnvironmentMetadata {
+  const { displayName: _displayName, ...rest } = metadata;
+  return rest;
+}
+
+function webEnvironmentIdsFromUrl(rawURL: string): string[] {
+  let components: URL;
+  try {
+    components = new URL(rawURL);
+  } catch {
+    return [];
   }
+  const scheme = components.protocol.toLowerCase();
+  if (scheme !== "http:" && scheme !== "https:") return [];
+  const host = components.hostname.toLowerCase();
+  if (!host) return [];
+  const segments = components.pathname.split("/").filter(Boolean);
+  const ids = [`web:${host}`];
+  let current = host;
+  for (const segment of segments) {
+    current += `/${segment}`;
+    ids.push(`web:${current}`);
+  }
+  return ids;
+}
+
+function dirEnvironmentIdsFromPath(rawPath: string): string[] {
+  const trimmed = rawPath.trim();
+  if (!trimmed.startsWith("/")) return [];
+  const normalized = path.posix.normalize(trimmed);
+  const segments = normalized.split("/").filter(Boolean);
+  const ids: string[] = [];
+  for (let index = 0; index < segments.length; index += 1) {
+    ids.push(`dir:/${segments.slice(0, index + 1).join("/")}`);
+  }
+  return ids;
 }
 
 export class EnvironmentManager {
@@ -179,7 +167,7 @@ export class EnvironmentManager {
     this.expiryTimer.unref?.();
   }
 
-  async registerAvailableEnvironment(env: EnvironmentRecord, info: EnvironmentOfferInfo = {}, contextText?: string): Promise<void> {
+  async registerAvailableEnvironment(env: EnvironmentRecord, info: EnvironmentOfferInfo = {}): Promise<void> {
     this.pruneMemory();
 
     const nowIso = new Date(this.now()).toISOString();
@@ -187,59 +175,61 @@ export class EnvironmentManager {
       await this.registrationCaptureSink.capture({
         capturedAt: nowIso,
         environmentId: env.id,
-        sourceName: info.sourceName,
-        canonicalSourceUrl: info.canonicalSourceUrl,
         metadata: env.metadata,
       });
     } catch (error) {
       this.logger.info({ environmentId: env.id, error }, "failed to append environment metadata capture");
     }
-    await this.rememberAvailableEnvironment(env, info, contextText, true);
+    await this.rememberAvailableEnvironment(env, info);
   }
 
   async registerCandidateEnvironment(candidate: CandidateEnvironmentRecord): Promise<void> {
     this.pruneMemory();
 
-    const now = this.now();
-    const nowIso = new Date(now).toISOString();
-    const info = observationInfoFromMetadata(candidate.metadata);
-    const contextText = stringMetadata(candidate.metadata, "contextText");
+    const nowIso = new Date(this.now()).toISOString();
     try {
       await this.registrationCaptureSink.capture({
         capturedAt: nowIso,
         environmentId: candidate.id,
-        sourceName: info.sourceName,
-        canonicalSourceUrl: info.canonicalSourceUrl,
         metadata: candidate.metadata,
       });
     } catch (error) {
       this.logger.info({ environmentId: candidate.id, error }, "failed to append environment metadata capture");
     }
 
-    if (environmentKind(candidate.id) === "web") {
-      const hierarchy = environmentHierarchy(candidate.id);
-      const idsToRegister = new Set<string>();
-      if (hierarchy.length > 0) idsToRegister.add(hierarchy[0]!);
-      for (const environmentId of hierarchy.slice(1)) {
-        const resolvedBundles = await this.repositoryService.getResolvedBundles(environmentId);
-        if (resolvedBundles.length > 0) idsToRegister.add(environmentId);
-      }
-      for (const environmentId of hierarchy) {
-        if (!idsToRegister.has(environmentId)) continue;
-        await this.rememberAvailableEnvironment({ id: environmentId, metadata: candidate.metadata }, info, contextText, false);
-      }
-      return;
+    const finalIds = await this.finalizedEnvironmentIds(candidate);
+    for (const environmentId of finalIds) {
+      const metadata = environmentId === candidate.id ? candidate.metadata : metadataWithoutDisplayName(candidate.metadata);
+      const info = environmentId === candidate.id ? observationInfoFromMetadata(candidate.metadata) : {};
+      await this.rememberAvailableEnvironment({ id: environmentId, metadata }, info);
     }
-
-    if (environmentKind(candidate.id) === "dir") {
-      await this.rememberAvailableEnvironment({ id: candidate.id, metadata: candidate.metadata }, info, contextText, false);
-      return;
-    }
-
-    await this.rememberAvailableEnvironment({ id: candidate.id, metadata: candidate.metadata }, info, contextText, true);
   }
 
-  private async rememberAvailableEnvironment(env: EnvironmentRecord, info: EnvironmentOfferInfo, contextText: string | undefined, autoRegisterParents: boolean): Promise<void> {
+  private async finalizedEnvironmentIds(candidate: CandidateEnvironmentRecord): Promise<string[]> {
+    const ids = new Set<string>([candidate.id]);
+    const implied = new Set<string>();
+
+    for (const observedPath of stringArrayMetadata(candidate.metadata, "observedPaths")) {
+      for (const environmentId of dirEnvironmentIdsFromPath(observedPath)) {
+        implied.add(environmentId);
+      }
+    }
+    for (const observedUrl of stringArrayMetadata(candidate.metadata, "observedUrls")) {
+      for (const environmentId of webEnvironmentIdsFromUrl(observedUrl)) {
+        implied.add(environmentId);
+      }
+    }
+
+    for (const environmentId of implied) {
+      if (ids.has(environmentId)) continue;
+      const bundles = await this.repositoryService.getResolvedBundles(environmentId);
+      if (bundles.length > 0) ids.add(environmentId);
+    }
+
+    return [...ids];
+  }
+
+  private async rememberAvailableEnvironment(env: EnvironmentRecord, info: EnvironmentOfferInfo): Promise<void> {
     const now = this.now();
     const nowIso = new Date(now).toISOString();
     const existing = this.remembered.get(env.id);
@@ -278,7 +268,6 @@ export class EnvironmentManager {
       bundles,
       bundleIds,
       bundleCollectionPaths,
-      ...(contextText ? { contextText } : {}),
     };
     this.remembered.set(env.id, entry);
     this.logger.info(
@@ -287,7 +276,7 @@ export class EnvironmentManager {
         previousStatus: existing?.status,
         registeredAt,
         activeUntil,
-        sourceName: info.sourceName,
+        displayName: deriveEnvironmentDisplayName(env.id, entry.record.metadata, info),
         bundleIds,
         bundleCollectionPaths,
       },
@@ -301,40 +290,8 @@ export class EnvironmentManager {
       this.sessionDecisions.clearAllForBundle(previousBundle.bundleHash);
       this.broadcastBundleResolution(env.id, previousBundle.bundleId, previousBundle.bundleHash, "unavailable");
     }
-
-    if (!autoRegisterParents) return;
-
-    for (const parentId of environmentHierarchy(env.id)) {
-      if (parentId === env.id) continue;
-      const parent = this.remembered.get(parentId);
-      if (parent?.status === "active") continue;
-
-      const parentEntry: RememberedEnvironmentEntry = {
-        record: { id: parentId, metadata: { ...env.metadata, registeredAt: nowIso } },
-        info: { canonicalSourceUrl: info.canonicalSourceUrl },
-        registeredAt: nowIso,
-        lastTouchedAt: nowIso,
-        activeUntil,
-        status: "active",
-        bundles: [],
-        bundleIds: [],
-        bundleCollectionPaths: [],
-        ...(contextText ? { contextText } : {}),
-      };
-      this.remembered.set(parentId, parentEntry);
-      this.logger.info(
-        { environmentId: parentId, parentOf: env.id, registeredAt: nowIso, activeUntil },
-        "environment auto-registered (parent)",
-      );
-    }
   }
 
-  /**
-   * Record a decision. Persistent decisions (approve/reject) go to SQLite.
-   * Session decisions (accept/ignore) are per-session in-memory and cleared on exit/expiry.
-   *
-   * @param sessionId required for session-scoped decisions (accept/ignore); optional for permanent.
-   */
   decideEnvironment(environmentId: string, decision: EnvironmentDecision, bundleHash?: string, sessionId?: string): void {
     this.pruneMemory();
     const decisionKey = bundleHash ?? environmentId;
@@ -343,11 +300,8 @@ export class EnvironmentManager {
       : undefined;
 
     if (decision === "approve" || decision === "reject") {
-      // Permanent: store in SQLite, clear session-level overrides.
       this.sessionDecisions.setPermanent(decisionKey, environmentId, bundle?.bundleId ?? null, decision);
     } else {
-      // Session-scoped: store per-session. If no sessionId is provided,
-      // apply to every session that has entered this environment (fallback).
       const targetSessions = sessionId
         ? [sessionId]
         : [...this.entered.entries()].filter(([, envs]) => envs.has(environmentId)).map(([sid]) => sid);
@@ -365,7 +319,6 @@ export class EnvironmentManager {
       );
     }
 
-    // When accepting or approving a bundle, reload skills for any session already inside this env.
     if (decision === "accept" || decision === "approve") {
       for (const [sid, entered] of this.entered.entries()) {
         if (!entered.has(environmentId)) continue;
@@ -373,12 +326,11 @@ export class EnvironmentManager {
         if (!listener) continue;
         const entry = this.remembered.get(environmentId);
         if (!entry || entry.status !== "active") continue;
-        listener.onEnvironmentEntered(environmentId, this.skillPathsForEntry(entry, sid), entry.contextText);
+        listener.onEnvironmentEntered(environmentId, this.skillPathsForEntry(entry, sid));
       }
     }
   }
 
-  /** Get the effective decision for a bundle hash from a session's perspective. */
   effectiveDecision(bundleHash: string, sessionId?: string): EffectiveDecision {
     this.pruneMemory();
     return this.sessionDecisions.effective(bundleHash, sessionId);
@@ -389,7 +341,6 @@ export class EnvironmentManager {
     this.listeners.set(sessionId, listener);
     if (!this.explicitlyEntered.has(sessionId)) this.explicitlyEntered.set(sessionId, new Set());
     if (!this.entered.has(sessionId)) this.entered.set(sessionId, new Set());
-    // Offers are deferred until the session enters an environment.
   }
 
   unsubscribe(sessionId: string): void {
@@ -419,17 +370,14 @@ export class EnvironmentManager {
         const binding = ensurePersonalEnvironmentBinding(environmentId);
         if (!binding) return null;
 
-        // Gather AGENTS.md content from every remembered bundle that has it.
         const agentsMdBundles = (remembered?.bundles ?? [])
           .filter((b) => b.agentsMd)
           .map((b) => ({ bundleId: b.bundleId, content: b.agentsMd! }));
 
         return {
           environmentId,
+          displayName: remembered ? deriveEnvironmentDisplayName(environmentId, remembered.record.metadata, remembered.info) : undefined,
           metadata: (remembered?.record.metadata ?? {}) as Record<string, unknown>,
-          sourceName: remembered?.info.sourceName,
-          canonicalSourceUrl: remembered?.info.canonicalSourceUrl,
-          contextText: remembered?.contextText,
           bindingDir: binding.personalBundleDir,
           skillsDir: binding.skillsDir,
           existingSkills: binding.existingSkills,
@@ -479,7 +427,6 @@ export class EnvironmentManager {
         registeredAt: entry.registeredAt,
         lastTouchedAt: entry.lastTouchedAt,
         activeUntil: entry.activeUntil,
-        contextText: entry.contextText,
         bundles: entry.bundles.map((bundle) => ({
           ...bundle,
           effectiveDecision: this.effectiveDecision(bundle.bundleHash, sessionId),
@@ -497,7 +444,6 @@ export class EnvironmentManager {
   environmentList(sessionId: string): {
     environmentId: string;
     displayName: string;
-    sourceName?: string;
     status: "active" | "recent";
     lastTouchedAt: string;
     entered: boolean;
@@ -514,8 +460,7 @@ export class EnvironmentManager {
       ).length;
       return {
         environmentId: entry.environmentId,
-        displayName: deriveEnvironmentDisplayName(entry.environmentId, entry.info.sourceName, entry.record.metadata),
-        sourceName: entry.info.sourceName,
+        displayName: deriveEnvironmentDisplayName(entry.environmentId, entry.record.metadata, entry.info),
         status: entry.status,
         lastTouchedAt: entry.lastTouchedAt,
         entered: entered.has(entry.environmentId),
@@ -524,7 +469,6 @@ export class EnvironmentManager {
       };
     });
 
-    // Sort: entered first, then active by recency, then recent by recency.
     list.sort((a, b) => {
       if (a.entered !== b.entered) return a.entered ? -1 : 1;
       if (a.status !== b.status) return a.status === "active" ? -1 : 1;
@@ -537,7 +481,7 @@ export class EnvironmentManager {
   private syncEnteredEnvironments(sessionId: string, listener: EnvironmentEventListener): string[] {
     if (!this.entered.has(sessionId)) this.entered.set(sessionId, new Set());
     const current = this.entered.get(sessionId)!;
-    const next = this.computeEffectiveEnteredSet(sessionId);
+    const next = new Set(this.explicitlyEntered.get(sessionId) ?? []);
 
     for (const environmentId of next) {
       if (current.has(environmentId)) continue;
@@ -545,18 +489,15 @@ export class EnvironmentManager {
       if (!entry) continue;
 
       ensurePersonalEnvironmentBinding(environmentId);
-      listener.onEnvironmentEntered(environmentId, this.skillPathsForEntry(entry, sessionId), entry.contextText);
+      listener.onEnvironmentEntered(environmentId, this.skillPathsForEntry(entry, sessionId));
 
-      // Offer undecided bundles only when this session enters the environment.
       for (const bundle of entry.bundles) {
         if (this.effectiveDecision(bundle.bundleHash, sessionId) !== "undecided") continue;
         listener.onEnvironmentOffered({
           environmentId,
-          displayName: deriveEnvironmentDisplayName(environmentId, entry.info.sourceName, entry.record.metadata),
+          displayName: deriveEnvironmentDisplayName(environmentId, entry.record.metadata, entry.info),
           bundleId: bundle.bundleId,
           bundleHash: bundle.bundleHash,
-          sourceName: entry.info.sourceName,
-          canonicalSourceUrl: entry.info.canonicalSourceUrl,
           skills: bundle.skills,
           mcpServers: bundle.mcpServers,
           apps: bundle.apps,
@@ -567,7 +508,6 @@ export class EnvironmentManager {
     for (const environmentId of current) {
       if (next.has(environmentId)) continue;
       listener.onEnvironmentExited(environmentId);
-      // Clear this session's decisions for the exited environment's bundles.
       const entry = this.remembered.get(environmentId);
       if (entry) {
         this.sessionDecisions.clearSessionForBundles(sessionId, entry.bundles.map((b) => b.bundleHash));
@@ -576,18 +516,6 @@ export class EnvironmentManager {
 
     this.entered.set(sessionId, next);
     return [...next];
-  }
-
-  private computeEffectiveEnteredSet(sessionId: string): Set<string> {
-    const effective = new Set<string>();
-    for (const environmentId of this.explicitlyEntered.get(sessionId) ?? []) {
-      for (const candidateId of environmentHierarchy(environmentId)) {
-        const entry = this.remembered.get(candidateId);
-        if (!entry) continue;
-        effective.add(candidateId);
-      }
-    }
-    return effective;
   }
 
   private skillPathsForEntry(entry: RememberedEnvironmentEntry, sessionId: string): string[] {
@@ -624,7 +552,6 @@ export class EnvironmentManager {
             status: "recent",
             activeUntil: undefined,
           });
-          // Clear all sessions' decisions for this environment's bundles.
           this.sessionDecisions.clearAllForBundles(entry.bundles.map((b) => b.bundleHash));
           for (const bundle of entry.bundles) {
             this.broadcastBundleResolution(environmentId, bundle.bundleId, bundle.bundleHash, "unavailable");

--- a/server/src/server/environment/EnvironmentPromptTemplate.test.ts
+++ b/server/src/server/environment/EnvironmentPromptTemplate.test.ts
@@ -54,24 +54,14 @@ describe("renderEnvironmentPrompt", () => {
     expect(result!).toContain("(none yet)");
   });
 
-  it("includes source name when provided", () => {
-    const result = renderEnvironmentPrompt([makeEntry({ sourceName: "Obsidian" })]);
-    expect(result!).toContain("Source name: Obsidian");
+  it("includes display name when provided", () => {
+    const result = renderEnvironmentPrompt([makeEntry({ displayName: "Obsidian" })]);
+    expect(result!).toContain("Display name: Obsidian");
   });
 
-  it("omits source name line when absent", () => {
-    const result = renderEnvironmentPrompt([makeEntry({ sourceName: undefined })]);
-    expect(result!).not.toContain("Source name:");
-  });
-
-  it("includes canonical source URL when provided", () => {
-    const result = renderEnvironmentPrompt([makeEntry({ canonicalSourceUrl: "https://example.com" })]);
-    expect(result!).toContain("Canonical source URL: https://example.com");
-  });
-
-  it("includes context text when provided", () => {
-    const result = renderEnvironmentPrompt([makeEntry({ contextText: "The user is browsing" })]);
-    expect(result!).toContain("Current environment context: The user is browsing");
+  it("omits display name line when absent", () => {
+    const result = renderEnvironmentPrompt([makeEntry({ displayName: undefined })]);
+    expect(result!).not.toContain("Display name:");
   });
 
   it("renders metadata as JSON block", () => {

--- a/server/src/server/environment/EnvironmentPromptTemplate.ts
+++ b/server/src/server/environment/EnvironmentPromptTemplate.ts
@@ -18,12 +18,8 @@ export interface EnvironmentPromptEntry {
   environmentId: string;
   /** Environment metadata (title, tags, vault name, etc.). */
   metadata: Record<string, unknown>;
-  /** Human-readable source name, e.g. "Arc", "Obsidian". */
-  sourceName?: string;
-  /** The canonical URL that produced this environment. */
-  canonicalSourceUrl?: string;
-  /** Ambient context pushed into the agent on enter (e.g. "The user is reading docs"). */
-  contextText?: string;
+  /** Human-readable display name. */
+  displayName?: string;
   /** Absolute path to the user's personal binding bundle for this environment. */
   bindingDir: string;
   /** Absolute path to the user's skill-authoring directory for this environment. */
@@ -118,9 +114,7 @@ The metadata shown for each environment below may contain useful details you can
 function renderEnvEntry(entry: EnvironmentPromptEntry): string {
   const meta: string[] = [];
 
-  if (entry.sourceName) meta.push(`- Source name: ${entry.sourceName}`);
-  if (entry.canonicalSourceUrl) meta.push(`- Canonical source URL: ${entry.canonicalSourceUrl}`);
-  if (entry.contextText) meta.push(`- Current environment context: ${entry.contextText}`);
+  if (entry.displayName) meta.push(`- Display name: ${entry.displayName}`);
 
   const agents = agentsMdBlock(entry.agentsMdBundles);
 

--- a/server/src/server/environment/environmentMetadataCapture.ts
+++ b/server/src/server/environment/environmentMetadataCapture.ts
@@ -5,8 +5,6 @@ import { REPO_ROOT } from "../paths.js";
 export interface EnvironmentMetadataCaptureRecord {
   capturedAt: string;
   environmentId: string;
-  sourceName?: string;
-  canonicalSourceUrl?: string;
   metadata: Record<string, unknown>;
 }
 

--- a/server/src/server/environment/types.ts
+++ b/server/src/server/environment/types.ts
@@ -27,8 +27,6 @@ export type EffectiveDecision = EnvironmentDecision | "undecided";
 export type EnvironmentResolution = "approved" | "dismissed" | "unavailable";
 
 export interface EnvironmentOfferInfo {
-  sourceName?: string;
-  canonicalSourceUrl?: string;
   displayName?: string;
 }
 
@@ -48,9 +46,8 @@ export interface EnvironmentBundleOffer extends EnvironmentOfferInfo {
 export interface EnvironmentEventListener {
   /** An undecided bundle the user should review (prompt in UI). */
   onEnvironmentOffered(offer: EnvironmentBundleOffer): void;
-  /** Skills to load for this environment (approved/permanently-approved bundles only).
-   * `contextText` (when present) is ambient context pushed into the agent on enter. */
-  onEnvironmentEntered(environmentId: string, skillPaths: string[], contextText?: string): void;
+  /** Skills to load for this environment (approved/permanently-approved bundles only). */
+  onEnvironmentEntered(environmentId: string, skillPaths: string[]): void;
   /** Env left or was turned negative: remove skills (restart when idle). */
   onEnvironmentExited(environmentId: string): void;
   /** An offer was resolved (by any client, or because the env left): close prompts. */

--- a/server/src/server/location/LocationRegistrar.test.ts
+++ b/server/src/server/location/LocationRegistrar.test.ts
@@ -38,9 +38,8 @@ describe("LocationRegistrar", () => {
         id: "location:cicis.com/a",
         metadata: expect.objectContaining({
           current: true,
-          sourceName: "location:cicis.com/a",
-          canonicalSourceUrl: "https://cicis.com/x",
-          contextText: expect.stringContaining("location:cicis.com/a"),
+          displayName: "location:cicis.com/a",
+          observedUrls: ["https://cicis.com/x"],
         }),
       }),
     );
@@ -49,7 +48,7 @@ describe("LocationRegistrar", () => {
       2,
       expect.objectContaining({
         id: "location:gamestop.com/b",
-        metadata: expect.objectContaining({ current: false, sourceName: "location:gamestop.com/b" }),
+        metadata: expect.objectContaining({ current: false, displayName: "location:gamestop.com/b" }),
       }),
     );
   });
@@ -76,7 +75,7 @@ describe("LocationRegistrar", () => {
     expect(s.registerCandidateEnvironment).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "location:c/3",
-        metadata: expect.objectContaining({ sourceName: "location:c/3", contextText: expect.any(String) }),
+        metadata: expect.objectContaining({ displayName: "location:c/3" }),
       }),
     );
   });

--- a/server/src/server/location/LocationRegistrar.ts
+++ b/server/src/server/location/LocationRegistrar.ts
@@ -1,5 +1,5 @@
 import type { CandidateEnvironmentRecord, EnvironmentCandidate } from "../../shared/environment.js";
-import { renderLocationContextText, writeLocationContextSkill } from "./LocationContextSkill.js";
+import { writeLocationContextSkill } from "./LocationContextSkill.js";
 
 /** The slice of EnvironmentManager the registrar needs (eases testing). */
 export interface LocationEnvironmentSink {
@@ -86,7 +86,6 @@ export class LocationRegistrar {
 
     const [current, ...nearby] = candidates;
     const contextDir = this.writeContextSkill(current, nearby);
-    const contextText = renderLocationContextText(current, nearby);
 
     // Serve the synthesized context bundle through the repository facade so the
     // manager can discover it as a normal environment bundle (no extra runtime channel).
@@ -95,9 +94,8 @@ export class LocationRegistrar {
       id: current.environmentId,
       metadata: {
         ...metadataFor(current, true),
-        sourceName: current.displayName,
-        ...(current.website ? { canonicalSourceUrl: current.website } : {}),
-        contextText,
+        displayName: current.displayName,
+        ...(current.website ? { observedUrls: [current.website] } : {}),
       },
     });
     // Auto-enter the current location so the agent gets the context immediately.
@@ -108,8 +106,8 @@ export class LocationRegistrar {
         id: c.environmentId,
         metadata: {
           ...metadataFor(c, false),
-          sourceName: c.displayName,
-          ...(c.website ? { canonicalSourceUrl: c.website } : {}),
+          displayName: c.displayName,
+          ...(c.website ? { observedUrls: [c.website] } : {}),
         },
       });
     }

--- a/server/src/server/routes/environmentRoutes.ts
+++ b/server/src/server/routes/environmentRoutes.ts
@@ -27,19 +27,38 @@ export async function registerEnvironmentRoutes(
     }
 
     const typedMetadata = (metadata ?? {}) as CandidateEnvironmentMetadata;
-    if (typedMetadata.sourceName !== undefined && typeof typedMetadata.sourceName !== "string") {
-      reply.code(400).send({ error: "Invalid metadata.sourceName" });
+    if (typedMetadata.displayName !== undefined && typeof typedMetadata.displayName !== "string") {
+      reply.code(400).send({ error: "Invalid metadata.displayName" });
       return;
     }
-    if (typedMetadata.canonicalSourceUrl !== undefined && typeof typedMetadata.canonicalSourceUrl !== "string") {
-      reply.code(400).send({ error: "Invalid metadata.canonicalSourceUrl" });
-      return;
+    for (const [key, value] of [
+      ["observedPaths", typedMetadata.observedPaths],
+      ["observedUrls", typedMetadata.observedUrls],
+      ["detectedSkillPaths", typedMetadata.detectedSkillPaths],
+      ["detectedAgentsMdPaths", typedMetadata.detectedAgentsMdPaths],
+    ] as const) {
+      if (value !== undefined && (!Array.isArray(value) || value.some((item) => typeof item !== "string"))) {
+        reply.code(400).send({ error: `Invalid metadata.${key}` });
+        return;
+      }
+    }
+    for (const [key, value] of [
+      ["observerDeviceId", typedMetadata.observerDeviceId],
+      ["editableSkillPath", typedMetadata.editableSkillPath],
+      ["editableAgentMdPath", typedMetadata.editableAgentMdPath],
+    ] as const) {
+      if (value !== undefined && typeof value !== "string") {
+        reply.code(400).send({ error: `Invalid metadata.${key}` });
+        return;
+      }
     }
 
     const candidate: CandidateEnvironmentRecord = { id: id.trim(), metadata: typedMetadata };
-    request.log.info({ environmentId: candidate.id, sourceName: candidate.metadata.sourceName, canonicalSourceUrl: candidate.metadata.canonicalSourceUrl }, "environment candidate registered");
+    request.log.info({ environmentId: candidate.id, displayName: candidate.metadata.displayName }, "environment candidate registered");
 
-    await environmentManager.registerCandidateEnvironment(candidate);
+    void environmentManager.registerCandidateEnvironment(candidate).catch((error) => {
+      request.log.warn({ environmentId: candidate.id, error }, "environment candidate finalization failed");
+    });
     const registeredAt = new Date().toISOString();
     return { ok: true, id: candidate.id, registeredAt };
   });

--- a/server/src/shared/environment.ts
+++ b/server/src/shared/environment.ts
@@ -16,9 +16,14 @@ export interface EnvironmentPreview {
 }
 
 export interface CandidateEnvironmentMetadata extends Record<string, unknown> {
-  sourceName?: string;
-  canonicalSourceUrl?: string;
-  contextText?: string;
+  displayName?: string;
+  observedPaths?: string[];
+  observedUrls?: string[];
+  observerDeviceId?: string;
+  detectedSkillPaths?: string[];
+  detectedAgentsMdPaths?: string[];
+  editableSkillPath?: string;
+  editableAgentMdPath?: string;
 }
 
 export interface CandidateEnvironmentRecord {
@@ -57,8 +62,6 @@ export interface EnvironmentOfferAvailablePayload {
   displayName?: string;
   bundleId: string;
   bundleHash: string;
-  sourceName?: string;
-  canonicalSourceUrl?: string;
   skills: string[];
   mcpServers: string[];
   apps: string[];


### PR DESCRIPTION
Closes #102
Closes #93
Closes #78

## What changed

- Made environment registration and entry literal on the server instead of implicitly expanding parent environments.
- Switched candidate metadata over to `displayName`, `observedPaths`, `observedUrls`, and local capability-path hints.
- Removed the old secondary environment display/url/context fields from server + clients and cleaned up offer/list UI around the simpler model.
- Made the mac generic provider conservatively emit `dir:` environments only for first-pass project-like or agentic directories under `/Users/<username>`.
- Added async candidate finalization so the server can discover repository-backed capabilities from exact ids plus observed-path / observed-URL implied environments.

## Why it matters

- This cuts way down on noisy environment explosions from deep paths while keeping the useful capability lookup behavior.
- It also makes the system more honest about what the client actually saw: the client sends observations, the server finalizes environments, and sessions only enter what was explicitly chosen.
- On the Mac side, it gets us much closer to the “open file → meaningful project / AGENTS / skills context” behavior without flooding the environment list.

## Notes for reviewers

- First-pass directory heuristics are intentionally simple and high-precision.
- `package.json` is deliberately out for now.
- Android unit tests were not runnable here because the machine does not have a local Java runtime installed.
- `npm run typecheck` still hits pre-existing websocket typing errors in `server/src/server/acpFacade.test.ts` (`off` / `once`), unrelated to this PR.

## Product specification alignment

**Classification:** Modifies

**Related PRODUCT/ docs:**
- [`PRODUCT/relationship-between-sessions-and-environments.md`](PRODUCT/relationship-between-sessions-and-environments.md) — environment entry is now literal rather than implicitly entering parent environments
- [`PRODUCT/relationship-between-environments-skills-and-agent.md`](PRODUCT/relationship-between-environments-skills-and-agent.md) — observed paths/URLs can help discover known environments, but path hierarchy is no longer implicitly expanded into active environments
- [`PRODUCT/environment-local-authoring.md`](PRODUCT/environment-local-authoring.md) — environment metadata examples now reflect display names plus observed paths/URLs

**Documentation updates in this PR:**
- [x] [`PRODUCT/relationship-between-sessions-and-environments.md`](PRODUCT/relationship-between-sessions-and-environments.md) — updated session/environment semantics to be literal
- [x] [`PRODUCT/relationship-between-environments-skills-and-agent.md`](PRODUCT/relationship-between-environments-skills-and-agent.md) — updated environment model notes to match literal registration plus server-side finalization
- [x] [`PRODUCT/environment-local-authoring.md`](PRODUCT/environment-local-authoring.md) — updated metadata description

**Notes:** This resolves the earlier “hierarchical child implies parent” direction in favor of explicit entry plus server-side capability lookup from observed paths/URLs.

## Architecture alignment

**Classification:** Modifies

**Related docs / patterns:**
- [`AS-BUILT-ARCHITECTURE/server.md`](AS-BUILT-ARCHITECTURE/server.md) — candidate registration, finalization, and offer model
- [`AS-BUILT-ARCHITECTURE/mac-client.md`](AS-BUILT-ARCHITECTURE/mac-client.md) — generic provider path scanning and conservative `dir:` emission
- [`AS-BUILT-ARCHITECTURE/rookkit.md`](AS-BUILT-ARCHITECTURE/rookkit.md) — shared client models / API surface cleanup

**Documentation updates in this PR:**
- [x] [`AS-BUILT-ARCHITECTURE/server.md`](AS-BUILT-ARCHITECTURE/server.md) — updated offer shape and candidate-finalization flow
- [x] [`AS-BUILT-ARCHITECTURE/mac-client.md`](AS-BUILT-ARCHITECTURE/mac-client.md) — updated generic `dir:` behavior
- [x] [`AS-BUILT-ARCHITECTURE/rookkit.md`](AS-BUILT-ARCHITECTURE/rookkit.md) — updated shared API/model notes
- [x] [`AS-BUILT-ARCHITECTURE/iphone-client.md`](AS-BUILT-ARCHITECTURE/iphone-client.md) — removed outdated secondary-label behavior note
- [x] [`AS-BUILT-ARCHITECTURE/android-client.md`](AS-BUILT-ARCHITECTURE/android-client.md) — removed outdated secondary-label behavior note
- [x] [`server/README.md`](server/README.md) — documented candidate registration / async finalization
- [x] [`clients/mac/README.md`](clients/mac/README.md) — documented conservative `dir:` emission

**Notes:** The biggest architectural shift is moving from implicit hierarchy behavior to “candidate observations + async finalization + explicit environment entry.”

## Technical touchpoints

- **Components:** `EnvironmentManager`, `LocationRegistrar`, mac `GenericEnvironmentProvider`, environment provider metadata emitters, shared client models
- **APIs / protocols:** `POST /api/environments/register`, environment offer payloads, shared candidate metadata schema
- **Data / events:** `displayName`, `observedPaths`, `observedUrls`, `detectedSkillPaths`, `detectedAgentsMdPaths`, `editableSkillPath`, `editableAgentMdPath`

## How to check it

- [x] `cd server && npm test`
- [x] `cd clients/RookKit && swift test`
- [x] `cd clients/mac && xcodebuild test -project Rook.xcodeproj -scheme Rook -destination 'platform=macOS'`
- [ ] Optional: run `./scripts/run-rook.sh server mac` and confirm that opening files in a project only emits meaningful `dir:` environments instead of every path segment
