### PR TITLE
Emit only host-level web environments on mac

### DIFF
--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -116,7 +116,7 @@ Tracked foreground environments include:
   - `mac:com.descript.beachcube/<project>`
   - `mac:com.hnc.Discord/<server>/<channel>`
   - exact `dir:/...` folder environments discovered from Finder windows
-- frontmost browser pages as deepest `web:<host>/<path>` ids
+- frontmost browser pages as host-level `web:<host>` ids
 
 Examples:
 
@@ -132,7 +132,7 @@ Examples:
 - Finder frontmost in `/Users/johnberryman/projects/github/rookkeeper` →
   `dir:/Users/johnberryman/projects/github/rookkeeper`
 - `https://en.wikipedia.org/wiki/Main_Page?foo=bar` →
-  `web:en.wikipedia.org/wiki/Main_Page`
+  `web:en.wikipedia.org`
 
 The Mac app registers the exact encountered ID it sees at the moment, such as:
 
@@ -142,7 +142,7 @@ The Mac app registers the exact encountered ID it sees at the moment, such as:
 - `mac:com.descript.beachcube/AI%20Tinkerers%202026.05.22`
 - `mac:com.hnc.Discord/Build%20With%20AI/self-promotion`
 - `dir:/Users/johnberryman/projects/github/rookkeeper`
-- `web:en.wikipedia.org/wiki/Main_Page`
+- `web:en.wikipedia.org`
 
 Specialist providers now live under `Sources/Models/EnvironmentProviders/` and
 are assembled into an explicit bundle-id registry. Bundle IDs with no

--- a/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
@@ -256,17 +256,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
               let host = components.host?.lowercased(), !host.isEmpty else {
             return []
         }
-        let segments = components.percentEncodedPath
-            .split(separator: "/")
-            .map(String.init)
-            .filter { !$0.isEmpty }
-        var ids = ["web:\(host)"]
-        var current = host
-        for segment in segments {
-            current += "/\(segment)"
-            ids.append("web:\(current)")
-        }
-        return ids
+        return ["web:\(host)"]
     }
 
     private static func webDisplayName(for environmentId: String) -> String {

--- a/clients/mac/Tests/EnvironmentProviderSupportTests.swift
+++ b/clients/mac/Tests/EnvironmentProviderSupportTests.swift
@@ -3,17 +3,17 @@ import XCTest
 
 @MainActor
 final class EnvironmentProviderSupportTests: XCTestCase {
-    func testGenericWebEnvironmentIdsBuildHierarchy() {
+    func testGenericWebEnvironmentIdsEmitOnlyHostEnvironment() {
         XCTAssertEqual(
             GenericEnvironmentProvider.webEnvironmentIds(from: "https://example.com/a/b%20c?x=1"),
-            ["web:example.com", "web:example.com/a", "web:example.com/a/b%20c"]
+            ["web:example.com"]
         )
     }
 
-    func testGenericWebEnvironmentIdsLowercaseHostAndSkipEmptySegments() {
+    func testGenericWebEnvironmentIdsLowercaseHost() {
         XCTAssertEqual(
             GenericEnvironmentProvider.webEnvironmentIds(from: "https://Example.COM//A//B/"),
-            ["web:example.com", "web:example.com/A", "web:example.com/A/B"]
+            ["web:example.com"]
         )
     }
 


### PR DESCRIPTION
## What changed

- changed the mac generic environment provider to emit only `web:<host>` for browser URLs
- removed the old client-side web path hierarchy expansion
- updated the mac test coverage and README to match the host-only behavior
- closes #113

## Why it matters

- a single page like Google Calendar no longer turns into a stack of active 0-bundle environments
- this matches the current product direction better: the client emits the literal web environment it sees, and broader environment discovery can stay selective/server-side
- it removes test coverage that was accidentally locking in the old prefix-explosion behavior

## Notes for reviewers

- this is intentionally a mac-client behavior change only
- server-side selective finalization from observed URLs is unchanged
- the visible effect should be that browser environments collapse to one host-level entry instead of many path-prefix entries

## Product specification alignment

**Classification:** Implements

**Related PRODUCT/ docs:**
- [`PRODUCT/relationship-between-environments-skills-and-agent.md`](https://github.com/rookkeeper/rook/blob/main/PRODUCT/relationship-between-environments-skills-and-agent.md) — explicitly says Rook should not implicitly expand every path segment into an active environment
- [`PRODUCT/environment-repository.md`](https://github.com/rookkeeper/rook/blob/main/PRODUCT/environment-repository.md) — keeps `web:<host>` as the stable base environment shape
- [`PRODUCT/goals-of-rook.md`](https://github.com/rookkeeper/rook/blob/main/PRODUCT/goals-of-rook.md) — reduces noisy environment awareness without changing the broader product idea

**Documentation updates in this PR:**
- No PRODUCT/ updates — the existing PRODUCT docs already describe the intended direction

**Notes:** This PR brings the mac client behavior back in line with the current product intent rather than introducing a new concept.

## Architecture alignment

**Classification:** Extends

**Related docs / patterns:**
- `clients/mac` environment provider flow — narrows browser candidate emission to one host-level env
- server-side observed-URL finalization — left unchanged so repository-backed discovery still happens selectively

**Documentation updates in this PR:**
- [x] `clients/mac/README.md` — updated browser environment examples/wording

**Notes:** The architecture change is small but important: stop doing hierarchical web expansion in the mac client, and rely on the existing server-side finalization rules for any broader discovery.

## Technical touchpoints

- **Components:** `GenericEnvironmentProvider`
- **APIs / protocols:** no HTTP or ACP changes
- **Data / events:** emitted mac web environment IDs are now host-only

## How to check it

- [x] `xcodebuild -project clients/mac/Rook.xcodeproj -scheme Rook -sdk macosx -configuration Debug test`
- [ ] Open a deep browser URL like `https://calendar.google.com/calendar/u/0/r/week`
- [ ] Confirm the environment list shows `web:calendar.google.com` only, not the whole path hierarchy
