### PR TITLE
Add Mac image attachments to chat prompts

### DIFF
--- a/.agents/skills/product-architecture-pr/SKILL.md
+++ b/.agents/skills/product-architecture-pr/SKILL.md
@@ -107,6 +107,8 @@ Examples:
 
 Use the template in [pr-template.md](pr-template.md). And update it as indicated in the template. Keep it short, casual, and easy to scan. Point to paths or types for detail; do not duplicate the diff.
 
+When tests change, include the template's **New tests** section. Summarize only the main behaviors or boundaries covered in a few bullets; do not turn it into an exhaustive test inventory.
+
 ### 7. Ship the PR
 
 Follow repo git safety rules (no force-push to main, no `--no-verify` unless asked).

--- a/.agents/skills/product-architecture-pr/pr-template.md
+++ b/.agents/skills/product-architecture-pr/pr-template.md
@@ -40,6 +40,13 @@
 
 **Notes:** [Boundary changes, new components, deprecated patterns]
 
+## New tests
+
+_If tests changed, summarize the new behavior covered at a high level. Keep this to a few bullets; do not list every test case._
+
+- [Behavior or boundary covered]
+- [Regression or integration behavior covered]
+
 ## Technical touchpoints
 
 _Optional. Abstract only — major types, services, APIs, events, schemas._

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -32,6 +32,9 @@ The macOS client is a native SwiftUI menu bar app with a regular app window. It 
   - loopback HTTP bridge for agent perception and control
 - `ServerController`
   - starts/stops a local dev server process and tails logs
+  - inherits the launcher-selected server profile when launched from the Mac client
+- `MacImageAttachmentFactory`
+  - normalizes pasted/dropped images into bounded ACP-ready PNG attachments
 - voice/control services
   - `VoiceController`, `HotKey`, `InputSynthesizer`, `ScreenCapturer`, `ScreenOCR`
 
@@ -69,7 +72,7 @@ The client derives and registers:
 - server status and runtime catalog
 - session list and current session
 - `blocks: [ChatBlock]`
-- queued chat messages
+- queued chat messages containing ordered text/image prompt content
 - current mode/config options
 - pending permission requests
 - pending environment offers and environment previews
@@ -110,7 +113,7 @@ Via `RookKit`:
 5. resumed handles open a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and run `initialize`
 6. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
 7. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
-8. queued messages are delivered automatically once the agent goes idle
+8. queued messages, including image attachments, are delivered automatically once the agent goes idle
 
 ### Foreground environment detection
 1. `ForegroundAppMonitor` detects app activation or window-title change
@@ -154,3 +157,4 @@ Via `RookKit`:
 - environment registration is local-first and derived from visible user context plus app-owned local data where needed
 - the Mac bridge centralizes Accessibility, Automation, and Screen Recording permissions in one native app
 - reconnect and queued-message handling are built into the client reducer
+- Mac image paste/drop is normalized locally, inserted inline in the composer, and sent in order as standard ACP image content; it is never coupled to the runtime `cwd`

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -17,7 +17,7 @@
 - `Models/ApiTypes.swift`
   - runtime/session/environment/location DTOs
 - `Models/ChatBlocks.swift`
-  - client-side chat/event abstractions used by both apps
+  - client-side chat/event abstractions used by both apps, including ACP-ready image attachments
 - `Models/JSONValue.swift`
   - Codable dynamic JSON representation for round-tripping wire payloads
 - `Design/*`
@@ -37,7 +37,7 @@
 - `disconnect()`
 - `createSession(runtimeId:title:cwd:)`
 - `loadSession(_:)`
-- `sendPrompt(text:)`
+- `sendPrompt(content:)` for ordered text/image blocks
 - `sendCancel()`
 - `setMode(_:)`
 - `setConfigOption(configId:value:)`
@@ -89,6 +89,8 @@
 - `AcpPermissionToolCall`, `AcpPermissionOption`
 - `EnvironmentBanner`
 - `AcpClientEvent`
+- `ChatImageAttachment`
+- `ChatPromptContent` — ordered text/image prompt items used by the composer, queues, blocks, and ACP transport
 
 ## Main processes
 
@@ -109,6 +111,7 @@
 2. RookKit design views render the block list consistently across macOS and iOS
 3. markdown/tool payload helpers normalize output for display
 4. `EnvironmentListPresentation` applies shared list-refresh behavior for environment metadata
+5. image prompts use standard ACP image blocks in composer order; Mac paste/drop staging never becomes part of the runtime working-directory contract
 
 ## Notable architectural characteristics
 

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -16,6 +16,7 @@ The server is a Fastify service on `127.0.0.1:7665` with an optional second remo
   - restarts only the affected session when environment state changes
 - `runtime/SessionRuntime`
   - generic ACP stdio transport for a single session runtime process
+  - forwards standard ACP image prompt blocks unchanged to image-capable runtimes
   - initializes the subprocess, sends JSON-RPC, and relays notifications
 - `environments/services/EnvironmentManager`
   - tracks available environments, offers, approvals, active/recent state, and session subscriptions
@@ -68,7 +69,7 @@ See also: [database.md](./database.md)
   - `session/new` (unbound websocket only; success binds that websocket to the new public session)
   - `session/load`
   - `session/resume`
-  - `session/prompt`
+  - `session/prompt` (including standard ACP image blocks when the selected runtime supports them)
   - `session/cancel`
   - `session/set_mode`
   - `session/set_config_option`
@@ -93,7 +94,7 @@ See also: [database.md](./database.md)
 - `GET /api/diagnostics/environments`
 
 ### Runtime boundary
-`SessionRuntime` speaks newline-delimited ACP JSON-RPC over stdio to subprocesses launched from runtime profiles. Supported runtime types are configured, not implicit: `pi`, `claude`, `cursor`, and generic `acp`.
+`SessionRuntime` speaks newline-delimited ACP JSON-RPC over stdio to subprocesses launched from runtime profiles. Supported runtime types are configured, not implicit: `pi`, `claude`, `cursor`, and generic `acp`. Runtime profiles report image-prompt support explicitly (Pi defaults to supported), and the facade validates image MIME/data limits before forwarding.
 
 ## Persistence shape
 

--- a/CHANGES/2026-08-07-mac-image-attachments/README.md
+++ b/CHANGES/2026-08-07-mac-image-attachments/README.md
@@ -1,0 +1,58 @@
+# Mac chat image attachments
+
+## Scope
+
+Add image paste and drag-and-drop to the native macOS chat composer. The user can place image thumbnails inline between text runs, preserve that order in the ACP prompt, and send the composed content to the selected agent.
+
+## What the current code does
+
+- `clients/mac/Sources/Views/ChatView.swift` wraps an AppKit `NSTextView` in `ChatComposeTextView`. It currently synchronizes only a `String`, submits on Return, and has no pasteboard or drag destination handling.
+- `clients/RookKit/Sources/RookKit/Net/AcpSocket.swift` sends every prompt as one ACP `{ type: "text", text }` block. It does not model image blocks.
+- `clients/RookKit/Sources/RookKit/Net/SessionHandle.swift` and `ChatState.swift` queue text-only messages, so attachments must travel through the same busy/offline queue rather than being discarded when the agent is running.
+- `server/src/shared/acp.ts` defines only text prompt/content blocks. `server/src/runtime/routes/acpFacadeRoute.ts` advertises `promptCapabilities.image: false`.
+- The server facade already forwards the prompt JSON to the selected runtime. `pi-acp` already translates ACP image blocks into Pi RPC image attachments, and Pi itself supports image content in its model messages.
+- The existing server transcript normalization is text-oriented. If attachment previews are expected after a session reload or in a second viewer, the transcript path must preserve an image representation too.
+
+## What Pi is actually doing
+
+Pi's interactive TUI reads the native clipboard using its platform clipboard helper. For an image it writes the bytes to the operating-system temporary directory as a file named like `pi-clipboard-<uuid>.png`, then inserts that path into the editor. That is not the session working directory. The later prompt/file-processing path turns the image file into an image attachment. Dragged image files follow the same attachment-oriented path.
+
+For Rook, the better protocol boundary is the standard ACP image content block:
+
+```json
+{
+  "type": "image",
+  "mimeType": "image/png",
+  "data": "<base64>"
+}
+```
+
+The Mac client may still use an OS temporary file as a staging/lifetime mechanism, but it should send image bytes over ACP rather than sending a local path. This works when the Rook server or runtime is remote, avoids coupling an attachment to `cwd`, and is already supported by `pi-acp`. The first implementation normalizes images directly in memory and does not create a persistent staging file.
+
+## Implemented first-release shape
+
+The current implementation accepts clipboard images and dropped image files in the Mac composer, normalizes them to bounded PNG attachments in memory, inserts small thumbnails inline with the draft text, preserves text/image order through ACP, and sends them as standard ACP image blocks. The server advertises support per runtime/session and rejects unsupported or malformed image prompts. Transcript persistence of full image bytes remains intentionally deferred; the local user bubble shows the ordered content for the current viewer.
+
+## Proposed implementation
+
+1. Add an attachment model in RookKit containing a stable ID, MIME type, and bounded image bytes. Keep the in-memory/queued representation bounded and make cleanup explicit.
+2. Extend the ACP prompt model and `AcpSocket.sendPrompt` to accept text plus image blocks. Advertise image support only when the selected runtime can process it; do not globally claim that Claude, Cursor, and arbitrary ACP runtimes support images merely because Pi does.
+3. Add a Mac-specific image intake path to `SubmitTextView`/its coordinator:
+   - intercept paste before AppKit inserts a textual representation;
+   - read image representations from `NSPasteboard` and normalize them to supported formats (initially PNG/JPEG, with a size/pixel limit);
+   - register dragged image files and image pasteboard data;
+   - reject unsupported files, duplicate drops, and oversized payloads with a visible composer error;
+   - do not expose or retain source filenames; the image bytes are the attachment.
+4. Insert a small image thumbnail at the current text insertion point. Keep ordinary text editing, Return, Shift+Return, and image deletion behavior. Enable Send when there is text or at least one image.
+5. Thread attachments through `RookMacModel` → `ChatSessionController` → `SessionHandle`, including queued messages while a run is active or while reconnecting. Only clear attachments after the message has been accepted into immediate delivery or the queue.
+6. Extend shared chat rendering enough to show the sent image in the user message. Decide whether this is a full persisted image preview or a lightweight “image attached” placeholder for the first release.
+7. Extend server ACP types, validation, capability negotiation, transcript normalization, and tests. Enforce MIME, pixel/byte limits, and safe base64 handling at the server boundary. Preserve text-only fallback behavior for runtimes that do not advertise image support.
+8. Update Mac/RookKit/server READMEs and the relevant as-built architecture notes after implementation. Product docs should only change if this introduces a durable concept such as general chat attachments.
+
+## Important design choices
+
+- Use standard ACP `ContentBlock::Image`; do not invent a Rook-specific prompt field.
+- Do not put pasted images in the session `cwd`, environment repository, or project checkout. Use the OS temp directory only for client-side staging, then send bytes through ACP.
+- Treat pasted images as user-controlled input: bound dimensions and encoded size, normalize formats, avoid retaining temp files indefinitely, and never execute or inspect image contents as files beyond decoding/validation.
+- Keep the first release Mac-focused. Shared ACP support belongs in RookKit/server so Pi works correctly, while iPhone/Android UI can remain text-only until their attachment UX is designed.
+- Verify Pi end-to-end first, then test a non-image runtime and a remote-server path so capability negotiation and fallback are real rather than assumed.

--- a/CHANGES/2026-08-07-mac-image-attachments/TODO.md
+++ b/CHANGES/2026-08-07-mac-image-attachments/TODO.md
@@ -1,0 +1,63 @@
+# Mac chat image attachments TODO
+
+## Discovery and decisions
+
+- [x] Confirm the first-release behavior: paste and drag image files into the composer, preview them, and send them with optional text.
+- [x] Decide that the first release shows current-viewer image previews but defers full image-byte transcript hydration.
+- [x] Set a 12 MB normalized PNG limit and 4096-pixel maximum dimension; accept PNG/JPEG/WebP/GIF at the server boundary.
+- [x] Keep normalized image bytes in the attachment value instead of creating persistent staging files.
+- [x] Define capability negotiation for a selected runtime so image support is not advertised for runtimes that cannot consume it.
+
+## ACP and server contract
+
+- [x] Extend `server/src/shared/acp.ts` with standard ACP image content blocks and prompt content unions.
+- [x] Extend `clients/RookKit/Sources/RookKit/Net/AcpSocket.swift` to send text plus `{ type: "image", mimeType, data }` blocks.
+- [x] Update `server/src/runtime/routes/acpFacadeRoute.ts` to advertise image support based on the selected/available runtime contract rather than the current hard-coded `false`.
+- [x] Ensure `AgentRuntimeManager`/`SessionRuntime` preserve image blocks unchanged when forwarding `session/prompt` to `pi-acp`.
+- [x] Validate image MIME types, base64 shape, and byte limits at the server boundary.
+- [x] Intentionally omit image bytes from normalized transcript events for this release; document the retention decision.
+- [x] Add server tests for image prompt forwarding, capability reporting, invalid data, and text-only runtime fallback.
+- [ ] Add an end-to-end Pi ACP test proving that an image prompt reaches Pi as an image attachment.
+
+## Shared Apple messaging state
+
+- [x] Add a RookKit attachment value type with stable identity, MIME type, and base64 data.
+- [x] Thread attachments through `SessionHandle.send`, immediate delivery, reconnect delivery, and queued-message storage.
+- [x] Keep attachment bytes available through queued delivery and deletion with no persistent staging resource.
+- [x] Add ordered prompt content to `ChatBlock`/`ChatBlockKind` and render current-viewer user text/image order.
+- [x] Keep transcript hydration text-only for this release without creating a misleading persisted image duplicate.
+- [x] Keep the iPhone client compiling and text-only.
+- [x] Add RookKit tests for attachment decoding and queue preservation.
+
+## Mac paste and drag/drop intake
+
+- [x] Extend `ChatComposeTextView`/`SubmitTextView` to detect image pasteboard data before inserting a text fallback.
+- [x] Read native macOS clipboard image types (`public.png`, `public.jpeg`, and compatible image representations) without depending on a textual file path.
+- [x] Add drag destination handling for image files and image data.
+- [x] Normalize image data to PNG and enforce the chosen dimensions/byte limits.
+- [x] Keep source filenames out of the attachment model and visible composer UI.
+- [x] Insert small image thumbnails inline at the composer caret, including between text runs.
+- [x] Allow submission with image-only prompts and keep the existing Return/Shift+Return behavior.
+- [x] Show recoverable preparation/validation errors in the composer without losing existing text or attachments.
+- [ ] Verify accessibility labels, keyboard focus, inline thumbnail deletion behavior, and dark/light appearance.
+
+## Model/controller integration
+
+- [x] Update `ChatDetail.submit()` so it submits text and attachments atomically and clears local state only after handoff.
+- [x] Update `RookMacModel` and `ChatSessionController` APIs to accept attachments.
+- [x] Ensure an attachment sent while the agent is running appears in the queue and is delivered with the text after the turn completes.
+- [x] Ensure an attachment sent while disconnected survives reconnect or fails visibly with cleanup.
+- [x] Prevent duplicate sends from the Return key and Send button.
+- [x] Add Mac tests for paste/drop intake and invalid/text-only handling.
+
+## Verification and documentation
+
+- [x] Run RookKit tests and Mac tests/build on macOS.
+- [x] Run server typecheck and test suites.
+- [ ] Manually verify clipboard paste from Screenshot/Preview, Finder drag-and-drop, image-only prompts, multi-line text plus image, and queued prompts.
+- [ ] Verify Pi receives the image and a vision-capable configured model can describe it.
+- [x] Verify a text-only runtime receives a clear unsupported behavior rather than a silent failure through server tests.
+- [x] Keep remote server operation independent of any Mac temporary path by sending image bytes over ACP.
+- [x] Update `clients/mac/README.md`, `server/README.md`, and relevant `AS-BUILT-ARCHITECTURE/` files.
+- [x] Review `PRODUCT/` and document the ACP image-block decision.
+- [x] Review the final diff for temporary-file leaks, oversized base64 payloads, and accidental changes to the existing text chat flow.

--- a/PRODUCT/agent-client-protocol.md
+++ b/PRODUCT/agent-client-protocol.md
@@ -14,6 +14,8 @@ Before ACP, Rookery used a custom realtime event vocabulary. ACP gives us a shar
 
 ## Rookery ACP extensions
 
+Standard ACP image content blocks are used for image-bearing prompts when the selected runtime advertises image support. Ordered text/image content is sent as ACP prompt blocks in the same sequence the user composed it. Rook does not turn Mac temporary file paths into a protocol-level attachment reference.
+
 ACP explicitly supports product-specific extensions in two ways:
 
 - custom data in `_meta`

--- a/clients/RookKit/Sources/RookKit/Design/ChatBlockViews.swift
+++ b/clients/RookKit/Sources/RookKit/Design/ChatBlockViews.swift
@@ -19,7 +19,9 @@ public struct ChatBlockView: View {
     public var body: some View {
         switch block.kind {
         case .user(let text):
-            UserBlockView(text: text)
+            UserBlockView(content: [.text(text)])
+        case .userContent(let content):
+            UserBlockView(content: content)
         case .assistantText(let text, let streaming):
             AssistantTextBlockView(text: text, streaming: streaming)
         case .thinking(let text, let streaming):
@@ -85,8 +87,10 @@ private func bubbleShape(tailAt corner: UnitPoint) -> UnevenRoundedRectangle {
 private struct UserBlockView: View {
     private static let collapsedLineLimit = 5
 
-    var text: String
+    var content: [ChatPromptContent]
     @State private var expanded = false
+
+    private var text: String { content.textValue }
 
     private var isCollapsedByDefault: Bool {
         estimatedLineCount(for: text) > Self.collapsedLineLimit
@@ -110,19 +114,43 @@ private struct UserBlockView: View {
                     }
                 }
 
-                Text(text)
-                    .font(.callout)
-                    .foregroundStyle(.white)
-                    .textSelection(.enabled)
-                    .multilineTextAlignment(.trailing)
-                    .lineLimit(isCollapsedByDefault && !expanded ? Self.collapsedLineLimit : nil)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
+                ForEach(Array(content.enumerated()), id: \.offset) { _, item in
+                    switch item {
+                    case .text(let text):
+                        Text(text)
+                            .font(.callout)
+                            .foregroundStyle(.white)
+                            .textSelection(.enabled)
+                            .multilineTextAlignment(.trailing)
+                            .lineLimit(isCollapsedByDefault && !expanded ? Self.collapsedLineLimit : nil)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    case .image(let attachment):
+                        if let image = chatImage(from: attachment) {
+                            image
+                                .resizable()
+                                .scaledToFit()
+                                .frame(maxWidth: 260, maxHeight: 220)
+                                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        }
+                    }
+                }
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .background(bubbleShape(tailAt: .bottomTrailing).fill(PanelPalette.accent))
         }
     }
+}
+
+private func chatImage(from attachment: ChatImageAttachment) -> Image? {
+    guard let data = attachment.data else { return nil }
+#if os(macOS)
+    guard let image = NSImage(data: data) else { return nil }
+    return Image(nsImage: image)
+#else
+    guard let image = UIImage(data: data) else { return nil }
+    return Image(uiImage: image)
+#endif
 }
 
 private struct AssistantTextBlockView: View {

--- a/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
@@ -35,6 +35,7 @@ public struct AgentSessionSummary: Equatable, Identifiable {
 
     public var id: String { raw["id"]?.stringValue ?? raw["sessionId"]?.stringValue ?? "" }
     public var agent: String { raw["agent"]?.stringValue ?? raw["_meta"]?["runtimeId"]?.stringValue ?? "" }
+    public var supportsImagePrompts: Bool { raw["supportsImagePrompts"]?.boolValue ?? raw["_meta"]?["supportsImagePrompts"]?.boolValue ?? false }
     public var name: String { raw["name"]?.stringValue ?? raw["title"]?.stringValue ?? "default" }
     public var running: Bool { raw["running"]?.boolValue ?? false }
     public var connectedClients: Int { Int(raw["connectedClients"]?.numberValue ?? 0) }

--- a/clients/RookKit/Sources/RookKit/Models/ChatBlocks.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ChatBlocks.swift
@@ -168,8 +168,70 @@ public struct EnvironmentBanner: Equatable {
     }
 }
 
+/// An image attachment carried in an ACP prompt. Data is base64 so the same
+/// value can be queued locally and serialized into a JSON-RPC prompt block.
+public struct ChatImageAttachment: Equatable, Identifiable {
+    public let id: String
+    public let mimeType: String
+    public let base64Data: String
+
+    public init(id: String = UUID().uuidString, mimeType: String, base64Data: String) {
+        self.id = id
+        self.mimeType = mimeType
+        self.base64Data = base64Data
+    }
+
+    public var data: Data? { Data(base64Encoded: base64Data) }
+}
+
+/// Ordered prompt content. Keeping text and images in one sequence preserves
+/// the order in which the user composed the request.
+public enum ChatPromptContent: Equatable {
+    case text(String)
+    case image(ChatImageAttachment)
+
+    public var textValue: String {
+        switch self {
+        case .text(let text): return text
+        case .image: return ""
+        }
+    }
+
+    public var imageValue: ChatImageAttachment? {
+        switch self {
+        case .text: return nil
+        case .image(let image): return image
+        }
+    }
+}
+
+public extension Array where Element == ChatPromptContent {
+    var textValue: String { compactMap(\.textValue).joined() }
+    var images: [ChatImageAttachment] { compactMap(\.imageValue) }
+    var isEmptyPrompt: Bool { images.isEmpty && textValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+    func replacingText(with text: String) -> [ChatPromptContent] {
+        var result: [ChatPromptContent] = []
+        var inserted = false
+        for item in self {
+            switch item {
+            case .text:
+                if !inserted, !text.isEmpty {
+                    result.append(.text(text))
+                    inserted = true
+                }
+            case .image:
+                result.append(item)
+            }
+        }
+        if !inserted, !text.isEmpty { result.insert(.text(text), at: 0) }
+        return result
+    }
+}
+
 public enum ChatBlockKind: Equatable {
     case user(text: String)
+    case userContent([ChatPromptContent])
     case assistantText(text: String, streaming: Bool)
     case thinking(text: String, streaming: Bool)
     case tool(ToolBlockState)

--- a/clients/RookKit/Sources/RookKit/Models/ChatState.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ChatState.swift
@@ -4,14 +4,17 @@ import Foundation
 
 public struct QueuedChatMessage: Identifiable, Equatable {
     public let id: String
-    public var text: String
+    public var content: [ChatPromptContent]
     public var draftText: String
     public var isEditing = false
 
-    public init(id: String, text: String, draftText: String, isEditing: Bool = false) {
+    public var text: String { content.textValue }
+    public var images: [ChatImageAttachment] { content.images }
+
+    public init(id: String, content: [ChatPromptContent], draftText: String? = nil, isEditing: Bool = false) {
         self.id = id
-        self.text = text
-        self.draftText = draftText
+        self.content = content
+        self.draftText = draftText ?? content.textValue
         self.isEditing = isEditing
     }
 }

--- a/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
+++ b/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
@@ -9,6 +9,7 @@ public final class AcpSocket {
 
     public private(set) var isConnected = false
     public private(set) var currentSessionId: String?
+    public private(set) var supportsImagePrompts = false
 
     private var task: URLSessionWebSocketTask?
     private var connectTask: Task<[String: Any], Error>?
@@ -45,6 +46,7 @@ public final class AcpSocket {
         task = nil
         connectTask = nil
         currentSessionId = nil
+        supportsImagePrompts = false
         runtimeIDs = []
         defaultRuntimeID = nil
         environmentOfferExtensionEnabled = false
@@ -60,6 +62,7 @@ public final class AcpSocket {
 
     public func runtimeCatalog() -> [String] { runtimeIDs }
     public func defaultRuntime() -> String? { defaultRuntimeID }
+    public func setSupportsImagePrompts(_ supported: Bool) { supportsImagePrompts = supported }
 
     public func selectSession(_ sessionId: String?) {
         currentSessionId = sessionId
@@ -90,12 +93,14 @@ public final class AcpSocket {
         guard let sessionId = result["sessionId"] as? String else {
             throw SocketError.server("Server returned no sessionId")
         }
+        supportsImagePrompts = imagePromptCapability(from: result)
         currentSessionId = sessionId
         return sessionId
     }
 
     public func loadSession(_ sessionId: String) async throws {
-        _ = try await request(method: "session/load", params: ["sessionId": sessionId])
+        let result = try await request(method: "session/load", params: ["sessionId": sessionId])
+        supportsImagePrompts = imagePromptCapability(from: result)
         currentSessionId = sessionId
     }
 
@@ -106,22 +111,35 @@ public final class AcpSocket {
         }
     }
 
-    public func sendPrompt(text: String) {
+    public func sendPrompt(content: [ChatPromptContent]) {
         guard let sessionId = currentSessionId else {
             onEvent?(.connectionError(message: "Not connected to a session"))
             return
         }
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+        guard !content.isEmptyPrompt else { return }
         nextRequestID += 1
         let requestId = "prompt-\(nextRequestID)"
         pendingPromptIds.insert(requestId)
-        pendingUserMessageEchoes.append(trimmed)
+        let text = content.textValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !text.isEmpty { pendingUserMessageEchoes.append(text) }
+        let prompt: [[String: Any]] = content.compactMap { item in
+            switch item {
+            case .text(let value):
+                guard !value.isEmpty else { return nil }
+                return ["type": "text", "text": value]
+            case .image(let image):
+                return [
+                    "type": "image",
+                    "mimeType": image.mimeType,
+                    "data": image.base64Data,
+                ]
+            }
+        }
         Task {
             do {
                 let _ = try await sendRequest(id: requestId, method: "session/prompt", params: [
                     "sessionId": sessionId,
-                    "prompt": [["type": "text", "text": trimmed]],
+                    "prompt": prompt,
                 ])
             } catch {
                 pendingPromptIds.remove(requestId)
@@ -208,6 +226,10 @@ public final class AcpSocket {
             "clientInfo": ["name": "rook", "title": "Rook", "version": "0.1.0"],
         ])
         let meta = initialize["_meta"] as? [String: Any]
+        if let agentCapabilities = initialize["agentCapabilities"] as? [String: Any],
+           let promptCapabilities = agentCapabilities["promptCapabilities"] as? [String: Any] {
+            supportsImagePrompts = promptCapabilities["image"] as? Bool ?? false
+        }
         runtimeIDs = (meta?["runtimeIds"] as? [String]) ?? []
         defaultRuntimeID = meta?["defaultRuntimeId"] as? String
         if let ext = meta?["com.rookkeeper"] as? [String: Any], ext["environmentOffers"] != nil {
@@ -425,6 +447,11 @@ public final class AcpSocket {
         }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed == "{}" ? nil : trimmed
+    }
+
+    private func imagePromptCapability(from result: [String: Any]) -> Bool {
+        guard let capabilities = result["promptCapabilities"] as? [String: Any] else { return false }
+        return capabilities["image"] as? Bool ?? false
     }
 
     private func parseUsageCost(_ value: Any?) -> AcpUsageCost? {

--- a/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
+++ b/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
@@ -25,6 +25,7 @@ public final class SessionHandle {
     public private(set) var isRunning = false { didSet { onStateChange?() } }
     public private(set) var statusLine = "" { didSet { onStateChange?() } }
     public private(set) var socketConnected = false { didSet { onStateChange?() } }
+    public var supportsImagePrompts: Bool { socket.supportsImagePrompts }
     public private(set) var reconnecting = false { didSet { onStateChange?() } }
     public private(set) var contextUsage: ContextUsageState? { didSet { onStateChange?() } }
     public private(set) var currentModes: AcpModesState? { didSet { onStateChange?() } }
@@ -54,11 +55,14 @@ public final class SessionHandle {
     private var replayAssistantBuffer = ""
     private var replayThinkingBuffer = ""
 
-    public init(sessionId: String, api: RookAPI, socket: AcpSocket? = nil, isLoaded: Bool = false) {
+    public init(sessionId: String, api: RookAPI, socket: AcpSocket? = nil, isLoaded: Bool = false, supportsImagePrompts: Bool? = nil) {
         self.sessionId = sessionId
         self.api = api
         self.socket = socket ?? AcpSocket()
         self.isLoaded = isLoaded
+        if let supportsImagePrompts {
+            self.socket.setSupportsImagePrompts(supportsImagePrompts)
+        }
         self.socket.onEvent = { [weak self] event in
             self?.handleSocketEvent(event)
         }
@@ -126,17 +130,20 @@ public final class SessionHandle {
 
     // MARK: - Messaging
 
-    public func send(_ text: String) {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
+    public func send(_ content: [ChatPromptContent]) {
+        guard !content.isEmptyPrompt else { return }
+        guard content.images.isEmpty || socket.supportsImagePrompts else {
+            appendErrorBlock(source: "prompt", message: "The selected runtime does not support image prompts.")
+            return
+        }
         if isRunning || !socket.isConnected {
-            queuedMessages.append(makeQueuedMessage(trimmed))
+            queuedMessages.append(makeQueuedMessage(content))
             if !socket.isConnected {
                 scheduleReconnect(delaySeconds: 0)
             }
             return
         }
-        deliver(trimmed)
+        deliver(content)
     }
 
     public func removeQueuedMessage(at index: Int) {
@@ -159,7 +166,9 @@ public final class SessionHandle {
     public func saveQueuedMessageEdit(_ id: String) {
         updateQueuedMessage(id) { message in
             let trimmed = message.draftText.trimmingCharacters(in: .whitespacesAndNewlines)
-            message.text = trimmed.isEmpty ? message.text : trimmed
+            if !trimmed.isEmpty {
+                message.content = message.content.replacingText(with: trimmed)
+            }
             message.draftText = message.text
             message.isEditing = false
         }
@@ -345,14 +354,14 @@ public final class SessionHandle {
 
     // MARK: - Private: delivery
 
-    private func deliver(_ text: String) {
+    private func deliver(_ content: [ChatPromptContent]) {
         finalizeStreamingBlocks()
-        appendBlock(.user(text: text))
+        appendBlock(.userContent(content))
         isRunning = true
         statusLine = "Agent is working…"
         lastStopReason = nil
         autoScrollEnabled = true
-        socket.sendPrompt(text: text)
+        socket.sendPrompt(content: content)
     }
 
     private func deliverNextQueuedIfIdle() {
@@ -364,7 +373,7 @@ public final class SessionHandle {
                 queuedMessages.insert(next, at: 0)
                 return
             }
-            deliver(next.text)
+            deliver(next.content)
         }
     }
 
@@ -531,9 +540,9 @@ public final class SessionHandle {
 
     // MARK: - Private: blocks / streaming
 
-    private func makeQueuedMessage(_ text: String) -> QueuedChatMessage {
+    private func makeQueuedMessage(_ content: [ChatPromptContent]) -> QueuedChatMessage {
         queuedMessageCounter += 1
-        return QueuedChatMessage(id: "queued-\(queuedMessageCounter)", text: text, draftText: text)
+        return QueuedChatMessage(id: "queued-\(queuedMessageCounter)", content: content)
     }
 
     private func updateQueuedMessage(_ id: String, mutate: (inout QueuedChatMessage) -> Void) {

--- a/clients/RookKit/Tests/RookKitTests/ChatImageAttachmentTests.swift
+++ b/clients/RookKit/Tests/RookKitTests/ChatImageAttachmentTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import RookKit
+
+final class ChatImageAttachmentTests: XCTestCase {
+    func testImageAttachmentDecodesBase64Data() {
+        let attachment = ChatImageAttachment(mimeType: "image/png", base64Data: Data("image".utf8).base64EncodedString())
+
+        XCTAssertEqual(attachment.mimeType, "image/png")
+        XCTAssertEqual(attachment.data, Data("image".utf8))
+    }
+
+    func testQueuedMessageRetainsImages() {
+        let image = ChatImageAttachment(mimeType: "image/png", base64Data: "aGVsbG8=")
+        let message = QueuedChatMessage(id: "queued-1", content: [.text("describe"), .image(image)])
+
+        XCTAssertEqual(message.images, [image])
+    }
+
+    func testPromptContentPreservesTextImageTextOrder() {
+        let first = ChatImageAttachment(mimeType: "image/png", base64Data: "Zmlyc3Q=")
+        let second = ChatImageAttachment(mimeType: "image/png", base64Data: "c2Vjb25k")
+        let content: [ChatPromptContent] = [
+            .text("before"),
+            .image(first),
+            .text("between"),
+            .image(second),
+            .text("after"),
+        ]
+
+        XCTAssertEqual(content.images, [first, second])
+        XCTAssertEqual(content.textValue, "beforebetweenafter")
+        XCTAssertEqual(content.replacingText(with: "edited").images, [first, second])
+    }
+}

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -20,7 +20,9 @@ WebSocket protocol. For repo-level setup, `.env`, binding, and auth, start with
   input/output (including auto-rendering well-formed JSON tool arguments as
   human-readable YAML), and assistant markdown with native drag-selection,
   standard copy/paste behavior, a copy-source button, and progressive
-  render-as-it-streams for stabilized markdown prefixes; also renders plans,
+  render-as-it-streams for stabilized markdown prefixes. The composer accepts
+  pasted or dragged images, inserts thumbnails inline with text, preserves their
+  order, and sends them as standard ACP image blocks; it also renders plans,
   run errors, stop/cancel semantics, context usage, and optional usage cost.
 - **ACP controls** — native support for permission requests
   (`session/request_permission`), session mode changes (`session/set_mode` /

--- a/clients/mac/Rook.xcodeproj/project.pbxproj
+++ b/clients/mac/Rook.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3940FBAF5C395485EF47AD06 /* DescriptEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B45927F85F1F4A50E48CCDF /* DescriptEnvironmentProviderTests.swift */; };
 		419704B079AFD2478AA896D9 /* ObsidianEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941EDDB77C90AA9FD6843DD6 /* ObsidianEnvironmentProviderTests.swift */; };
 		437DFA10167DD112587F7EB5 /* EnvironmentsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93A5264726E74327D489A47 /* EnvironmentsDetailView.swift */; };
+		60A23F92DBE7E8434F6058CD /* MacImageAttachmentFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DA2212E080B005F7111E80 /* MacImageAttachmentFactoryTests.swift */; };
 		620DCBCC3C91EFE21C5C2697 /* RookKit in Frameworks */ = {isa = PBXBuildFile; productRef = 08EDA88AD90E24EB23D3D170 /* RookKit */; };
 		63D2E0332EA1C12AED347106 /* DescriptEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6978A7CFCFEF87F2952C4AC5 /* DescriptEnvironmentProvider.swift */; };
 		64732F130DD711AA245FEE1A /* ScreenCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684A1389822C3C6175B654FC /* ScreenCapturer.swift */; };
@@ -43,6 +44,7 @@
 		CEEBCE8607A6BCB97868C2A0 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F2330969071E5BF5037823E /* ChatView.swift */; };
 		D323C04BBED012225BCB910F /* AppEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB3BA363AD70B9B41E1823F /* AppEnvironmentProvider.swift */; };
 		E1AE321D976D7E91E7CCE85F /* EnvironmentOfferControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 700CE33894B323CBE9D99B12 /* EnvironmentOfferControllerTests.swift */; };
+		EB7ED8FCC7C9597E430A20D7 /* MacImageAttachmentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208361F86466FB1CF444A79B /* MacImageAttachmentFactory.swift */; };
 		EBC50709AA957F9E95F341E3 /* LogViewerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0087B8D63F86E9DD505D802D /* LogViewerView.swift */; };
 		EC3CCE47D902A251BD27408A /* RookMacChatSessionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */; };
 /* End PBXBuildFile section */
@@ -61,6 +63,7 @@
 		0087B8D63F86E9DD505D802D /* LogViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogViewerView.swift; sourceTree = "<group>"; };
 		08EF90459F4F62F45D925B32 /* AXReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AXReader.swift; sourceTree = "<group>"; };
 		1FD0CA244739F56CDABF5F1C /* OBSStudioEnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OBSStudioEnvironmentProviderTests.swift; sourceTree = "<group>"; };
+		208361F86466FB1CF444A79B /* MacImageAttachmentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacImageAttachmentFactory.swift; sourceTree = "<group>"; };
 		25E9E22AB1F639E8B0DA98B4 /* FinderEnvironmentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderEnvironmentProvider.swift; sourceTree = "<group>"; };
 		269B251888C4528269DA7E81 /* RookMacSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookMacSupport.swift; sourceTree = "<group>"; };
 		2970A475DCF3F26A17C649E2 /* Rook.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rook.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -79,6 +82,7 @@
 		684A1389822C3C6175B654FC /* ScreenCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturer.swift; sourceTree = "<group>"; };
 		6978A7CFCFEF87F2952C4AC5 /* DescriptEnvironmentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptEnvironmentProvider.swift; sourceTree = "<group>"; };
 		700CE33894B323CBE9D99B12 /* EnvironmentOfferControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentOfferControllerTests.swift; sourceTree = "<group>"; };
+		77DA2212E080B005F7111E80 /* MacImageAttachmentFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacImageAttachmentFactoryTests.swift; sourceTree = "<group>"; };
 		7F2330969071E5BF5037823E /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		891E038256B011C6B53596BB /* HotKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotKey.swift; sourceTree = "<group>"; };
 		89D369786A8FE57C99D452D1 /* RookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookView.swift; sourceTree = "<group>"; };
@@ -165,6 +169,7 @@
 				700CE33894B323CBE9D99B12 /* EnvironmentOfferControllerTests.swift */,
 				F944826D4DF0C05CAB24B551 /* EnvironmentProviderSupportTests.swift */,
 				E9E5581B2B0E5B8573C71E69 /* FinderEnvironmentProviderTests.swift */,
+				77DA2212E080B005F7111E80 /* MacImageAttachmentFactoryTests.swift */,
 				941EDDB77C90AA9FD6843DD6 /* ObsidianEnvironmentProviderTests.swift */,
 				1FD0CA244739F56CDABF5F1C /* OBSStudioEnvironmentProviderTests.swift */,
 				3343AE46AAED661AD40C912B /* SlackEnvironmentProviderTests.swift */,
@@ -204,6 +209,7 @@
 				891E038256B011C6B53596BB /* HotKey.swift */,
 				5143B8CA8023334102A62F2C /* InputSynthesizer.swift */,
 				FCDBF5403D71795728D9928A /* MacBridge.swift */,
+				208361F86466FB1CF444A79B /* MacImageAttachmentFactory.swift */,
 				684A1389822C3C6175B654FC /* ScreenCapturer.swift */,
 				31C1E516358520D9FFE6E0AE /* ScreenOCR.swift */,
 				3AE9A6A5B6DDFA2693DF009B /* ServerController.swift */,
@@ -340,6 +346,7 @@
 				C0541E82132250AD65401A01 /* InputSynthesizer.swift in Sources */,
 				EBC50709AA957F9E95F341E3 /* LogViewerView.swift in Sources */,
 				86F91627A128BBD4CBF341B2 /* MacBridge.swift in Sources */,
+				EB7ED8FCC7C9597E430A20D7 /* MacImageAttachmentFactory.swift in Sources */,
 				A42863FF4BE5CA2C3871D94D /* OBSStudioEnvironmentProvider.swift in Sources */,
 				071B3FB59CED95720606766F /* ObsidianEnvironmentProvider.swift in Sources */,
 				BC167FA11552D7BB927EA275 /* RookApp.swift in Sources */,
@@ -364,6 +371,7 @@
 				E1AE321D976D7E91E7CCE85F /* EnvironmentOfferControllerTests.swift in Sources */,
 				85C2D954A01F79270B40A48D /* EnvironmentProviderSupportTests.swift in Sources */,
 				C85887BE97842995601DE67E /* FinderEnvironmentProviderTests.swift in Sources */,
+				60A23F92DBE7E8434F6058CD /* MacImageAttachmentFactoryTests.swift in Sources */,
 				159D103CE9B49E8DBB2CA0F5 /* OBSStudioEnvironmentProviderTests.swift in Sources */,
 				419704B079AFD2478AA896D9 /* ObsidianEnvironmentProviderTests.swift in Sources */,
 				C1C532DBF0E733EDBEE32EEA /* SlackEnvironmentProviderTests.swift in Sources */,

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -46,6 +46,7 @@ final class ChatSessionController {
     var isRunning: Bool { currentHandle?.isRunning ?? false }
     var statusLine: String { currentHandle?.statusLine ?? "" }
     var socketConnected: Bool { currentHandle?.socketConnected ?? false }
+    var supportsImagePrompts: Bool { currentHandle?.supportsImagePrompts ?? false }
     var reconnecting: Bool { currentHandle?.reconnecting ?? false }
     var contextUsage: ContextUsageState? { currentHandle?.contextUsage }
     var currentModes: AcpModesState? { currentHandle?.currentModes }
@@ -157,7 +158,7 @@ final class ChatSessionController {
         }
     }
 
-    func send(_ text: String) { currentHandle?.send(text) }
+    func send(_ content: [ChatPromptContent]) { currentHandle?.send(content) }
     func stopAgent() { currentHandle?.stopAgent() }
     func removeQueuedMessage(at index: Int) { currentHandle?.removeQueuedMessage(at: index) }
     func beginEditingQueuedMessage(_ id: String) { currentHandle?.beginEditingQueuedMessage(id) }
@@ -179,7 +180,7 @@ final class ChatSessionController {
 
     private func getOrCreateHandle(for session: AgentSessionSummary) -> SessionHandle {
         if let existing = handles[session.id] { return existing }
-        let handle = SessionHandle(sessionId: session.id, api: api)
+        let handle = SessionHandle(sessionId: session.id, api: api, supportsImagePrompts: session.supportsImagePrompts)
         handles[session.id] = handle
         return handle
     }

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -43,6 +43,7 @@ final class RookMacModel: ObservableObject {
     @Published var isRunning = false
     @Published var statusLine = ""
     @Published var socketConnected = false
+    @Published var supportsImagePrompts = false
     @Published var reconnecting = false
     @Published var contextUsage: ContextUsageState?
     @Published var currentModes: AcpModesState?
@@ -214,6 +215,7 @@ final class RookMacModel: ObservableObject {
         isRunning = chatSessionController.isRunning
         statusLine = chatSessionController.statusLine
         socketConnected = chatSessionController.socketConnected
+        supportsImagePrompts = chatSessionController.supportsImagePrompts
         reconnecting = chatSessionController.reconnecting
         contextUsage = chatSessionController.contextUsage
         currentModes = chatSessionController.currentModes
@@ -424,8 +426,8 @@ final class RookMacModel: ObservableObject {
         }
     }
 
-    func send(_ text: String) {
-        chatSessionController.send(text)
+    func send(_ content: [ChatPromptContent]) {
+        chatSessionController.send(content)
     }
 
     func stopAgent() {

--- a/clients/mac/Sources/Services/MacImageAttachmentFactory.swift
+++ b/clients/mac/Sources/Services/MacImageAttachmentFactory.swift
@@ -1,0 +1,90 @@
+import AppKit
+import Foundation
+import ImageIO
+import RookKit
+import UniformTypeIdentifiers
+
+/// Converts macOS clipboard and drag/drop image representations into bounded
+/// ACP-ready attachments. Images are normalized to PNG before transmission.
+enum MacImageAttachmentFactory {
+    private static let maxBytes = 12 * 1024 * 1024
+    private static let maxPixelSize = 4096
+
+    static func make(from pasteboard: NSPasteboard) throws -> ChatImageAttachment? {
+        if let objects = pasteboard.readObjects(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]),
+           let object = objects.first {
+            if let url = object as? URL {
+                return try make(from: url)
+            }
+            if let url = object as? NSURL, url.isFileURL, let path = url.path {
+                return try make(from: URL(fileURLWithPath: path))
+            }
+        }
+
+        let imageTypes: [NSPasteboard.PasteboardType] = [
+            .png,
+            NSPasteboard.PasteboardType(UTType.png.identifier),
+            .tiff,
+            NSPasteboard.PasteboardType(UTType.tiff.identifier),
+            NSPasteboard.PasteboardType(UTType.jpeg.identifier),
+            NSPasteboard.PasteboardType(UTType.gif.identifier),
+            NSPasteboard.PasteboardType(UTType.webP.identifier),
+            NSPasteboard.PasteboardType(UTType.image.identifier),
+        ]
+        for type in imageTypes {
+            if let imageData = pasteboard.data(forType: type) {
+                return try make(data: imageData)
+            }
+        }
+        return nil
+    }
+
+    static func make(from url: URL) throws -> ChatImageAttachment? {
+        guard url.isFileURL else { return nil }
+        let values = try? url.resourceValues(forKeys: [.contentTypeKey])
+        if let contentType = values?.contentType, !contentType.conforms(to: .image) {
+            return nil
+        }
+        let data = try Data(contentsOf: url)
+        return try make(data: data)
+    }
+
+    private static func make(data: Data) throws -> ChatImageAttachment {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else {
+            throw ImageAttachmentError.invalidImage
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+        ]
+        guard let image = CGImageSourceCreateThumbnailAtIndex(source, 0, options as CFDictionary) else {
+            throw ImageAttachmentError.invalidImage
+        }
+        let bitmap = NSBitmapImageRep(cgImage: image)
+        guard let pngData = bitmap.representation(using: .png, properties: [:]) else {
+            throw ImageAttachmentError.invalidImage
+        }
+        guard pngData.count <= maxBytes else {
+            throw ImageAttachmentError.tooLarge
+        }
+        return ChatImageAttachment(
+            mimeType: "image/png",
+            base64Data: pngData.base64EncodedString()
+        )
+    }
+
+    enum ImageAttachmentError: LocalizedError {
+        case invalidImage
+        case tooLarge
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidImage:
+                return "That file does not contain a readable image."
+            case .tooLarge:
+                return "That image is too large to attach (12 MB maximum)."
+            }
+        }
+    }
+}

--- a/clients/mac/Sources/Views/ChatView.swift
+++ b/clients/mac/Sources/Views/ChatView.swift
@@ -2,6 +2,7 @@ import AppKit
 import Foundation
 import RookKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ChatDetail: View {
     @ObservedObject var model: RookMacModel
@@ -12,6 +13,8 @@ struct ChatDetail: View {
     @State private var isHoveringSend = false
     @State private var settingsExpanded = false
     @State private var threadIsAtBottom = true
+    @State private var composerContent: [ChatPromptContent] = []
+    @State private var composeError = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -37,6 +40,13 @@ struct ChatDetail: View {
 
             if settingsExpanded, hasSettings {
                 settingsCard
+            }
+
+            if !composeError.isEmpty {
+                Text(composeError)
+                    .font(.caption)
+                    .foregroundStyle(PanelPalette.danger)
+                    .padding(.horizontal, 6)
             }
 
             statusRow
@@ -237,6 +247,11 @@ struct ChatDetail: View {
                             .truncationMode(.tail)
                         Spacer(minLength: 4)
                         HStack(spacing: 6) {
+                            if !message.images.isEmpty {
+                                Label("\(message.images.count)", systemImage: "photo")
+                                    .font(.caption2)
+                                    .foregroundStyle(PanelPalette.secondaryText)
+                            }
                             queueButton("Edit", systemImage: "pencil", tint: PanelPalette.secondaryText) {
                                 model.beginEditingQueuedMessage(message.id)
                             }
@@ -327,10 +342,19 @@ struct ChatDetail: View {
     private var composeRow: some View {
         HStack(alignment: .bottom, spacing: 8) {
             ChatComposeTextView(
-                text: $draft,
+                content: $composerContent,
                 placeholder: composePlaceholder,
                 measuredHeight: $composeHeight,
-                onSubmit: submit
+                onSubmit: submit,
+                onContentChange: { content in
+                    guard content.images.isEmpty || model.supportsImagePrompts else {
+                        composeError = "The selected runtime does not support image prompts."
+                        return
+                    }
+                    composerContent = content
+                    composeError = ""
+                },
+                onError: { composeError = $0 }
             )
             .frame(minHeight: 38, maxHeight: 96)
             .frame(height: min(max(composeHeight, 38), 96))
@@ -358,7 +382,7 @@ struct ChatDetail: View {
             .onHover { isHoveringSend = $0 }
             .buttonStyle(.plain)
             .help(model.isRunning ? "Queue message" : "Send message")
-            .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            .disabled(composerContent.isEmptyPrompt)
             .pointingHandOnHover()
         }
     }
@@ -452,21 +476,25 @@ struct ChatDetail: View {
     }
 
     private func submit() {
-        let text = draft
-        draft = ""
+        let content = composerContent
+        guard !content.isEmptyPrompt else { return }
+        composerContent = []
+        composeError = ""
         model.resumeAutoScroll()
-        model.send(text)
+        model.send(content)
     }
 }
 
 private struct ChatComposeTextView: NSViewRepresentable {
-    @Binding var text: String
+    @Binding var content: [ChatPromptContent]
     var placeholder: String
     @Binding var measuredHeight: CGFloat
     var onSubmit: () -> Void
+    var onContentChange: ([ChatPromptContent]) -> Void
+    var onError: (String) -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text, placeholder: placeholder, measuredHeight: $measuredHeight, onSubmit: onSubmit)
+        Coordinator(content: $content, placeholder: placeholder, measuredHeight: $measuredHeight, onSubmit: onSubmit, onContentChange: onContentChange, onError: onError)
     }
 
     func makeNSView(context: Context) -> NSScrollView {
@@ -487,6 +515,22 @@ private struct ChatComposeTextView: NSViewRepresentable {
         textView.textContainer?.widthTracksTextView = true
         textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
         textView.delegate = context.coordinator
+        textView.onPasteImage = { [weak coordinator = context.coordinator, weak textView] in
+            guard let textView else { return false }
+            return coordinator?.handlePasteboard(NSPasteboard.general, in: textView) ?? false
+        }
+        textView.onDrop = { [weak coordinator = context.coordinator, weak textView] pasteboard in
+            guard let textView else { return false }
+            return coordinator?.handlePasteboard(pasteboard, in: textView) ?? false
+        }
+        textView.registerForDraggedTypes([
+            .fileURL,
+            .png,
+            .tiff,
+            NSPasteboard.PasteboardType(UTType.jpeg.identifier),
+            NSPasteboard.PasteboardType(UTType.gif.identifier),
+            NSPasteboard.PasteboardType(UTType.webP.identifier),
+        ])
         textView.drawsBackground = false
         textView.isRichText = false
         textView.importsGraphics = false
@@ -498,8 +542,7 @@ private struct ChatComposeTextView: NSViewRepresentable {
         textView.textContainer?.widthTracksTextView = true
         textView.isHorizontallyResizable = false
         textView.isVerticallyResizable = true
-        textView.string = text
-        context.coordinator.updateHeight(for: textView)
+        context.coordinator.apply(content: content, to: textView)
         return scrollView
     }
 
@@ -507,33 +550,63 @@ private struct ChatComposeTextView: NSViewRepresentable {
         guard let textView = scrollView.documentView as? SubmitTextView else {
             return
         }
-        if textView.string != text {
-            textView.string = text
-        }
+        context.coordinator.apply(content: content, to: textView)
         context.coordinator.placeholder = placeholder
         textView.needsDisplay = true
         context.coordinator.updateHeight(for: textView)
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
-        @Binding var text: String
+        @Binding var content: [ChatPromptContent]
         @Binding var measuredHeight: CGFloat
         var placeholder: String
         var onSubmit: () -> Void
+        var onContentChange: ([ChatPromptContent]) -> Void
+        var onError: (String) -> Void
+        private var renderedContent: [ChatPromptContent] = []
+        private var applyingContent = false
 
-        init(text: Binding<String>, placeholder: String, measuredHeight: Binding<CGFloat>, onSubmit: @escaping () -> Void) {
-            _text = text
+        init(content: Binding<[ChatPromptContent]>, placeholder: String, measuredHeight: Binding<CGFloat>, onSubmit: @escaping () -> Void, onContentChange: @escaping ([ChatPromptContent]) -> Void, onError: @escaping (String) -> Void) {
+            _content = content
             _measuredHeight = measuredHeight
             self.placeholder = placeholder
             self.onSubmit = onSubmit
+            self.onContentChange = onContentChange
+            self.onError = onError
+        }
+
+        func apply(content: [ChatPromptContent], to textView: NSTextView) {
+            guard renderedContent != content else { return }
+            applyingContent = true
+            let selection = textView.selectedRange()
+            textView.textStorage?.setAttributedString(makeAttributedString(content))
+            let location = min(selection.location, textView.string.utf16.count)
+            textView.setSelectedRange(NSRange(location: location, length: 0))
+            applyingContent = false
+            renderedContent = content
+        }
+
+        func handlePasteboard(_ pasteboard: NSPasteboard, in textView: NSTextView) -> Bool {
+            do {
+                guard let attachment = try MacImageAttachmentFactory.make(from: pasteboard) else { return false }
+                guard !extractContent(from: textView).images.contains(where: { $0.base64Data == attachment.base64Data }) else { return true }
+                let replacement = makeAttributedString([.image(attachment)])
+                let selection = textView.selectedRange()
+                textView.textStorage?.replaceCharacters(in: selection, with: replacement)
+                textView.setSelectedRange(NSRange(location: selection.location + 1, length: 0))
+                notifyContentChanged(for: textView)
+                return true
+            } catch {
+                onError(error.localizedDescription)
+                return true
+            }
         }
 
         func textDidChange(_ notification: Notification) {
-            guard let textView = notification.object as? NSTextView else {
+            guard !applyingContent, let textView = notification.object as? NSTextView else {
                 return
             }
-            text = textView.string
-            updateHeight(for: textView)
+            notifyContentChanged(for: textView)
         }
 
         func textView(_ textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
@@ -552,6 +625,57 @@ private struct ChatComposeTextView: NSViewRepresentable {
             return false
         }
 
+        private func notifyContentChanged(for textView: NSTextView) {
+            let next = extractContent(from: textView)
+            renderedContent = next
+            onContentChange(next)
+            updateHeight(for: textView)
+        }
+
+        private func makeAttributedString(_ content: [ChatPromptContent]) -> NSAttributedString {
+            let result = NSMutableAttributedString()
+            let attributes: [NSAttributedString.Key: Any] = [.font: NSFont.systemFont(ofSize: NSFont.systemFontSize)]
+            for item in content {
+                switch item {
+                case .text(let text):
+                    result.append(NSAttributedString(string: text, attributes: attributes))
+                case .image(let image):
+                    guard let data = image.data, let nsImage = NSImage(data: data) else { continue }
+                    let attachment = NSTextAttachment()
+                    attachment.image = nsImage
+                    attachment.bounds = NSRect(x: 0, y: -4, width: 28, height: 28)
+                    let start = result.length
+                    result.append(NSAttributedString(attachment: attachment))
+                    result.addAttribute(NSAttributedString.Key("RookChatImageAttachment"), value: image, range: NSRange(location: start, length: 1))
+                }
+            }
+            return result
+        }
+
+        private func extractContent(from textView: NSTextView) -> [ChatPromptContent] {
+            guard let storage = textView.textStorage else { return [] }
+            let imageKey = NSAttributedString.Key("RookChatImageAttachment")
+            var result: [ChatPromptContent] = []
+            var location = 0
+            while location < storage.length {
+                var range = NSRange(location: location, length: 0)
+                if let image = storage.attribute(imageKey, at: location, effectiveRange: &range) as? ChatImageAttachment {
+                    result.append(.image(image))
+                } else {
+                    let text = storage.attributedSubstring(from: range).string
+                    if !text.isEmpty && text != "\u{FFFC}" {
+                        if case .text(let previous)? = result.last {
+                            result[result.count - 1] = .text(previous + text)
+                        } else {
+                            result.append(.text(text))
+                        }
+                    }
+                }
+                location = NSMaxRange(range)
+            }
+            return result
+        }
+
         func updateHeight(for textView: NSTextView) {
             guard let layoutManager = textView.layoutManager, let textContainer = textView.textContainer else {
                 return
@@ -567,6 +691,64 @@ private struct ChatComposeTextView: NSViewRepresentable {
 }
 
 private final class SubmitTextView: NSTextView {
+    var onPasteImage: (() -> Bool)?
+    var onDrop: ((NSPasteboard) -> Bool)?
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if event.keyCode == 9, event.modifierFlags.contains(.command), onPasteImage?() == true {
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.keyCode == 9, event.modifierFlags.contains(.command), onPasteImage?() == true {
+            return
+        }
+        super.keyDown(with: event)
+    }
+
+    override func paste(_ sender: Any?) {
+        if onPasteImage?() == true { return }
+        super.paste(sender)
+    }
+
+    override func pasteAsPlainText(_ sender: Any?) {
+        if onPasteImage?() == true { return }
+        super.pasteAsPlainText(sender)
+    }
+
+    override func pasteAsRichText(_ sender: Any?) {
+        if onPasteImage?() == true { return }
+        super.pasteAsRichText(sender)
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        let types = sender.draggingPasteboard.types ?? []
+        let rawImageTypes: Set<NSPasteboard.PasteboardType> = [
+            .png,
+            .tiff,
+            NSPasteboard.PasteboardType(UTType.jpeg.identifier),
+            NSPasteboard.PasteboardType(UTType.gif.identifier),
+            NSPasteboard.PasteboardType(UTType.webP.identifier),
+        ]
+        guard sender.draggingPasteboard.canReadObject(forClasses: [NSURL.self], options: [.urlReadingFileURLsOnly: true]) || !rawImageTypes.isDisjoint(with: Set(types)) else {
+            return []
+        }
+        return .copy
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        let point = convert(sender.draggingLocation, from: nil)
+        let index = characterIndex(for: point)
+        setSelectedRange(NSRange(location: index, length: 0))
+        return .copy
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        onDrop?(sender.draggingPasteboard) ?? false
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
 

--- a/clients/mac/Tests/MacImageAttachmentFactoryTests.swift
+++ b/clients/mac/Tests/MacImageAttachmentFactoryTests.swift
@@ -1,0 +1,45 @@
+import AppKit
+import XCTest
+@testable import Rook
+import RookKit
+
+final class MacImageAttachmentFactoryTests: XCTestCase {
+    func testClipboardPngBecomesBoundedAttachment() throws {
+        let bitmap = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: 1, pixelsHigh: 1, bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false, colorSpaceName: .deviceRGB, bitmapFormat: [], bytesPerRow: 0, bitsPerPixel: 0)!
+        bitmap.setColor(NSColor(red: 0.1, green: 0.2, blue: 0.9, alpha: 1), atX: 0, y: 0)
+        let png = bitmap.representation(using: .png, properties: [:])!
+
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("rook-image-test-png"))
+        pasteboard.clearContents()
+        pasteboard.setData(png, forType: NSPasteboard.PasteboardType.png)
+
+        let attachment = try XCTUnwrap(MacImageAttachmentFactory.make(from: pasteboard))
+        XCTAssertEqual(attachment.mimeType, "image/png")
+        XCTAssertNotNil(attachment.data)
+        XCTAssertNotNil(NSImage(data: try XCTUnwrap(attachment.data)))
+    }
+
+    func testFileURLPasteboardResolvesPiClipboardImagePath() throws {
+        let bitmap = NSBitmapImageRep(bitmapDataPlanes: nil, pixelsWide: 1, pixelsHigh: 1, bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false, colorSpaceName: .deviceRGB, bitmapFormat: [], bytesPerRow: 0, bitsPerPixel: 0)!
+        bitmap.setColor(.systemBlue, atX: 0, y: 0)
+        let png = bitmap.representation(using: .png, properties: [:])!
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("pi-clipboard-test.png")
+        try png.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("rook-image-test-file-url"))
+        pasteboard.clearContents()
+        pasteboard.setString(url.absoluteString, forType: .fileURL)
+
+        let attachment = try XCTUnwrap(MacImageAttachmentFactory.make(from: pasteboard))
+        XCTAssertNotNil(attachment.data)
+    }
+
+    func testTextOnlyPasteReturnsNoAttachment() throws {
+        let pasteboard = NSPasteboard(name: NSPasteboard.Name("rook-image-test-text"))
+        pasteboard.clearContents()
+        pasteboard.setString("hello", forType: NSPasteboard.PasteboardType.string)
+
+        XCTAssertNil(try MacImageAttachmentFactory.make(from: pasteboard))
+    }
+}

--- a/server/README.md
+++ b/server/README.md
@@ -96,7 +96,7 @@ It implements:
 - `session/list` — legacy/unbound-only session list (REST is preferred)
 - `session/new` — creates session for a chosen runtime via `_meta.runtimeId` and `_meta.title` on an unbound websocket; on success that same websocket becomes bound to the new public session
 - `session/load`, `session/resume` — loads an existing session; replay is requester-private, not broadcast to all watchers
-- `session/prompt`, `session/cancel` — standard prompt flow
+- `session/prompt`, `session/cancel` — standard prompt flow; image-capable runtimes accept standard ACP image content blocks with per-session capability reporting and bounded base64 validation
 - `session/set_mode`, `session/set_config_option` — ACP controls
 - `session/close` — closes a session
 - `session/request_permission` — permission request relay

--- a/server/src/infrastructure/config/agentRuntimes.ts
+++ b/server/src/infrastructure/config/agentRuntimes.ts
@@ -18,6 +18,9 @@ export interface AgentRuntimeProfile {
   startupTimeoutMs?: number;
   mcpServers?: Array<Record<string, unknown>>;
   model?: string;
+  promptCapabilities?: {
+    image?: boolean;
+  };
 }
 
 export function getAgentRuntimesPath(): string {
@@ -48,6 +51,12 @@ function validProfile(value: unknown): value is AgentRuntimeProfile {
   if (!validStrings(profile.args) || !validStrings(profile.skillPaths) || !validStrings(profile.extensionPaths)) return false;
   if (profile.env !== undefined && (typeof profile.env !== "object" || profile.env === null || Array.isArray(profile.env) || Object.values(profile.env).some((item) => typeof item !== "string"))) return false;
   if (profile.mcpServers !== undefined && (!Array.isArray(profile.mcpServers) || profile.mcpServers.some((item) => typeof item !== "object" || item === null || Array.isArray(item)))) return false;
+  if (profile.promptCapabilities !== undefined && (
+    typeof profile.promptCapabilities !== "object" ||
+    profile.promptCapabilities === null ||
+    Array.isArray(profile.promptCapabilities) ||
+    (profile.promptCapabilities.image !== undefined && typeof profile.promptCapabilities.image !== "boolean")
+  )) return false;
   return true;
 }
 

--- a/server/src/runtime/acpFacade.test.ts
+++ b/server/src/runtime/acpFacade.test.ts
@@ -73,6 +73,14 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
           args: [mockServerPath],
           cwd: process.cwd(),
         },
+        {
+          id: "ImageMockAcpAgent",
+          type: "acp",
+          command: "node",
+          args: [mockServerPath],
+          cwd: process.cwd(),
+          promptCapabilities: { image: true },
+        },
       ],
     }));
     process.env.ROOK_AGENT_RUNTIMES_PATH = runtimesPath;
@@ -121,6 +129,56 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
     expect(list.sessions.some((session) => session.sessionId === sessionId)).toBe(true);
 
     await request(ws, 6, "session/close", { sessionId });
+    ws.close();
+  });
+
+  it("forwards image prompt blocks for runtimes that advertise image support", async () => {
+    const ws = await connect();
+    await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    const created = await request(ws, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "ImageMockAcpAgent", title: "image-test" },
+    });
+    expect(created.promptCapabilities).toEqual({ image: true });
+    const result = await request(ws, 3, "session/prompt", {
+      sessionId: created.sessionId,
+      prompt: [{ type: "text", text: "describe this" }, { type: "image", mimeType: "image/png", data: "aGVsbG8=" }],
+    });
+    expect(result.stopReason).toBe("end_turn");
+    await request(ws, 4, "session/close", { sessionId: created.sessionId });
+    ws.close();
+  });
+
+  it("rejects image prompts for runtimes without image support", async () => {
+    const ws = await connect();
+    await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    const created = await request(ws, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "text-only-image-test" },
+    });
+    await expect(request(ws, 3, "session/prompt", {
+      sessionId: created.sessionId,
+      prompt: [{ type: "image", mimeType: "image/png", data: "aGVsbG8=" }],
+    })).rejects.toThrow("does not support image prompts");
+    await request(ws, 4, "session/close", { sessionId: created.sessionId });
+    ws.close();
+  });
+
+  it("rejects malformed image prompt data", async () => {
+    const ws = await connect();
+    await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test" } });
+    const created = await request(ws, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "ImageMockAcpAgent", title: "invalid-image-test" },
+    });
+    await expect(request(ws, 3, "session/prompt", {
+      sessionId: created.sessionId,
+      prompt: [{ type: "image", mimeType: "image/png", data: "not base64!" }],
+    })).rejects.toThrow("Invalid or oversized image data");
+    await request(ws, 4, "session/close", { sessionId: created.sessionId });
     ws.close();
   });
 

--- a/server/src/runtime/routes/acpFacadeRoute.ts
+++ b/server/src/runtime/routes/acpFacadeRoute.ts
@@ -87,7 +87,7 @@ async function handleMessage(
         send(success(requestId!, {
           protocolVersion: 1,
           agentInfo: { name: "rook", title: "Rook", version: "0.1.0" },
-          agentCapabilities: { loadSession: true, sessionCapabilities: { list: {}, resume: {}, close: {} }, promptCapabilities: { image: false, audio: false, embeddedContext: false } },
+          agentCapabilities: { loadSession: true, sessionCapabilities: { list: {}, resume: {}, close: {} }, promptCapabilities: { image: runtimes.runtimeIds().some((runtimeId) => runtimes.supportsImagePrompts(runtimeId)), audio: false, embeddedContext: false } },
           authMethods: [],
           _meta: { runtimeIds: runtimes.runtimeIds(), defaultRuntimeId: runtimes.defaultRuntimeId(), "com.rookkeeper": { environmentOffers: { offerNotification: true, resolveRequest: true } } },
         }));
@@ -117,7 +117,10 @@ async function handleMessage(
         const title = typeof meta?.title === "string" && meta.title.trim() ? meta.title.trim() : "session";
         const record = await runtimes.createSession(runtimeId, withoutMeta(params), title);
         binding.bindSessionId(record.sessionId);
-        send(success(requestId!, { sessionId: record.sessionId }));
+        send(success(requestId!, {
+          sessionId: record.sessionId,
+          promptCapabilities: { image: runtimes.supportsImagePrompts(record.runtimeId) },
+        }));
         return;
       }
       case "session/load":
@@ -128,9 +131,18 @@ async function handleMessage(
         const params = object(message.params) ?? {};
         const sessionId = requiredBoundSessionId(params, binding);
         subscribe(sessionId);
-        const result = await runtimes.requestForSession(sessionId, message.method, withoutSessionId(params), {
+        if (message.method === "session/prompt" && hasImagePrompt(params.prompt)) {
+          validateImagePrompt(params.prompt);
+          const capabilities = await runtimes.sessionPromptCapabilities(sessionId);
+          if (!capabilities.image) throw new Error("The selected runtime does not support image prompts.");
+        }
+        let result = await runtimes.requestForSession(sessionId, message.method, withoutSessionId(params), {
           ...(message.method === "session/load" || message.method === "session/resume" ? { privateReplayListener: send } : {}),
         });
+        const resultObject = object(result);
+        if ((message.method === "session/load" || message.method === "session/resume") && resultObject) {
+          result = { ...resultObject, promptCapabilities: await runtimes.sessionPromptCapabilities(sessionId) };
+        }
         send(success(requestId!, result));
         return;
       }
@@ -153,6 +165,31 @@ async function handleMessage(
     }
   } catch (error) {
     send(failure(requestId, error instanceof Error ? error.message : String(error)));
+  }
+}
+
+const SUPPORTED_IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+const MAX_IMAGE_BYTES = 12 * 1024 * 1024;
+const MAX_IMAGE_BASE64_LENGTH = Math.ceil(MAX_IMAGE_BYTES / 3) * 4;
+
+function hasImagePrompt(value: unknown): boolean {
+  return Array.isArray(value) && value.some((block) => object(block)?.type === "image");
+}
+
+function validateImagePrompt(value: unknown): void {
+  if (!Array.isArray(value)) throw new Error("Prompt must be an array of content blocks.");
+  for (const block of value) {
+    const image = object(block);
+    if (image?.type !== "image") continue;
+    if (typeof image.mimeType !== "string" || !SUPPORTED_IMAGE_MIME_TYPES.has(image.mimeType.toLowerCase())) {
+      throw new Error("Unsupported image MIME type.");
+    }
+    if (typeof image.data !== "string" || image.data.length === 0 || image.data.length > MAX_IMAGE_BASE64_LENGTH || !/^[A-Za-z0-9+/]*={0,2}$/.test(image.data)) {
+      throw new Error("Invalid or oversized image data.");
+    }
+    const padding = image.data.endsWith("==") ? 2 : image.data.endsWith("=") ? 1 : 0;
+    const byteLength = Math.floor(image.data.length * 3 / 4) - padding;
+    if (byteLength > MAX_IMAGE_BYTES) throw new Error("Image exceeds the 12 MB limit.");
   }
 }
 

--- a/server/src/runtime/services/AgentRuntimeManager.ts
+++ b/server/src/runtime/services/AgentRuntimeManager.ts
@@ -43,7 +43,7 @@ export class AgentRuntimeManager {
     return [...this.profilesById.keys()];
   }
 
-  runtimeDefinitions(): Array<Pick<AgentRuntimeProfile, "id" | "type" | "parentId" | "model">> {
+  runtimeDefinitions(): Array<Pick<AgentRuntimeProfile, "id" | "type" | "parentId" | "model"> & { supportsImagePrompts: boolean }> {
     return this.runtimeIds().map((id) => {
       const profile = this.profilesById.get(id)!;
       return {
@@ -51,8 +51,18 @@ export class AgentRuntimeManager {
         type: profile.type,
         ...(profile.parentId !== undefined ? { parentId: profile.parentId } : {}),
         ...(profile.model ? { model: profile.model } : {}),
+        supportsImagePrompts: supportsImagePrompts(profile),
       };
     });
+  }
+
+  supportsImagePrompts(runtimeId: string): boolean {
+    return supportsImagePrompts(this.requireProfile(runtimeId));
+  }
+
+  async sessionPromptCapabilities(sessionId: string): Promise<{ image: boolean }> {
+    const record = await this.requireSession(sessionId);
+    return { image: this.supportsImagePrompts(record.runtimeId) };
   }
 
   defaultRuntimeId(): string | undefined {
@@ -427,6 +437,10 @@ export class AgentRuntimeManager {
     if (!this.timingLogsEnabled) return;
     this.logger.info({ component: "AgentRuntimeManager", event, ...details }, "session timing");
   }
+}
+
+function supportsImagePrompts(profile: AgentRuntimeProfile): boolean {
+  return profile.promptCapabilities?.image ?? profile.type === "pi";
 }
 
 function roundMs(value: number): number {

--- a/server/src/sessions/routes/sessionRoutes.ts
+++ b/server/src/sessions/routes/sessionRoutes.ts
@@ -16,6 +16,7 @@ export async function registerSessionRoutes(app: FastifyInstance, runtimeManager
         _meta: {
           runtimeId: record.runtimeId,
           startedAt: record.startedAt,
+          supportsImagePrompts: runtimeManager.supportsImagePrompts(record.runtimeId),
         },
       })),
     };

--- a/server/src/shared/acp.ts
+++ b/server/src/shared/acp.ts
@@ -38,6 +38,15 @@ export interface AcpTextContentBlock {
   text: string;
 }
 
+export interface AcpImageContentBlock {
+  type: "image";
+  mimeType: string;
+  data: string;
+  uri?: string;
+}
+
+export type AcpPromptContentBlock = AcpTextContentBlock | AcpImageContentBlock;
+
 export interface AcpContentItem {
   type: "content";
   content: AcpTextContentBlock;
@@ -172,9 +181,18 @@ export interface AcpPromptTextParam {
   text: string;
 }
 
+export interface AcpPromptImageParam {
+  type: "image";
+  mimeType: string;
+  data: string;
+  uri?: string;
+}
+
+export type AcpPromptContentParam = AcpPromptTextParam | AcpPromptImageParam;
+
 export interface AcpPromptParams {
   sessionId: string;
-  prompt: AcpPromptTextParam[];
+  prompt: AcpPromptContentParam[];
   _meta?: JsonRpcMeta;
 }
 


### PR DESCRIPTION
## What changed

- Add Mac clipboard paste and Finder drag/drop for images, including Pi's temporary file-URL clipboard format.
- Render images as inline thumbnails in the composer and preserve text/image ordering in ACP prompts.
- Carry ordered image content through RookKit delivery, busy/offline queues, reconnects, and user-message rendering.
- Add per-runtime image capability reporting, server-side ACP image validation, tests, and product/architecture documentation.

- Update the PR-writing skill/template to summarize new tests at a high level.

## Why it matters

Rook's native Mac chat can now work with visual context without making the agent depend on a Mac-local path or session working directory. Users can write naturally around images — for example, “compare this [image] with this [image]” — while the selected agent receives the same ordered prompt content. Text-only runtimes continue to behave safely, and images are not lost when a session is busy or reconnecting.

## Notes for reviewers

- Images are normalized to bounded PNG data in memory and sent as standard ACP image blocks.
- The server advertises image support per runtime and rejects unsupported or malformed image prompts.
- Full image bytes are intentionally not restored from normalized transcripts in this release; live/current-viewer rendering is supported.
- The Pi clipboard regression was caused by an `[NSURL]` → `[URL]` array cast; the client now handles `NSURL` file URLs explicitly.

## Product specification alignment

**Classification:** Extends

**Related PRODUCT/ docs:**
- [`PRODUCT/goals-of-rook.md`](PRODUCT/goals-of-rook.md) — extends direct chat and bring-your-own-agent interaction with visual prompts.
- [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md) — establishes ordered standard ACP image blocks and keeps local paths out of the protocol.

**Documentation updates in this PR:**
- [x] [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md) — documents ordered image-bearing ACP prompts.

**Notes:** This adds a Mac-focused input modality without changing Rook's agent choice, environment, or safety philosophy. iPhone/Android remain text-only for now.

## Architecture alignment

**Classification:** Extends

**Related docs / patterns:**
- [`AS-BUILT-ARCHITECTURE/mac-client.md`](AS-BUILT-ARCHITECTURE/mac-client.md) — documents inline composer content and ACP delivery.
- [`AS-BUILT-ARCHITECTURE/rookkit.md`](AS-BUILT-ARCHITECTURE/rookkit.md) — documents ordered `ChatPromptContent` across rendering, queues, and transport.
- [`AS-BUILT-ARCHITECTURE/server.md`](AS-BUILT-ARCHITECTURE/server.md) — documents runtime capability negotiation and server-boundary validation.

**Documentation updates in this PR:**
- [x] `AS-BUILT-ARCHITECTURE/mac-client.md` — Mac image intake and ordered delivery.
- [x] `AS-BUILT-ARCHITECTURE/rookkit.md` — shared ordered prompt model.
- [x] `AS-BUILT-ARCHITECTURE/server.md` — ACP image capability and validation behavior.

**Notes:** The existing ACP WebSocket boundary and one-session-per-socket model remain intact. Image bytes are transported as ACP content, never as runtime `cwd` paths.

## New tests

- Mac image intake covers native clipboard PNGs, Pi's temporary file-URL clipboard format, and ordinary text-only paste.
- Shared prompt-state tests cover ordered text/image content and retention through queued delivery.
- Server integration tests cover image forwarding, runtime capability gating, and malformed image rejection.

## Technical touchpoints

- **Components:** `ChatComposeTextView`, `MacImageAttachmentFactory`, `ChatPromptContent`, `SessionHandle`, `AcpSocket`, `AgentRuntimeManager`, ACP facade route.
- **APIs / protocols:** ACP `session/prompt` image blocks; runtime/session `promptCapabilities.image` reporting.
- **Data / events:** ordered text/image content in local queues and current-viewer user blocks; transcript image-byte hydration remains deferred.

## How to check it

- [x] `swift test --package-path clients/RookKit`
- [x] `xcodebuild ... test CODE_SIGNING_ALLOWED=NO`
- [x] `npm run typecheck --prefix server`
- [x] `npm test --prefix server`
- [x] `npm run build --prefix server`
- [x] Manually verify Mac clipboard paste, including a Pi `pi-clipboard-*.png` file URL.
- [ ] Verify an end-to-end vision-capable Pi model describes an attached image.

