### PR TITLE
Make projected workspace capabilities discoverable by Claude runtimes

### DIFF
--- a/AS-BUILT-ARCHITECTURE/database.md
+++ b/AS-BUILT-ARCHITECTURE/database.md
@@ -77,11 +77,14 @@ Each session receives disposable links:
 ```text
 ~/.rook/agent-workspaces/<session-id>/
 ├── AGENTS.md
-└── .agents/
-    ├── editable-per-environment/<environment> -> shared environment directory
-    └── skills/<visible-name>                  -> shared skill source
+├── CLAUDE.md -> AGENTS.md
+├── .agents/
+│   ├── editable-per-environment/<environment> -> shared environment directory
+│   └── skills/<visible-name>                  -> shared skill source
+└── .claude/
+    └── skills -> ../.agents/skills
 ```
 
-`AGENTS.md` at the workspace root is a generated read-only aggregate. The individual instruction and skill sources are the editable paths. Canonical/external content is materialized read-only, while project-directory content links directly to project files.
+`AGENTS.md` at the workspace root is a generated read-only aggregate. The `CLAUDE.md` and `.claude/skills` entries are relative symlink aliases for Claude Code runtimes, which auto-load `CLAUDE.md` and discover project skills only under `.claude/skills`. The individual instruction and skill sources are the editable paths. Canonical/external content is materialized read-only, while project-directory content links directly to project files.
 
 The global watcher debounces settled shared-source changes, persists current file maps, recognizes missing writable source entries as membership deletion, and refreshes active session projections. Rebuild, startup cleanup, and session disposal are excluded from deletion inference.

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -177,7 +177,7 @@ Related tables:
 5. server returns that public session ID and binds the same websocket to it
 
 ### Prompt execution
-1. every configured runtime starts with the base `## You are Rook` identity prompt and uses its agent workspace as process cwd; environment-specific instructions are discovered through generated `AGENTS.md`
+1. every configured runtime starts with the base `## You are Rook` identity prompt and uses its agent workspace as process cwd; environment-specific instructions are discovered through generated `AGENTS.md` (aliased as `CLAUDE.md` for Claude runtimes)
 2. client sends ACP `session/prompt` on a session-bound websocket
 3. ACP facade resolves the public session
 4. `AgentRuntimeManager` rewrites to the runtime-local session ID
@@ -192,7 +192,7 @@ Related tables:
 3. finalized environments resolve matching bundles and hash them
 4. undecided bundles are offered to subscribed sessions when that session enters the finalized environment
 5. client resolves via REST decision or ACP extension resolution
-6. approved/personal bundle content is resolved for workspace projection. The generated aggregate `AGENTS.md` exposes approved/user-owned instruction sources in environment-tagged blocks, gives authoring guidance, inventories known skill names by environment, and the workspace uses the standard `.agents/skills/` discovery directory; Pi receives one-run project approval because ACP is non-interactive, and the runtime no longer receives duplicate environment prompt injection.
+6. approved/personal bundle content is resolved for workspace projection. The generated aggregate `AGENTS.md` exposes approved/user-owned instruction sources in environment-tagged blocks, gives authoring guidance, inventories known skill names by environment, and the workspace uses the standard `.agents/skills/` discovery directory, aliased as `.claude/skills` so Claude Code's native skill discovery finds the same content; Pi receives one-run project approval because ACP is non-interactive, and the runtime no longer receives duplicate environment prompt injection.
 
 ### Environment-driven runtime restart
 1. session enters or exits an environment

--- a/PRODUCT/skills-definitions.md
+++ b/PRODUCT/skills-definitions.md
@@ -14,7 +14,7 @@ Resolved skills are materialized under:
 <session-workspace>/.agents/skills/<skill-name>/
 ```
 
-The `.agents/skills/` directory follows the standard Agent Skills discovery convention, so Pi and other compatible runtimes discover it from the workspace cwd. Rook launches Pi with project approval for this generated workspace because non-interactive ACP sessions cannot answer Pi's trust prompt. Skills from personal bundles are writable through shared links and synchronize back to SQLite. Canonical and external skills are projected read-only. Duplicate skill names use naive `_2`, `_3`, etc. workspace names without changing skill frontmatter.
+The `.agents/skills/` directory follows the standard Agent Skills discovery convention, so Pi and other compatible runtimes discover it from the workspace cwd. Claude Code discovers skills only from `.claude/skills` and auto-loads `CLAUDE.md` rather than `AGENTS.md`, so each session workspace also carries `.claude/skills` and `CLAUDE.md` symlink aliases onto the projected content. Rook launches Pi with project approval for this generated workspace because non-interactive ACP sessions cannot answer Pi's trust prompt. Skills from personal bundles are writable through shared links and synchronize back to SQLite. Canonical and external skills are projected read-only. Duplicate skill names use naive `_2`, `_3`, etc. workspace names without changing skill frontmatter.
 
 ## Other capability types
 

--- a/server/src/environments/repositories/ProjectDirectoryEnvironmentRepository.test.ts
+++ b/server/src/environments/repositories/ProjectDirectoryEnvironmentRepository.test.ts
@@ -49,6 +49,27 @@ describe("ProjectDirectoryEnvironmentRepository", () => {
     expect(result.bundles[0]?.skills.map((artifact) => artifact.id)).toEqual(["deploy"]);
   });
 
+  it("merges skills across discovery roots, earlier roots winning name collisions", async () => {
+    const project = await mkdtemp(path.join(os.tmpdir(), "rook-project-env-"));
+    tempDirs.push(project);
+    const agentsDeploy = path.join(project, ".agents", "skills", "deploy");
+    await mkdir(agentsDeploy, { recursive: true });
+    await writeFile(path.join(agentsDeploy, "SKILL.md"), "Deploy from .agents.");
+    const claudeDeploy = path.join(project, ".claude", "skills", "deploy");
+    await mkdir(claudeDeploy, { recursive: true });
+    await writeFile(path.join(claudeDeploy, "SKILL.md"), "Deploy from .claude.");
+    const claudeReview = path.join(project, ".claude", "skills", "review");
+    await mkdir(claudeReview, { recursive: true });
+    await writeFile(path.join(claudeReview, "SKILL.md"), "Review carefully.");
+
+    const repository = new ProjectDirectoryEnvironmentRepository();
+    const result = await repository.getBundles(`dir:${project}`);
+
+    expect(result.bundles[0]?.skills.map((artifact) => artifact.id)).toEqual(["deploy", "review"]);
+    expect(result.bundles[0]?.skills[0]?.sourcePath).toBe(agentsDeploy);
+    expect(result.bundles[0]?.skills[1]?.sourcePath).toBe(claudeReview);
+  });
+
   it("uses CLAUDE.md only when AGENTS.md is absent", async () => {
     const project = await mkdtemp(path.join(os.tmpdir(), "rook-project-env-"));
     tempDirs.push(project);

--- a/server/src/environments/repositories/ProjectDirectoryEnvironmentRepository.ts
+++ b/server/src/environments/repositories/ProjectDirectoryEnvironmentRepository.ts
@@ -83,10 +83,11 @@ export class ProjectDirectoryEnvironmentRepository extends EnvironmentRepository
     // THIS IS FOR BACKWARDS COMPATIBILITY
     // Preserve skill discovery from the established tool-specific project
     // directories while the standard .agents/skills layout is adopted.
+    // All roots are merged; on a name collision the earlier root wins.
     const roots = [".agents/skills", ".claude/skills", ".codex/skills", ".cursor/skills", ".github/skills"]
       .map((relative) => path.join(directory, relative))
       .filter((candidate) => existsSync(candidate));
-    const artifacts: BundleArtifact[] = [];
+    const artifactsById = new Map<string, BundleArtifact>();
     for (const root of roots) {
       let entries;
       try {
@@ -97,6 +98,7 @@ export class ProjectDirectoryEnvironmentRepository extends EnvironmentRepository
       }
       for (const entry of entries) {
         if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+        if (artifactsById.has(entry.name)) continue;
         const skillPath = path.join(root, entry.name);
         if (entry.isSymbolicLink()) {
           // Skill directories are commonly linked from tool-specific roots.
@@ -118,11 +120,10 @@ export class ProjectDirectoryEnvironmentRepository extends EnvironmentRepository
           errors.push({ code: "invalid_bundle_contents", message: `Skill ${entry.name} is missing SKILL.md`, repository: this.repositoryId, environmentId, path: skillPath });
           continue;
         }
-        artifacts.push({ id: entry.name, files, sourcePath: skillPath });
+        artifactsById.set(entry.name, { id: entry.name, files, sourcePath: skillPath });
       }
-      if (artifacts.length > 0) break;
     }
-    return artifacts.sort((a, b) => a.id.localeCompare(b.id));
+    return [...artifactsById.values()].sort((a, b) => a.id.localeCompare(b.id));
   }
 }
 

--- a/server/src/runtime/CapabilityWorkspaceManager.test.ts
+++ b/server/src/runtime/CapabilityWorkspaceManager.test.ts
@@ -38,6 +38,23 @@ describe("CapabilityWorkspaceManager", () => {
     await manager.close();
   });
 
+  it("aliases the projection for Claude runtimes via .claude/skills and CLAUDE.md links", async () => {
+    const manager = await CapabilityWorkspaceManager.create({ workspaceRoot: await temporaryDirectory(), sessionRoot: await temporaryDirectory() });
+    const workspace = await manager.materialize("session", [personalBundle({ skills: [skill("remember")], agentsMd: "Remember this." })]);
+
+    const claudeSkills = path.join(workspace.root, ".claude", "skills");
+    const claudeMd = path.join(workspace.root, "CLAUDE.md");
+    expect((await lstat(claudeSkills)).isSymbolicLink()).toBe(true);
+    expect(await realpath(claudeSkills)).toBe(await realpath(workspace.skillsRoot));
+    expect((await lstat(claudeMd)).isSymbolicLink()).toBe(true);
+    expect(await readFile(claudeMd, "utf8")).toBe(await readFile(workspace.agentsPath, "utf8"));
+
+    await manager.materialize("session", [personalBundle({ skills: [skill("remember")], agentsMd: "Remember this." })]);
+    expect((await lstat(claudeSkills)).isSymbolicLink()).toBe(true);
+    expect((await lstat(claudeMd)).isSymbolicLink()).toBe(true);
+    await manager.close();
+  });
+
   it("links one SQLite-backed writable skill into every session and authoring slot", async () => {
     const root = await temporaryDirectory();
     const sessionRoot = await temporaryDirectory();

--- a/server/src/runtime/CapabilityWorkspaceManager.ts
+++ b/server/src/runtime/CapabilityWorkspaceManager.ts
@@ -99,6 +99,8 @@ export class CapabilityWorkspaceManager {
       removeTree(internalInstructionsRoot),
       removeTree(mcpRoot),
       removeTree(agentsPath),
+      removeTree(path.join(root, ".claude")),
+      removeTree(path.join(root, "CLAUDE.md")),
     ]);
     await Promise.all([
       mkdir(skillsRoot, { recursive: true }),
@@ -214,6 +216,12 @@ export class CapabilityWorkspaceManager {
     });
     await writeFile(agentsPath, await renderAggregateAgents(root, agentInstructionSources, inlineFacts, skillNamesByEnvironment, skillAuthoringPaths), "utf8");
     await chmod(agentsPath, 0o444);
+    // Claude Code discovers project skills only under .claude/skills and
+    // auto-loads CLAUDE.md rather than AGENTS.md, so alias the projection
+    // under those names for Claude runtimes. Relative targets keep the links
+    // valid if the workspace root moves.
+    await replaceWithSymlink(path.join(root, ".claude", "skills"), path.join("..", ".agents", "skills"));
+    await replaceWithSymlink(path.join(root, "CLAUDE.md"), "AGENTS.md");
     await this.writeManifest();
     return { root, agentsPath, skillsRoot, editablePerEnvironmentRoot, mcpRoot, skillPaths };
   }


### PR DESCRIPTION
## What changed

- Every session agent workspace now carries two relative symlink aliases: `.claude/skills → ../.agents/skills` and `CLAUDE.md → AGENTS.md`, created on each materialization by `CapabilityWorkspaceManager`.
- Project-directory skill discovery now merges all scan roots (`.agents/skills`, `.claude/skills`, `.codex/skills`, `.cursor/skills`, `.github/skills`) instead of stopping at the first non-empty one; on a duplicate skill name the earlier root wins.
- AS-BUILT architecture docs and `PRODUCT/skills-definitions.md` updated to describe the aliases.

## Why it matters

A Claude runtime launched in a session workspace was effectively capability-blind: Claude Code only discovers skills under `<cwd>/.claude/skills` and only auto-loads `CLAUDE.md`, so it saw neither the projected `.agents/skills/` content nor the generated `AGENTS.md` aggregate. Pi worked (explicit `--skill` flags + `AGENTS.md` reading); Claude silently got nothing. This closes that gap so "bring your own agent" actually holds for Claude runtimes, using the same alias pattern this repo already uses for its own checkout (`.claude/skills → ../.agents/skills`).

The scan-root merge fixes a second silent loss: a project with skills split between `.agents/skills` and `.claude/skills` previously dropped everything outside the first non-empty root.

## Notes for reviewers

- The aliases are created unconditionally rather than per runtime type — they're inert for Pi/Cursor, and `materialize()` doesn't currently know which runtime a session uses.
- The `AGENTS.md` aggregate is rewritten in place on refresh, so the `CLAUDE.md` alias stays valid across watcher-driven regeneration.
- Backward-compatibility surfaces: the multi-root project scan in `ProjectDirectoryEnvironmentRepository.readSkills` is the only one; it already carries the `THIS IS FOR BACKWARDS COMPATIBILITY` marker, extended with the merge/collision note. The new symlinks are runtime interop, not a legacy shim.
- Verified live: a `claude`-runtime session on a worktree dev server materialized `CLAUDE.md -> AGENTS.md` and `.claude/skills -> ../.agents/skills` in `~/.rook/agent-workspaces/<session-id>/`.
- Observed while testing (pre-existing, not addressed here): `CapabilityWorkspaceManager.create()` is called without options in `server/src/index.ts`, so `global-workspace/` and `agent-workspaces/` always resolve under `~/.rook` even when `ROOK_HOME` points at a development profile home.

## Product specification alignment

**Classification:** Implements

**Related PRODUCT/ docs:**
- `PRODUCT/goals-of-rook.md` — "Bring your own agent": runtime interchangeability now holds for Claude Code, which previously couldn't see environment capabilities.
- `PRODUCT/skills-definitions.md` — the runtime representation section assumed `.agents/skills` discovery covered compatible runtimes; Claude Code needed the documented alias.
- `PRODUCT/relationship-between-environments-skills-and-agent.md` — capability materialization contract unchanged; this makes the projection reachable by one more runtime.

**Documentation updates in this PR:**
- [x] `PRODUCT/skills-definitions.md` — one sentence documenting the Claude discovery aliases.

**Notes:** No philosophy change; the projection stays `.agents`-first with `.claude` as a compatibility view.

## Architecture alignment

**Classification:** Extends

**Related docs / patterns:**
- `AS-BUILT-ARCHITECTURE/database.md` (workspace projection) — session workspace shape gains two alias entries.
- `AS-BUILT-ARCHITECTURE/server.md` (prompt execution, offer/approval) — instruction/skill discovery notes now mention the aliases.

**Documentation updates in this PR:**
- [x] `AS-BUILT-ARCHITECTURE/database.md` — projection tree shows `CLAUDE.md` and `.claude/skills` links.
- [x] `AS-BUILT-ARCHITECTURE/server.md` — discovery notes updated.

**Notes:** No new components or boundaries; `CapabilityWorkspaceManager` remains the sole owner of workspace shape.

## New tests

- Workspace materialization creates both aliases, points them at the projected content, and keeps them across re-materialization.
- Project skill scan merges roots and resolves name collisions in favor of the earlier root.

## How to check it

- [ ] `cd server && npm test` (full suite green: 132 passed, 5 skipped) and `npm run typecheck`
- [ ] Start a `claude`-runtime session, enter an environment with skills, and confirm `~/.rook/agent-workspaces/<session-id>/` contains working `CLAUDE.md` and `.claude/skills` links
- [ ] Ask the Claude session what skills it has — it should list the projected ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFTK54NR6aQyeqM1iArzr8