### PR TITLE
Add session management and recent-view ordering

### DIFF
--- a/AS-BUILT-ARCHITECTURE/database.md
+++ b/AS-BUILT-ARCHITECTURE/database.md
@@ -10,6 +10,8 @@ Rook's durable server state is split across SQLite databases:
 
 The application database remains separate from environment repositories. This database is intentionally small: it stores session persistence and durable environment decisions. Runtime processes, active/recent environment caches, subscribers, and workspace projections remain transient. The main checkout keeps the database under `.var/rook/rook.sqlite`; worktree profiles select an isolated SQLite path through `ROOK_DATABASE_PATH`.
 
+For session recency, no extra table or column was added: the existing `sessions.updated_at` field now represents both prompt activity and explicit client-side view/touch events, so opening a session can reorder the shared recents list without synthesizing transcript content.
+
 ## Environment repository schema
 
 Each environment repository database has exactly three tables.

--- a/AS-BUILT-ARCHITECTURE/iphone-client.md
+++ b/AS-BUILT-ARCHITECTURE/iphone-client.md
@@ -95,9 +95,10 @@ Same shared contract as other clients:
 2. starting a new session opens an unbound WebSocket, sends ACP `session/new`, then keeps that same socket as the new session's `SessionHandle`
 3. resuming an existing session creates or retrieves a `SessionHandle`
 4. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
-5. resumed handles open a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and reduce wire frames into `AcpClientEvent`s
-6. `RookModel` mirrors handle state into published chat/UI state and layers on voice / Live Activity behavior
-7. on reconnect the model reattaches to the current session handle and re-announces place state
+5. after a successful resume/open, the client calls `POST /api/sessions/:id/touch` so the shared recents list reflects viewed sessions even without a prompt
+6. resumed handles open a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and reduce wire frames into `AcpClientEvent`s
+7. `RookModel` mirrors handle state into published chat/UI state, drives rename/delete session actions through REST, and layers on voice / Live Activity behavior
+8. on reconnect the model reattaches to the current session handle and re-announces place state
 
 ### Voice flow
 1. user starts listening

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -110,10 +110,12 @@ Via `RookKit`:
 2. starting a new session opens an unbound WebSocket, sends ACP `session/new`, then keeps that same socket as the new session's `SessionHandle`
 3. resuming an existing session creates or retrieves a `SessionHandle`
 4. if the session is already running, the handle hydrates from `GET /api/sessions/:id/transcript`; otherwise it performs ACP `session/load`
-5. resumed handles open a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and run `initialize`
-6. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
-7. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
-8. queued messages, including image attachments, are delivered automatically once the agent goes idle
+5. after a successful resume/open, the client calls `POST /api/sessions/:id/touch` so the shared recents list reflects viewed sessions even without a prompt
+6. resumed handles open a dedicated session-bound WebSocket (`/api/ws?sessionId=...`) and run `initialize`
+7. the handle reduces `AcpClientEvent`s into `ChatBlock`s, tool states, plan state, permissions, and run lifecycle
+8. switching sessions changes which handle the UI observes — background sessions keep their WebSocket and continue running
+9. session rows expose rename/delete management actions that call the REST session-management routes without stealing the primary click-to-resume interaction
+10. queued messages, including image attachments, are delivered automatically once the agent goes idle
 
 ### Foreground environment detection
 1. `ForegroundAppMonitor` detects app activation or window-title change

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -51,6 +51,7 @@
 - `healthResult()` / `health()`
 - `agents()`
 - `sessions()` — session list over REST
+- `renameSession(sessionId:title:)`, `touchSession(sessionId:)`, `deleteSession(sessionId:)` — session management over REST
 - `sessionTranscript(sessionId:)` — normalized transcript hydration for second viewers / running sessions
 - `environmentPreview(environmentId:)`
 - `registerEnvironment(candidate)`
@@ -69,6 +70,7 @@
   - `id`, `parentId`
 - `AgentSessionSummary`
   - wraps raw JSON and exposes normalized accessors like `id`, `agent`, `name`, `updatedAt`, `startedAt`
+  - can produce updated summaries while preserving unknown server fields for local/session-list refreshes
 
 ### Environment/location models
 - `EnvironmentArtifactPreview`

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -88,6 +88,9 @@ See also: [database.md](./database.md)
 - `GET /api/health`
 - `GET /api/agent_runtimes`
 - `GET /api/sessions` — session listing over REST
+- `PATCH /api/sessions/:sessionId` — rename one session without changing recency ordering
+- `POST /api/sessions/:sessionId/touch` — mark one session as recently viewed so it sorts to the top
+- `DELETE /api/sessions/:sessionId` — delete one session plus transcript/workspace state
 - `GET /api/sessions/:sessionId/transcript` — server-owned normalized transcript for hydrators / second viewers
 - `POST /api/environments/register`
 - `POST /api/environments/decision`
@@ -132,6 +135,9 @@ Persisted in SQLite:
 
 The `GET /api/sessions` response additionally includes a `running` boolean
 (derived from whether a `SessionRuntime` is active for that session).
+`updatedAt` is used for both prompt activity and explicit view/touch operations,
+so entering a session can move it to the top of the shared recents list without
+creating a synthetic prompt.
 
 Related tables:
 - `session_environments(session_id, environment_id, entered_at)`

--- a/CHANGES/2026-08-09-session-list-management/TODO.md
+++ b/CHANGES/2026-08-09-session-list-management/TODO.md
@@ -59,31 +59,31 @@ Important files likely involved:
 
 ## Steps
 
-- [ ] Confirm and document the v1 behavior boundaries in this change set: rename everywhere, delete everywhere, recent-view ordering, and no pin/manual reorder.
-- [ ] Extend the server session domain with explicit operations for rename, delete, and mark-as-viewed/touch so the product behavior is modeled intentionally rather than as a GET side effect.
-- [ ] Add public REST routes for session management (rename, delete, and viewed/touch) and keep the session list response shape aligned with the existing client models.
-- [ ] Update server-side session tests to cover rename persistence, destructive delete behavior, and recent-view ordering based on the chosen touch/view operation.
-- [ ] Update shared Apple client networking in `RookKit` to call the new session-management APIs and expose any updated session fields cleanly.
-- [ ] Update Mac session flow so creating or opening a session records it as most recently viewed, and add session row management UI for rename/delete without breaking the primary click-to-resume interaction.
-- [ ] Update iPhone session flow so creating or opening a session records it as most recently viewed, and add native-feeling rename/delete affordances that keep the card layout visually simple.
-- [ ] Update Android session flow so creating or opening a session records it as most recently viewed, and add native-feeling rename/delete affordances that keep tap-to-resume as the primary action.
-- [ ] Handle current-session edge cases consistently across clients: renaming the active session updates visible labels immediately, and deleting the active session exits chat/list state cleanly.
-- [ ] Refresh session lists/state after rename/delete/view operations so the acting client reflects the new title/order immediately; decide whether any additional passive refresh is needed for non-acting clients in v1.
-- [ ] Add or update focused client tests for the new state-management behavior where the existing Swift/Kotlin test harnesses make that practical.
-- [ ] Update relevant READMEs and product/architecture notes if the public session-management contract or session ordering semantics are now meaningfully different.
-- [ ] Run tests/build/typecheck appropriate to the change run and pass.
-- [ ] Review the final diff for leftover backward-compatibility code, compatibility documentation, fallback paths, temporary shims, abandoned experiments, and other no-longer-needed transitional code.
-- [ ] Remove all unnecessary backward-compatibility code and compatibility documentation rather than keeping it around.
-- [ ] Update `AS-BUILT-ARCHITECTURE/` as needed.
-- [ ] Update `PRODUCT/` as needed.
+- [x] Confirm and document the v1 behavior boundaries in this change set: rename everywhere, delete everywhere, recent-view ordering, and no pin/manual reorder.
+- [x] Extend the server session domain with explicit operations for rename, delete, and mark-as-viewed/touch so the product behavior is modeled intentionally rather than as a GET side effect.
+- [x] Add public REST routes for session management (rename, delete, and viewed/touch) and keep the session list response shape aligned with the existing client models.
+- [x] Update server-side session tests to cover rename persistence, destructive delete behavior, and recent-view ordering based on the chosen touch/view operation.
+- [x] Update shared Apple client networking in `RookKit` to call the new session-management APIs and expose any updated session fields cleanly.
+- [x] Update Mac session flow so creating or opening a session records it as most recently viewed, and add session row management UI for rename/delete without breaking the primary click-to-resume interaction.
+- [x] Update iPhone session flow so creating or opening a session records it as most recently viewed, and add native-feeling rename/delete affordances that keep the card layout visually simple.
+- [x] Update Android session flow so creating or opening a session records it as most recently viewed, and add native-feeling rename/delete affordances that keep tap-to-resume as the primary action.
+- [x] Handle current-session edge cases consistently across clients: renaming the active session updates visible labels immediately, and deleting the active session exits chat/list state cleanly.
+- [x] Refresh session lists/state after rename/delete/view operations so the acting client reflects the new title/order immediately; decide whether any additional passive refresh is needed for non-acting clients in v1.
+- [x] Add or update focused client tests for the new state-management behavior where the existing Swift/Kotlin test harnesses make that practical.
+- [x] Update relevant READMEs and product/architecture notes if the public session-management contract or session ordering semantics are now meaningfully different.
+- [x] Run tests/build/typecheck appropriate to the change run and pass.
+- [x] Review the final diff for leftover backward-compatibility code, compatibility documentation, fallback paths, temporary shims, abandoned experiments, and other no-longer-needed transitional code.
+- [x] Remove all unnecessary backward-compatibility code and compatibility documentation rather than keeping it around.
+- [x] Update `AS-BUILT-ARCHITECTURE/` as needed.
+- [x] Update `PRODUCT/` as needed.
 
 ## Exit criteria
 
-- [ ] Mac, iPhone, and Android users can rename any session from the session list without the rows becoming permanently busy/editable.
-- [ ] Mac, iPhone, and Android users can delete any session, including the currently open one, with clean navigation/state handling.
-- [ ] Newly created sessions appear at the top of the list.
-- [ ] Opening/resuming a session moves it to the top even when no new prompt is sent.
-- [ ] Session ordering behavior is consistent because it is stored on the server and returned through the shared session list API.
-- [ ] Server tests cover rename/delete/recent-view ordering behavior.
-- [ ] Client behavior is covered by focused tests or clearly justified manual verification where automated coverage is impractical.
-- [ ] Architecture/product docs and README surfaces match the final session-management behavior.
+- [x] Mac, iPhone, and Android users can rename any session from the session list without the rows becoming permanently busy/editable.
+- [x] Mac, iPhone, and Android users can delete any session, including the currently open one, with clean navigation/state handling.
+- [x] Newly created sessions appear at the top of the list.
+- [x] Opening/resuming a session moves it to the top even when no new prompt is sent.
+- [x] Session ordering behavior is consistent because it is stored on the server and returned through the shared session list API.
+- [x] Server tests cover rename/delete/recent-view ordering behavior.
+- [x] Client behavior is covered by focused tests or clearly justified manual verification where automated coverage is impractical.
+- [x] Architecture/product docs and README surfaces match the final session-management behavior.

--- a/PRODUCT/agent-client-protocol.md
+++ b/PRODUCT/agent-client-protocol.md
@@ -14,9 +14,9 @@ Fastify Rook server
 one runtime subprocess per public session
 ```
 
-Client interaction uses a session-bound WebSocket at `/api/ws?sessionId=...` plus REST for health, session listing, transcript hydration, environment previews, registration, and decisions. An unbound socket can create a session and becomes bound to it.
+Client interaction uses a session-bound WebSocket at `/api/ws?sessionId=...` plus REST for health, session listing, transcript hydration, session rename/delete/view-touch management, environment previews, registration, and decisions. An unbound socket can create a session and becomes bound to it.
 
-The server maps public session ids to runtime-local ACP session ids and owns normalized transcript persistence. A second client can hydrate a running session from the server transcript without asking the runtime to replay publicly.
+The server maps public session ids to runtime-local ACP session ids and owns normalized transcript persistence. A second client can hydrate a running session from the server transcript without asking the runtime to replay publicly. Session recency is also server-owned: clients explicitly touch/view a session over REST when entering it so the shared list moves it to the top even if no new prompt is sent.
 
 ## Environment integration
 

--- a/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
@@ -69,6 +69,20 @@ public struct AgentSessionSummary: Equatable, Identifiable {
         formatDate(dateFromISO(updatedAtISO))
     }
 
+    public func updating(title: String? = nil, updatedAtISO: String? = nil, running: Bool? = nil) -> AgentSessionSummary {
+        var object = raw.objectValue ?? [:]
+        if let title {
+            object["title"] = .string(title)
+        }
+        if let updatedAtISO {
+            object["updatedAt"] = .string(updatedAtISO)
+        }
+        if let running {
+            object["running"] = .bool(running)
+        }
+        return AgentSessionSummary(raw: .object(object))
+    }
+
     private func dateFromISO(_ value: String?) -> Date? {
         guard let iso = value else { return nil }
         let withFraction = ISO8601DateFormatter()

--- a/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
@@ -69,6 +69,9 @@ public struct AgentSessionSummary: Equatable, Identifiable {
         formatDate(dateFromISO(updatedAtISO))
     }
 
+    // THIS IS FOR BACKWARDS COMPATIBILITY
+    // Preserve unknown server fields while updating known session-list values so
+    // older/newer clients can continue round-tripping the shared summary shape.
     public func updating(title: String? = nil, updatedAtISO: String? = nil, running: Bool? = nil) -> AgentSessionSummary {
         var object = raw.objectValue ?? [:]
         if let title {

--- a/clients/RookKit/Sources/RookKit/Models/JSONValue.swift
+++ b/clients/RookKit/Sources/RookKit/Models/JSONValue.swift
@@ -74,4 +74,11 @@ public enum JSONValue: Codable, Equatable {
         }
         return nil
     }
+
+    public var objectValue: [String: JSONValue]? {
+        if case .object(let value) = self {
+            return value
+        }
+        return nil
+    }
 }

--- a/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
+++ b/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
@@ -112,6 +112,21 @@ public struct RookAPI {
         return response.events
     }
 
+    public func renameSession(sessionId: String, title: String) async throws -> AgentSessionSummary {
+        AgentSessionSummary(raw: try await patchJSON(
+            path: "api/sessions/\(sessionId)",
+            payload: .object(["title": .string(title)])
+        ))
+    }
+
+    public func touchSession(sessionId: String) async throws -> AgentSessionSummary {
+        AgentSessionSummary(raw: try await postJSON(path: "api/sessions/\(sessionId)/touch", payload: .object([:])) )
+    }
+
+    public func deleteSession(sessionId: String) async throws {
+        _ = try await deleteJSON(path: "api/sessions/\(sessionId)")
+    }
+
     public func environmentPreview(environmentId: String) async throws -> EnvironmentPreview {
         try await get(
             path: "api/environments/preview",
@@ -214,13 +229,11 @@ public struct RookAPI {
     }
 
     private func post<T: Decodable>(path: String, payload: JSONValue) async throws -> T {
-        var request = authorizedRequest(url: requestURL(path: path, query: [:]))
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONEncoder().encode(payload)
-        let (data, response) = try await URLSession.shared.data(for: request)
-        try throwIfErrorResponse(data: data, response: response)
-        return try JSONDecoder().decode(T.self, from: data)
+        try await sendJSON(path: path, method: "POST", payload: payload)
+    }
+
+    private func patch<T: Decodable>(path: String, payload: JSONValue) async throws -> T {
+        try await sendJSON(path: path, method: "PATCH", payload: payload)
     }
 
     private func getJSON(path: String, query: [String: String]) async throws -> JSONValue {
@@ -228,13 +241,29 @@ public struct RookAPI {
     }
 
     private func postJSON(path: String, payload: JSONValue) async throws -> JSONValue {
+        try await sendJSON(path: path, method: "POST", payload: payload)
+    }
+
+    private func patchJSON(path: String, payload: JSONValue) async throws -> JSONValue {
+        try await sendJSON(path: path, method: "PATCH", payload: payload)
+    }
+
+    private func deleteJSON(path: String) async throws -> JSONValue {
         var request = authorizedRequest(url: requestURL(path: path, query: [:]))
-        request.httpMethod = "POST"
+        request.httpMethod = "DELETE"
+        let (data, response) = try await URLSession.shared.data(for: request)
+        try throwIfErrorResponse(data: data, response: response)
+        return try JSONDecoder().decode(JSONValue.self, from: data)
+    }
+
+    private func sendJSON<T: Decodable>(path: String, method: String, payload: JSONValue) async throws -> T {
+        var request = authorizedRequest(url: requestURL(path: path, query: [:]))
+        request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(payload)
         let (data, response) = try await URLSession.shared.data(for: request)
         try throwIfErrorResponse(data: data, response: response)
-        return try JSONDecoder().decode(JSONValue.self, from: data)
+        return try JSONDecoder().decode(T.self, from: data)
     }
 
     private func authorizedRequest(url: URL) -> URLRequest {

--- a/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
+++ b/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
@@ -76,6 +76,20 @@ final class ApiTypesTests: XCTestCase {
         XCTAssertEqual(summary.updatedAtISO, "2026-01-15T11:00:00Z")
     }
 
+    func testAgentSessionSummaryUpdatingPreservesUnknownFields() {
+        let raw = JSONValue.object([
+            "sessionId": .string("s1"),
+            "title": .string("before"),
+            "updatedAt": .string("2026-01-15T11:00:00Z"),
+            "extra": .string("keep-me")
+        ])
+        let summary = AgentSessionSummary(raw: raw).updating(title: "after", updatedAtISO: "2026-01-15T12:00:00Z", running: true)
+        XCTAssertEqual(summary.name, "after")
+        XCTAssertEqual(summary.updatedAtISO, "2026-01-15T12:00:00Z")
+        XCTAssertEqual(summary.running, true)
+        XCTAssertEqual(summary.raw["extra"]?.stringValue, "keep-me")
+    }
+
     // MARK: - EnvironmentCandidate Codable
 
     func testEnvironmentCandidateRoundTrip() throws {

--- a/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/RookViewModel.kt
@@ -343,6 +343,10 @@ class RookViewModel(
                 } else {
                     socket.loadSession(session.id)
                 }
+                val touched = AgentSessionSummary(api.touchSession(session.id))
+                _currentSession.value = touched
+                _sessions.value = api.sessions().map(::AgentSessionSummary)
+                _sessions.value.firstOrNull { it.id == session.id }?.let { _currentSession.value = it }
             } catch (e: Exception) {
                 _sessionsError.value = e.message ?: "Failed to resume session"
             } finally {
@@ -351,8 +355,58 @@ class RookViewModel(
         }
     }
 
+    fun renameSession(session: AgentSessionSummary, title: String) {
+        scope.launch {
+            try {
+                val renamed = AgentSessionSummary(api.renameSession(session.id, title))
+                if (_currentSession.value?.id == session.id) {
+                    _currentSession.value = renamed
+                }
+                _sessions.value = api.sessions().map(::AgentSessionSummary)
+                _sessions.value.firstOrNull { it.id == session.id }?.let {
+                    if (_currentSession.value?.id == session.id) _currentSession.value = it
+                }
+            } catch (e: Exception) {
+                _sessionsError.value = e.message ?: "Failed to rename session"
+            }
+        }
+    }
+
+    fun deleteSession(session: AgentSessionSummary) {
+        scope.launch {
+            try {
+                api.deleteSession(session.id)
+                if (_currentSession.value?.id == session.id) {
+                    socket.disconnect()
+                    connectedSocketSessionId = null
+                    _currentSession.value = null
+                    _chatVisible.value = false
+                }
+                _sessions.value = _sessions.value.filterNot { it.id == session.id }
+                _sessions.value = api.sessions().map(::AgentSessionSummary)
+            } catch (e: Exception) {
+                _sessionsError.value = e.message ?: "Failed to delete session"
+            }
+        }
+    }
+
+    fun touchCurrentSession() {
+        val session = _currentSession.value ?: return
+        scope.launch {
+            try {
+                val touched = AgentSessionSummary(api.touchSession(session.id))
+                _currentSession.value = touched
+                _sessions.value = api.sessions().map(::AgentSessionSummary)
+                _sessions.value.firstOrNull { it.id == session.id }?.let { _currentSession.value = it }
+            } catch (e: Exception) {
+                _sessionsError.value = e.message ?: "Failed to update session recency"
+            }
+        }
+    }
+
     fun openChat() {
         if (_currentSession.value == null) return
+        touchCurrentSession()
         _chatVisible.value = true
     }
 

--- a/clients/android/app/src/main/java/com/rookery/rook/net/RookApi.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/net/RookApi.kt
@@ -106,6 +106,19 @@ class RookApi(
         return json.decodeFromJsonElement(TranscriptResponse.serializer(), body).events
     }
 
+    suspend fun renameSession(sessionId: String, title: String): JsonObject =
+        patchJson(
+            "api/sessions/$sessionId",
+            buildJsonObject { put("title", title) }
+        ).jsonObject
+
+    suspend fun touchSession(sessionId: String): JsonObject =
+        postJson("api/sessions/$sessionId/touch", buildJsonObject { }).jsonObject
+
+    suspend fun deleteSession(sessionId: String) {
+        deleteJson("api/sessions/$sessionId")
+    }
+
     suspend fun environmentPreview(environmentId: String): EnvironmentPreview {
         val body = getJson("api/environments/preview", mapOf("environmentId" to environmentId))
         return json.decodeFromJsonElement(EnvironmentPreview.serializer(), body)
@@ -194,8 +207,21 @@ class RookApi(
     }
 
     private suspend fun postJson(path: String, payload: JsonElement): JsonElement {
+        return sendJson(path, "POST", payload)
+    }
+
+    private suspend fun patchJson(path: String, payload: JsonElement): JsonElement {
+        return sendJson(path, "PATCH", payload)
+    }
+
+    private suspend fun deleteJson(path: String): JsonElement {
+        val request = authorized(Request.Builder().url(requestUrl(path)).delete()).build()
+        return execute(request)
+    }
+
+    private suspend fun sendJson(path: String, method: String, payload: JsonElement): JsonElement {
         val body = json.encodeToString(JsonElement.serializer(), payload).toRequestBody("application/json".toMediaType())
-        val request = authorized(Request.Builder().url(requestUrl(path)).post(body)).build()
+        val request = authorized(Request.Builder().url(requestUrl(path)).method(method, body)).build()
         return execute(request)
     }
 

--- a/clients/android/app/src/main/java/com/rookery/rook/ui/AgentPickerScreen.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/ui/AgentPickerScreen.kt
@@ -26,15 +26,21 @@ import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.HourglassEmpty
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.WarningAmber
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -75,6 +81,9 @@ fun SessionsHomeScreen(viewModel: RookViewModel) {
     val agentTree = remember(agents) { buildAgentTree(agents) }
     var newSessionName by remember { mutableStateOf("") }
     var selectedRuntimeId by remember(agents) { mutableStateOf(agents.firstOrNull()?.id ?: "") }
+    var sessionToRename by remember { mutableStateOf<AgentSessionSummary?>(null) }
+    var renameDraft by remember { mutableStateOf("") }
+    var sessionToDelete by remember { mutableStateOf<AgentSessionSummary?>(null) }
 
     Column(modifier = Modifier.fillMaxSize().background(PanelPalette.backgroundPrimary)) {
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth().padding(start = 16.dp, top = 8.dp, bottom = 4.dp, end = 8.dp)) {
@@ -129,13 +138,69 @@ fun SessionsHomeScreen(viewModel: RookViewModel) {
                         Text("No sessions yet — start a new chat above.", fontSize = 14.sp, color = PanelPalette.textMuted, modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp))
                     } else {
                         sessions.forEachIndexed { index, session ->
-                            SessionRow(session = session, currentSessionId = currentSession?.id, enabled = !startingSession, onClick = { viewModel.resumeSession(session) })
+                            SessionRow(
+                                session = session,
+                                currentSessionId = currentSession?.id,
+                                enabled = !startingSession,
+                                onClick = { viewModel.resumeSession(session) },
+                                onRename = {
+                                    renameDraft = session.name
+                                    sessionToRename = session
+                                },
+                                onDelete = {
+                                    sessionToDelete = session
+                                }
+                            )
                             if (index < sessions.lastIndex) HorizontalDivider(color = PanelPalette.border)
                         }
                     }
                 }
             }
         }
+    }
+
+    sessionToRename?.let { session ->
+        AlertDialog(
+            onDismissRequest = { sessionToRename = null },
+            title = { Text("Rename Session") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Update the title for ${session.name}.")
+                    OutlinedTextField(
+                        value = renameDraft,
+                        onValueChange = { renameDraft = it },
+                        singleLine = true,
+                        label = { Text("Session title") }
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.renameSession(session, renameDraft)
+                    sessionToRename = null
+                }) { Text("Save") }
+            },
+            dismissButton = {
+                TextButton(onClick = { sessionToRename = null }) { Text("Cancel") }
+            }
+        )
+    }
+
+    sessionToDelete?.let { session ->
+        AlertDialog(
+            onDismissRequest = { sessionToDelete = null },
+            title = { Text("Delete Session?") },
+            text = { Text("Delete ${session.name} permanently?") },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.deleteSession(session)
+                    sessionToDelete = null
+                }) { Text("Delete") }
+            },
+            dismissButton = {
+                TextButton(onClick = { sessionToDelete = null }) { Text("Cancel") }
+            }
+        )
     }
 }
 
@@ -201,13 +266,15 @@ private fun NewChatNameField(value: String, onValueChange: (String) -> Unit, onS
 }
 
 @Composable
-private fun SessionRow(session: AgentSessionSummary, currentSessionId: String?, enabled: Boolean, onClick: () -> Unit) {
+private fun SessionRow(session: AgentSessionSummary, currentSessionId: String?, enabled: Boolean, onClick: () -> Unit, onRename: () -> Unit, onDelete: () -> Unit) {
     val status = session.selectionStatus(currentSessionId)
     val statusTint = when (status) {
         SessionSelectionStatus.ACTIVE -> PanelPalette.warning
         SessionSelectionStatus.ON -> PanelPalette.success
         SessionSelectionStatus.OFF -> PanelPalette.textMuted
     }
+
+    var menuExpanded by remember(session.id) { mutableStateOf(false) }
 
     Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp), modifier = Modifier.fillMaxWidth().clickable(enabled = enabled, onClick = onClick).padding(vertical = 9.dp)) {
         Box(modifier = Modifier.size(30.dp).clip(CircleShape).background(PanelPalette.info.copy(alpha = 0.14f)), contentAlignment = Alignment.Center) {
@@ -222,6 +289,21 @@ private fun SessionRow(session: AgentSessionSummary, currentSessionId: String?, 
             Text(status.label, fontSize = 11.sp, fontWeight = FontWeight.SemiBold, color = Color.White.copy(alpha = 0.95f))
         }
         Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = null, tint = PanelPalette.textMuted)
+        Box {
+            IconButton(onClick = { menuExpanded = true }) {
+                Icon(Icons.Filled.MoreVert, contentDescription = "Session actions", tint = PanelPalette.textMuted)
+            }
+            DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                DropdownMenuItem(text = { Text("Rename") }, onClick = {
+                    menuExpanded = false
+                    onRename()
+                })
+                DropdownMenuItem(text = { Text("Delete") }, onClick = {
+                    menuExpanded = false
+                    onDelete()
+                })
+            }
+        }
     }
 }
 

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -28,7 +28,7 @@ binding, and bearer-token auth, start with [docs/setup.md](../../docs/setup.md).
   contains, then decide with the same 2×2 choices as every other client.
   Leaving the region simply stops refreshing it from the phone; the server ages
   it out on its own.
-- **Full chat parity.** Agent picker, REST-backed session discovery, one-socket session creation (`session/new` binds the just-opened websocket), per-session websocket attach for resumed sessions, transcript hydration for already-running sessions, and streaming ACP chat
+- **Full chat parity.** Agent picker, REST-backed session discovery, session rename/delete management from the session list, one-socket session creation (`session/new` binds the just-opened websocket), per-session websocket attach for resumed sessions, transcript hydration for already-running sessions, and streaming ACP chat
   (text, thinking, tool calls, plans, errors, context usage) — including
   auto-rendering well-formed JSON tool arguments as human-readable YAML and
   assistant markdown with native drag-selection, standard copy/paste behavior,

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -493,6 +493,21 @@ final class RookModel: ObservableObject {
         }
     }
 
+    private func replaceSessionSummary(_ summary: AgentSessionSummary) {
+        guard let index = sessions.firstIndex(where: { $0.id == summary.id }) else { return }
+        sessions[index] = summary
+    }
+
+    private func applyLocalSessionTitle(_ title: String, to sessionId: String) {
+        let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "session" : title.trimmingCharacters(in: .whitespacesAndNewlines)
+        sessions = sessions.map { existing in
+            existing.id == sessionId ? existing.updating(title: normalizedTitle) : existing
+        }
+        if currentSession?.id == sessionId {
+            currentSession = currentSession?.updating(title: normalizedTitle)
+        }
+    }
+
     func startNewSession(agentId: String, name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         startingSession = true
@@ -552,6 +567,12 @@ final class RookModel: ObservableObject {
                 } else {
                     try await handle.load()
                 }
+                let touched = try await api.touchSession(sessionId: session.id)
+                currentSession = touched
+                await loadSessions()
+                if let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
                 selectedAgentId = nil
                 chatVisible = true
                 enteredEnvironments = []
@@ -564,12 +585,74 @@ final class RookModel: ObservableObject {
         }
     }
 
+    func renameSession(_ session: AgentSessionSummary, title: String) {
+        Task {
+            applyLocalSessionTitle(title, to: session.id)
+            do {
+                let renamed = try await api.renameSession(sessionId: session.id, title: title)
+                replaceSessionSummary(renamed)
+                if currentSession?.id == session.id {
+                    currentSession = renamed
+                }
+                await loadSessions()
+                if currentSession?.id == session.id, let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
+                updateLiveActivity()
+            } catch {
+                sessionsError = error.localizedDescription
+                await loadSessions()
+                if currentSession?.id == session.id, let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
+            }
+        }
+    }
+
+    func deleteSession(_ session: AgentSessionSummary) {
+        Task {
+            do {
+                try await api.deleteSession(sessionId: session.id)
+                handles.removeValue(forKey: session.id)?.close()
+                if currentSession?.id == session.id {
+                    currentSession = nil
+                    chatVisible = false
+                    selectedAgentId = nil
+                    environmentListItems = []
+                    enteredEnvironments = []
+                }
+                sessions.removeAll { $0.id == session.id }
+                await loadSessions()
+                updateLiveActivity()
+            } catch {
+                sessionsError = error.localizedDescription
+            }
+        }
+    }
+
+    func touchCurrentSession() {
+        guard let session = currentSession else { return }
+        Task {
+            do {
+                let touched = try await api.touchSession(sessionId: session.id)
+                currentSession = touched
+                await loadSessions()
+                if let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
+            } catch {
+                sessionsError = error.localizedDescription
+            }
+        }
+    }
+
     /// Bring the (already live) current session's chat on screen — used by the
     /// "Resume chat" affordance and the Live Activity deep link.
     func openChat() {
         guard currentSession != nil else {
             return
         }
+        touchCurrentSession()
         selectedAgentId = nil
         chatVisible = true
     }
@@ -699,10 +782,74 @@ final class RookModel: ObservableObject {
         appendBlock(.error(source: source, message: message))
     }
 
+    func finalizeActiveTools(as finalStatus: ToolBlockStatus) {
+        for index in blocks.indices {
+            guard case .tool(var state) = blocks[index].kind else { continue }
+            guard !state.status.isTerminal else { continue }
+            state.status = finalStatus
+            blocks[index].kind = .tool(state)
+        }
+    }
 
+    func handleSocketEvent(_ event: AcpClientEvent) {
+        switch event {
+        case .toolCallStarted(let toolCallId, let title, let kind, let status, let rawInput):
+            let toolStatus: ToolBlockStatus = status == "in_progress" ? .running : .pending
+            let state = ToolBlockState(toolCallId: toolCallId, title: title, kindLabel: kind, status: toolStatus, arguments: rawInput ?? "", output: "")
+            appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
+        case .toolCallUpdate(let toolCallId, let status, let toolName, let output):
+            updateTool(toolCallId) { tool in
+                if let toolName, tool.title.isEmpty { tool.title = toolName }
+                switch status {
+                case "pending": tool.status = .pending
+                case "in_progress": tool.status = .running; if let output { tool.output = output }
+                case "completed": tool.status = .completed; if let output { tool.output = output }
+                case "failed": tool.status = .failed; if let output { tool.output = output }
+                case "cancelled": tool.status = .cancelled
+                default: break
+                }
+            }
+        case .toolInputSnapshot(let toolCallId, _, let text):
+            updateTool(toolCallId) { tool in
+                tool.status = .inputStreaming
+                tool.arguments = text
+            }
+        case .toolInputDelta(let toolCallId, _, let delta):
+            updateTool(toolCallId) { tool in
+                tool.status = .inputStreaming
+                tool.arguments += delta
+            }
+        case .toolCallReady(let toolCallId, _):
+            updateTool(toolCallId) { tool in
+                tool.status = .ready
+            }
+        case .toolOutputSnapshot(let toolCallId, _, let text):
+            updateTool(toolCallId) { tool in
+                tool.status = .running
+                tool.output = text
+            }
+        case .toolOutputDelta(let toolCallId, _, let delta):
+            updateTool(toolCallId) { tool in
+                tool.status = .running
+                tool.output += delta
+            }
+        default:
+            return
+        }
+    }
 
-
-
+    private func updateTool(_ toolCallId: String, mutate: (inout ToolBlockState) -> Void) {
+        for index in blocks.indices.reversed() {
+            if case .tool(var state) = blocks[index].kind, state.toolCallId == toolCallId {
+                mutate(&state)
+                blocks[index].kind = .tool(state)
+                return
+            }
+        }
+        var state = ToolBlockState(toolCallId: toolCallId, title: "Tool", kindLabel: "", status: .running, arguments: "", output: "")
+        mutate(&state)
+        appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
+    }
 
     // MARK: - Environment offers
 

--- a/clients/iphone/Sources/Views/AgentPickerScreen.swift
+++ b/clients/iphone/Sources/Views/AgentPickerScreen.swift
@@ -7,6 +7,9 @@ struct SessionsHomeScreen: View {
     @State private var showingPlaces = false
     @State private var newSessionName = ""
     @State private var selectedRuntimeID = ""
+    @State private var sessionToRename: AgentSessionSummary?
+    @State private var renameDraft = ""
+    @State private var sessionToDelete: AgentSessionSummary?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -44,6 +47,29 @@ struct SessionsHomeScreen: View {
         }
         .sheet(isPresented: $showingSettings) { SettingsScreen(model: model) }
         .sheet(isPresented: $showingPlaces) { PlacesScreen(model: model) }
+        .sheet(item: $sessionToRename) { session in
+            RenameSessionSheet(
+                sessionName: session.name,
+                draft: $renameDraft,
+                onCancel: { sessionToRename = nil },
+                onSave: {
+                    model.renameSession(session, title: renameDraft)
+                    sessionToRename = nil
+                }
+            )
+            .presentationDetents([.height(220)])
+        }
+        .alert("Delete Session?", isPresented: Binding(get: { sessionToDelete != nil }, set: { if !$0 { sessionToDelete = nil } }), presenting: sessionToDelete) { session in
+            Button("Delete", role: .destructive) {
+                model.deleteSession(session)
+                sessionToDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                sessionToDelete = nil
+            }
+        } message: { session in
+            Text("Delete \(session.name) permanently?")
+        }
         .onAppear {
             if selectedRuntimeID.isEmpty { selectedRuntimeID = model.agents.first?.id ?? "" }
         }
@@ -123,11 +149,23 @@ struct SessionsHomeScreen: View {
             } else {
                 VStack(spacing: 0) {
                     ForEach(Array(model.sessions.enumerated()), id: \.element.id) { index, session in
-                        Button { model.resumeSession(session) } label: {
-                            SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                        HStack(spacing: 8) {
+                            Button { model.resumeSession(session) } label: {
+                                SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(model.startingSession)
+
+                            SessionActionsMenu(
+                                onRename: {
+                                    renameDraft = session.name
+                                    sessionToRename = session
+                                },
+                                onDelete: {
+                                    sessionToDelete = session
+                                }
+                            )
                         }
-                        .buttonStyle(.plain)
-                        .disabled(model.startingSession)
 
                         if index < model.sessions.count - 1 {
                             Divider().overlay(PanelPalette.border).opacity(0.5)
@@ -265,5 +303,50 @@ private struct SessionRow: View {
         case .on: return "bolt.fill"
         case .off: return "moon.zzz"
         }
+    }
+}
+
+private struct SessionActionsMenu: View {
+    var onRename: () -> Void
+    var onDelete: () -> Void
+
+    var body: some View {
+        Menu {
+            Button("Rename", action: onRename)
+            Button("Delete", role: .destructive, action: onDelete)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(PanelPalette.textMuted)
+                .frame(width: 30, height: 30)
+        }
+    }
+}
+
+private struct RenameSessionSheet: View {
+    let sessionName: String
+    @Binding var draft: String
+    var onCancel: () -> Void
+    var onSave: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Rename Session")
+                .font(.headline)
+            Text("Update the title for \(sessionName).")
+                .font(.caption)
+                .foregroundStyle(PanelPalette.textMuted)
+            TextField("Session title", text: $draft)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textFieldStyle(.roundedBorder)
+            HStack {
+                Button("Cancel", action: onCancel)
+                Spacer()
+                Button("Save", action: onSave)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
     }
 }

--- a/clients/iphone/Sources/Views/SessionsScreen.swift
+++ b/clients/iphone/Sources/Views/SessionsScreen.swift
@@ -10,6 +10,9 @@ struct SessionsScreen: View {
     let agentId: String
     @State private var newSessionName = ""
     @FocusState private var nameFocused: Bool
+    @State private var sessionToRename: AgentSessionSummary?
+    @State private var renameDraft = ""
+    @State private var sessionToDelete: AgentSessionSummary?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -21,6 +24,29 @@ struct SessionsScreen: View {
                 }
                 .padding(16)
             }
+        }
+        .sheet(item: $sessionToRename) { session in
+            RenameSessionSheet(
+                sessionName: session.name,
+                draft: $renameDraft,
+                onCancel: { sessionToRename = nil },
+                onSave: {
+                    model.renameSession(session, title: renameDraft)
+                    sessionToRename = nil
+                }
+            )
+            .presentationDetents([.height(220)])
+        }
+        .alert("Delete Session?", isPresented: Binding(get: { sessionToDelete != nil }, set: { if !$0 { sessionToDelete = nil } }), presenting: sessionToDelete) { session in
+            Button("Delete", role: .destructive) {
+                model.deleteSession(session)
+                sessionToDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                sessionToDelete = nil
+            }
+        } message: { session in
+            Text("Delete \(session.name) permanently?")
         }
     }
 
@@ -133,13 +159,25 @@ struct SessionsScreen: View {
             } else {
                 VStack(spacing: 0) {
                     ForEach(Array(model.sessions.enumerated()), id: \.element.id) { index, session in
-                        Button {
-                            model.resumeSession(session)
-                        } label: {
-                            SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                        HStack(spacing: 8) {
+                            Button {
+                                model.resumeSession(session)
+                            } label: {
+                                SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(model.startingSession)
+
+                            SessionActionsMenu(
+                                onRename: {
+                                    renameDraft = session.name
+                                    sessionToRename = session
+                                },
+                                onDelete: {
+                                    sessionToDelete = session
+                                }
+                            )
                         }
-                        .buttonStyle(.plain)
-                        .disabled(model.startingSession)
 
                         if index < model.sessions.count - 1 {
                             Divider().overlay(PanelPalette.border).opacity(0.5)
@@ -228,5 +266,50 @@ private struct SessionRow: View {
 
     private var statusLabel: String {
         status.label
+    }
+}
+
+private struct SessionActionsMenu: View {
+    var onRename: () -> Void
+    var onDelete: () -> Void
+
+    var body: some View {
+        Menu {
+            Button("Rename", action: onRename)
+            Button("Delete", role: .destructive, action: onDelete)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(PanelPalette.textMuted)
+                .frame(width: 30, height: 30)
+        }
+    }
+}
+
+private struct RenameSessionSheet: View {
+    let sessionName: String
+    @Binding var draft: String
+    var onCancel: () -> Void
+    var onSave: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Rename Session")
+                .font(.headline)
+            Text("Update the title for \(sessionName).")
+                .font(.caption)
+                .foregroundStyle(PanelPalette.textMuted)
+            TextField("Session title", text: $draft)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textFieldStyle(.roundedBorder)
+            HStack {
+                Button("Cancel", action: onCancel)
+                Spacer()
+                Button("Save", action: onSave)
+                    .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(20)
     }
 }

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -13,7 +13,7 @@ WebSocket protocol. For repo-level setup, `.env`, binding, and auth, start with
 ## Features
 
 - **Sessions home** - unified session-selection screen listing all sessions across runtimes, with a New Chat form that selects a configured runtime.
-- **Sessions** - session history ordered by most recently updated; resume any session by clicking it. Discovery is REST (`GET /api/sessions`). New chats start on one unbound WebSocket that becomes session-bound after `session/new`; thereafter live interaction is one session WebSocket per session.
+- **Sessions** - session history ordered by most recently viewed/updated; resume any session by clicking it, rename it from the row action menu, or delete it with confirmation. Discovery is REST (`GET /api/sessions`), management uses `PATCH/DELETE /api/sessions/:id`, and opening/resuming a session records a REST touch so it moves to the top even without a new prompt. New chats start on one unbound WebSocket that becomes session-bound after `session/new`; thereafter live interaction is one session WebSocket per session.
 - **Auto-resume** - on launch the app rejoins the most recent session; if it is already running, it hydrates from `GET /api/sessions/:id/transcript` instead of reloading the runtime.
 - **Streaming chat** — `session/prompt` over `ws://127.0.0.1:7665/api/ws?sessionId=...`;
   renders agent text, thinking (collapsible), tool calls with normalized raw

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -152,6 +152,67 @@ final class ChatSessionController {
                 } else {
                     try await handle.load()
                 }
+                let touched = try await api.touchSession(sessionId: session.id)
+                currentSession = touched
+                await loadSessions()
+                if let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
+            } catch {
+                sessionsError = error.localizedDescription
+            }
+        }
+    }
+
+    func renameSession(_ session: AgentSessionSummary, title: String) {
+        Task {
+            applyLocalSessionTitle(title, to: session.id)
+            do {
+                let renamed = try await api.renameSession(sessionId: session.id, title: title)
+                replaceSessionSummary(renamed)
+                currentSession = currentSession?.id == session.id ? renamed : currentSession
+                await loadSessions()
+                if currentSession?.id == session.id, let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
+            } catch {
+                sessionsError = error.localizedDescription
+                await loadSessions()
+                if currentSession?.id == session.id, let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
+            }
+        }
+    }
+
+    func deleteSession(_ session: AgentSessionSummary, completion: ((Bool) -> Void)? = nil) {
+        Task {
+            do {
+                try await api.deleteSession(sessionId: session.id)
+                handles.removeValue(forKey: session.id)?.close()
+                if currentSession?.id == session.id {
+                    currentSession = nil
+                }
+                sessions.removeAll { $0.id == session.id }
+                await loadSessions()
+                completion?(true)
+            } catch {
+                sessionsError = error.localizedDescription
+                completion?(false)
+            }
+        }
+    }
+
+    func touchCurrentSession() {
+        guard let session = currentSession else { return }
+        Task {
+            do {
+                let touched = try await api.touchSession(sessionId: session.id)
+                currentSession = touched
+                await loadSessions()
+                if let refreshed = sessions.first(where: { $0.id == session.id }) {
+                    currentSession = refreshed
+                }
             } catch {
                 sessionsError = error.localizedDescription
             }
@@ -177,6 +238,22 @@ final class ChatSessionController {
     func appendSystemMessage(_ text: String) { currentHandle?.appendSystemMessage(text) }
 
     // MARK: - Private
+
+    private func replaceSessionSummary(_ summary: AgentSessionSummary) {
+        guard let index = sessions.firstIndex(where: { $0.id == summary.id }) else { return }
+        sessions[index] = summary
+    }
+
+    private func applyLocalSessionTitle(_ title: String, to sessionId: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedTitle = trimmed.isEmpty ? "session" : trimmed
+        sessions = sessions.map { existing in
+            existing.id == sessionId ? existing.updating(title: normalizedTitle) : existing
+        }
+        if currentSession?.id == sessionId {
+            currentSession = currentSession?.updating(title: normalizedTitle)
+        }
+    }
 
     private func getOrCreateHandle(for session: AgentSessionSummary) -> SessionHandle {
         if let existing = handles[session.id] { return existing }

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -400,6 +400,7 @@ final class RookMacModel: ObservableObject {
     func openChat() {
         guard currentSession != nil else { return }
         stopEnvironmentListAutoRefresh()
+        chatSessionController.touchCurrentSession()
         panelMode = .chat
     }
 
@@ -419,6 +420,18 @@ final class RookMacModel: ObservableObject {
     func resumeSession(_ session: AgentSessionSummary) {
         chatSessionController.resumeSession(session) { [weak self] in
             self?.panelMode = .chat
+        }
+    }
+
+    func renameSession(_ session: AgentSessionSummary, title: String) {
+        chatSessionController.renameSession(session, title: title)
+    }
+
+    func deleteSession(_ session: AgentSessionSummary) {
+        let deletingCurrent = currentSession?.id == session.id
+        chatSessionController.deleteSession(session) { [weak self] succeeded in
+            guard succeeded, deletingCurrent else { return }
+            self?.panelMode = .home
         }
     }
 

--- a/clients/mac/Sources/Views/RookView.swift
+++ b/clients/mac/Sources/Views/RookView.swift
@@ -982,6 +982,7 @@ private struct SessionActionsMenu: View {
                 .frame(width: 28, height: 28)
                 .background(Circle().fill(Color.white.opacity(0.06)))
         }
+        .menuIndicator(.hidden)
         .menuStyle(.borderlessButton)
         .fixedSize()
     }

--- a/clients/mac/Sources/Views/RookView.swift
+++ b/clients/mac/Sources/Views/RookView.swift
@@ -699,9 +699,6 @@ private struct SessionHomeRow: View {
                         .fill(statusTint.opacity(0.25))
                 )
 
-            Image(systemName: "chevron.right")
-                .font(.system(size: 10, weight: .bold))
-                .foregroundStyle(.secondary)
         }
         .padding(.vertical, 8)
         .padding(.horizontal, 6)

--- a/clients/mac/Sources/Views/RookView.swift
+++ b/clients/mac/Sources/Views/RookView.swift
@@ -230,6 +230,9 @@ private struct HomeContent: View {
     @ObservedObject var model: RookMacModel
     @State private var newSessionName = ""
     @State private var selectedRuntimeID = ""
+    @State private var sessionToRename: AgentSessionSummary?
+    @State private var renameDraft = ""
+    @State private var sessionToDelete: AgentSessionSummary?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -252,6 +255,28 @@ private struct HomeContent: View {
                 serverOfflineCard
             }
             footerActions
+        }
+        .sheet(item: $sessionToRename) { session in
+            RenameSessionSheet(
+                sessionName: session.name,
+                draft: $renameDraft,
+                onCancel: { sessionToRename = nil },
+                onSave: {
+                    model.renameSession(session, title: renameDraft)
+                    sessionToRename = nil
+                }
+            )
+        }
+        .alert("Delete Session?", isPresented: Binding(get: { sessionToDelete != nil }, set: { if !$0 { sessionToDelete = nil } }), presenting: sessionToDelete) { session in
+            Button("Delete", role: .destructive) {
+                model.deleteSession(session)
+                sessionToDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                sessionToDelete = nil
+            }
+        } message: { session in
+            Text("Delete \(session.name) permanently?")
         }
         .onAppear {
             ensureSelectedRuntimeID()
@@ -539,13 +564,25 @@ private struct HomeContent: View {
                 ScrollView(.vertical) {
                     LazyVStack(spacing: 0) {
                         ForEach(Array(model.sessions.enumerated()), id: \.element.id) { index, session in
-                            Button {
-                                model.resumeSession(session)
-                            } label: {
-                                SessionHomeRow(session: session, currentSessionId: model.currentSession?.id)
+                            HStack(spacing: 8) {
+                                Button {
+                                    model.resumeSession(session)
+                                } label: {
+                                    SessionHomeRow(session: session, currentSessionId: model.currentSession?.id)
+                                }
+                                .buttonStyle(.plain)
+                                .pointingHandOnHover()
+
+                                SessionActionsMenu(
+                                    onRename: {
+                                        renameDraft = session.name
+                                        sessionToRename = session
+                                    },
+                                    onDelete: {
+                                        sessionToDelete = session
+                                    }
+                                )
                             }
-                            .buttonStyle(.plain)
-                            .pointingHandOnHover()
                             if index < model.sessions.count - 1 {
                                 Divider().opacity(0.45)
                             }
@@ -691,6 +728,9 @@ private struct SessionsDetail: View {
     @ObservedObject var model: RookMacModel
     var agentId: String
     @State private var newSessionName = ""
+    @State private var sessionToRename: AgentSessionSummary?
+    @State private var renameDraft = ""
+    @State private var sessionToDelete: AgentSessionSummary?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -704,6 +744,28 @@ private struct SessionsDetail: View {
 
             newChatCard
             sessionsCard
+        }
+        .sheet(item: $sessionToRename) { session in
+            RenameSessionSheet(
+                sessionName: session.name,
+                draft: $renameDraft,
+                onCancel: { sessionToRename = nil },
+                onSave: {
+                    model.renameSession(session, title: renameDraft)
+                    sessionToRename = nil
+                }
+            )
+        }
+        .alert("Delete Session?", isPresented: Binding(get: { sessionToDelete != nil }, set: { if !$0 { sessionToDelete = nil } }), presenting: sessionToDelete) { session in
+            Button("Delete", role: .destructive) {
+                model.deleteSession(session)
+                sessionToDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                sessionToDelete = nil
+            }
+        } message: { session in
+            Text("Delete \(session.name) permanently?")
         }
     }
 
@@ -792,15 +854,27 @@ private struct SessionsDetail: View {
                 ScrollView(.vertical) {
                     LazyVStack(spacing: 0) {
                         ForEach(Array(model.sessions.enumerated()), id: \.element.id) { index, session in
-                            Button {
-                                model.resumeSession(session)
-                            } label: {
-                                SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                            HStack(spacing: 8) {
+                                Button {
+                                    model.resumeSession(session)
+                                } label: {
+                                    SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Resume this session")
+                                .disabled(model.startingSession)
+                                .pointingHandOnHover()
+
+                                SessionActionsMenu(
+                                    onRename: {
+                                        renameDraft = session.name
+                                        sessionToRename = session
+                                    },
+                                    onDelete: {
+                                        sessionToDelete = session
+                                    }
+                                )
                             }
-                            .buttonStyle(.plain)
-                            .help("Resume this session")
-                            .disabled(model.startingSession)
-                            .pointingHandOnHover()
 
                             if index < model.sessions.count - 1 {
                                 Divider()
@@ -892,5 +966,54 @@ private struct SessionRow: View {
 
     private var statusLabel: String {
         status.label
+    }
+}
+
+private struct SessionActionsMenu: View {
+    var onRename: () -> Void
+    var onDelete: () -> Void
+
+    var body: some View {
+        Menu {
+            Button("Rename", action: onRename)
+            Divider()
+            Button("Delete", role: .destructive, action: onDelete)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(PanelPalette.secondaryText)
+                .frame(width: 28, height: 28)
+                .background(Circle().fill(Color.white.opacity(0.06)))
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+    }
+}
+
+private struct RenameSessionSheet: View {
+    let sessionName: String
+    @Binding var draft: String
+    var onCancel: () -> Void
+    var onSave: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Rename Session")
+                .font(.headline)
+            Text("Update the title for \(sessionName).")
+                .font(.caption)
+                .foregroundStyle(PanelPalette.secondaryText)
+            TextField("Session title", text: $draft)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(onSave)
+            HStack {
+                Spacer()
+                Button("Cancel", action: onCancel)
+                Button("Save", action: onSave)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 320)
     }
 }

--- a/server/README.md
+++ b/server/README.md
@@ -108,6 +108,9 @@ It implements:
 - `session/prompt`, `session/cancel` — standard prompt flow; image-capable runtimes accept standard ACP image content blocks with per-session capability reporting and bounded base64 validation
 - `session/set_mode`, `session/set_config_option` — ACP controls
 - `session/close` — closes a session
+- `PATCH /api/sessions/:id` — rename a session without changing its recency ordering
+- `POST /api/sessions/:id/touch` — mark a session as recently viewed so it moves to the top of the recents list even without a prompt
+- `DELETE /api/sessions/:id` — delete a session, its transcript, and its workspace state
 - `session/request_permission` — permission request relay
 - `_com.rookkeeper/environment_offer*` — negotiated env-offer extension
 
@@ -116,6 +119,7 @@ It implements:
 - Public session IDs are stable Rook-generated UUIDs (not runtime-derived)
 - Each session maps to `runtimeId` + runtime-local `runtimeSessionId` in SQLite
 - Sessions are a unified cross-runtime list ordered by `updatedAt` desc
+- `updatedAt` now represents both prompt activity and explicit client-side "viewed" touches, so opening/resuming a session moves it to the top
 - Session-to-environment membership persists in `session_environments`
 - Transcript history persists in `session_transcript_events` so later viewers can hydrate from server state instead of forcing runtime replay
 

--- a/server/src/agents/test-fixtures/mockAcpServer.mjs
+++ b/server/src/agents/test-fixtures/mockAcpServer.mjs
@@ -198,7 +198,11 @@ async function handleMessage(message) {
   }
 
   if (message.method === 'session/close') {
-    write({ jsonrpc: '2.0', id: message.id, result: { ok: true } });
+    if (process.env.MOCK_ACP_SESSION_CLOSE_UNSUPPORTED === '1') {
+      write({ jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'Method not found: session/close' } });
+    } else {
+      write({ jsonrpc: '2.0', id: message.id, result: { ok: true } });
+    }
     return;
   }
 

--- a/server/src/runtime/acpFacade.test.ts
+++ b/server/src/runtime/acpFacade.test.ts
@@ -600,6 +600,84 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
     // TODO: reconnect test needs runtime serialization investigation.
   });
 
+  it("renames, touches, and deletes sessions via REST session management endpoints", async () => {
+    const wsA = await connect();
+    await request(wsA, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "manage-a" } });
+    const sessionA = await request(wsA, 2, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "manage-a" },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const wsB = await connect();
+    await request(wsB, 3, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "manage-b" } });
+    const sessionB = await request(wsB, 4, "session/new", {
+      cwd: "/tmp",
+      mcpServers: [],
+      _meta: { runtimeId: "MockAcpAgent", title: "manage-b" },
+    });
+
+    let sessions = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((response) => response.json()) as { sessions: Array<Record<string, unknown>> };
+    const managedOrderBeforeTouch = sessions.sessions
+      .filter((session) => session.sessionId === sessionA.sessionId || session.sessionId === sessionB.sessionId)
+      .map((session) => session.sessionId);
+    expect(managedOrderBeforeTouch).toEqual([sessionB.sessionId, sessionA.sessionId]);
+
+    const renamed = await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionA.sessionId}`, {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "renamed-a" }),
+    }).then((response) => response.json()) as Record<string, unknown>;
+    expect(renamed.title).toBe("renamed-a");
+    sessions = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((response) => response.json()) as { sessions: Array<Record<string, unknown>> };
+    const managedOrderAfterRename = sessions.sessions
+      .filter((session) => session.sessionId === sessionA.sessionId || session.sessionId === sessionB.sessionId)
+      .map((session) => session.sessionId);
+    expect(managedOrderAfterRename).toEqual([sessionB.sessionId, sessionA.sessionId]);
+
+    await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionA.sessionId}/touch`, { method: "POST" });
+    sessions = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((response) => response.json()) as { sessions: Array<Record<string, unknown>> };
+    expect(sessions.sessions[0]?.sessionId).toBe(sessionA.sessionId);
+
+    await request(wsA, 5, "session/prompt", {
+      sessionId: sessionA.sessionId as string,
+      prompt: [{ type: "text", text: "tell me a joke" }],
+    });
+    const transcriptBeforeDelete = await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionA.sessionId}/transcript`).then((response) => response.json()) as { events: Array<Record<string, unknown>> };
+    expect(transcriptBeforeDelete.events.length).toBeGreaterThan(0);
+
+    const deleted = await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionA.sessionId}`, { method: "DELETE" });
+    expect(deleted.status).toBe(200);
+    sessions = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((response) => response.json()) as { sessions: Array<Record<string, unknown>> };
+    expect(sessions.sessions.some((session) => session.sessionId === sessionA.sessionId)).toBe(false);
+    expect(await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionA.sessionId}/transcript`).then((response) => response.status)).toBe(404);
+
+    wsA.close();
+    wsB.close();
+  });
+
+  it("deletes a session when its runtime does not implement session/close", async () => {
+    const previousUnsupported = process.env.MOCK_ACP_SESSION_CLOSE_UNSUPPORTED;
+    process.env.MOCK_ACP_SESSION_CLOSE_UNSUPPORTED = "1";
+    try {
+      const ws = await connect();
+      await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "delete-unsupported-close" } });
+      const session = await request(ws, 2, "session/new", {
+        cwd: "/tmp",
+        mcpServers: [],
+        _meta: { runtimeId: "MockAcpAgent", title: "delete-unsupported-close" },
+      });
+      const deleted = await fetch(`http://127.0.0.1:${PORT}/api/sessions/${session.sessionId}`, { method: "DELETE" });
+      expect(deleted.status).toBe(200);
+      expect(await fetch(`http://127.0.0.1:${PORT}/api/sessions/${session.sessionId}`).then((response) => response.status)).toBe(404);
+      ws.close();
+    } finally {
+      if (previousUnsupported === undefined) delete process.env.MOCK_ACP_SESSION_CLOSE_UNSUPPORTED;
+      else process.env.MOCK_ACP_SESSION_CLOSE_UNSUPPORTED = previousUnsupported;
+    }
+  });
+
   it("lists sessions via REST /api/sessions", async () => {
     const wsA = await connect();
     await request(wsA, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "test-a" } });

--- a/server/src/runtime/services/AgentRuntimeManager.ts
+++ b/server/src/runtime/services/AgentRuntimeManager.ts
@@ -76,6 +76,24 @@ export class AgentRuntimeManager {
     return this.sessions.list();
   }
 
+  async getSession(sessionId: string): Promise<SessionRecord> {
+    return this.requireSession(sessionId);
+  }
+
+  async renameSession(sessionId: string, title: string): Promise<SessionRecord> {
+    const record = await this.requireSession(sessionId);
+    const normalizedTitle = title.trim() || "session";
+    await this.sessions.rename(sessionId, normalizedTitle);
+    return { ...record, title: normalizedTitle };
+  }
+
+  async touchSession(sessionId: string): Promise<SessionRecord> {
+    await this.requireSession(sessionId);
+    const updatedAt = new Date().toISOString();
+    await this.sessions.touch(sessionId, updatedAt);
+    return await this.requireSession(sessionId);
+  }
+
   async createSession(runtimeId: string, params: JsonObject, title: string): Promise<SessionRecord> {
     const startedAt = performance.now();
     const profile = this.requireProfile(runtimeId);
@@ -209,16 +227,32 @@ export class AgentRuntimeManager {
     await this.sessions.touch(sessionId);
   }
 
-  async closeSession(sessionId: string): Promise<unknown> {
+  async deleteSession(sessionId: string): Promise<unknown> {
     const record = await this.requireSession(sessionId);
     await this.workspaceManager.assessAndFlush();
-    const runtime = this.runtimeFor(record);
-    const result = await runtime.request("session/close", { sessionId: record.runtimeSessionId });
-    await runtime.close();
+    let result: unknown = { ok: true };
+    const runtime = this.sessionRuntimes.get(record.sessionId);
+    if (runtime) {
+      // ACP runtimes are not required to implement session/close. The server
+      // owns the public session lifecycle, so terminating the per-session
+      // runtime must not be blocked by an optional/unsupported ACP method.
+      try {
+        result = await runtime.request("session/close", { sessionId: record.runtimeSessionId });
+      } catch (error) {
+        this.logger.info({ sessionId, error: error instanceof Error ? error.message : String(error) }, "runtime did not accept session/close; terminating runtime directly");
+      } finally {
+        await runtime.close();
+      }
+    }
+    await this.transcriptRepository?.clear(sessionId);
     await this.workspaceManager.removeSession(sessionId);
     this.detachSessionRuntime(sessionId);
     await this.sessions.delete(sessionId);
     return result;
+  }
+
+  async closeSession(sessionId: string): Promise<unknown> {
+    return this.deleteSession(sessionId);
   }
 
   /** Relay a standard ACP response to an ACP request initiated by a runtime. */

--- a/server/src/runtime/services/AgentRuntimeManager.ts
+++ b/server/src/runtime/services/AgentRuntimeManager.ts
@@ -251,6 +251,9 @@ export class AgentRuntimeManager {
     return result;
   }
 
+  // THIS IS FOR BACKWARDS COMPATIBILITY
+  // Keep ACP session/close callers on the existing manager entry point while
+  // applying the new durable deletion semantics underneath.
   async closeSession(sessionId: string): Promise<unknown> {
     return this.deleteSession(sessionId);
   }

--- a/server/src/sessions/repositories/SessionRepository.ts
+++ b/server/src/sessions/repositories/SessionRepository.ts
@@ -12,6 +12,7 @@ export interface SessionRepository {
   list(): Promise<SessionRecord[]>;
   get(sessionId: string): Promise<SessionRecord | undefined>;
   save(record: SessionRecord): Promise<void>;
+  rename(sessionId: string, title: string): Promise<void>;
   touch(sessionId: string, updatedAt?: string): Promise<void>;
   delete(sessionId: string): Promise<void>;
   environmentIds(sessionId: string): Promise<string[]>;

--- a/server/src/sessions/repositories/SqliteSessionRepository.test.ts
+++ b/server/src/sessions/repositories/SqliteSessionRepository.test.ts
@@ -24,10 +24,20 @@ describe("SqliteSessionRepository", () => {
     });
 
     expect((await repository.list()).map((session) => session.sessionId)).toEqual(["Claude:claude-1", "Pi:pi-1"]);
+
+    await repository.rename("Pi:pi-1", "Renamed");
+    expect((await repository.get("Pi:pi-1"))?.title).toBe("Renamed");
+    expect((await repository.list()).map((session) => session.sessionId)).toEqual(["Claude:claude-1", "Pi:pi-1"]);
+
     await repository.touch("Pi:pi-1", "2026-01-04T00:00:00.000Z");
     expect((await repository.list())[0]?.sessionId).toBe("Pi:pi-1");
+
     await repository.replaceEnvironmentIds("Pi:pi-1", ["web:example.com", "location:target"]);
     expect(new Set(await repository.environmentIds("Pi:pi-1"))).toEqual(new Set(["web:example.com", "location:target"]));
+
+    await repository.delete("Pi:pi-1");
+    expect(await repository.get("Pi:pi-1")).toBeUndefined();
+    expect(await repository.environmentIds("Pi:pi-1")).toEqual([]);
     repository.close();
   });
 });

--- a/server/src/sessions/repositories/SqliteSessionRepository.ts
+++ b/server/src/sessions/repositories/SqliteSessionRepository.ts
@@ -39,7 +39,7 @@ export class SqliteSessionRepository implements SessionRepository {
   async list(): Promise<SessionRecord[]> {
     return this.db.prepare(`
       SELECT session_id, runtime_id, runtime_session_id, title, cwd, started_at, updated_at
-      FROM sessions ORDER BY updated_at DESC
+      FROM sessions ORDER BY updated_at DESC, started_at DESC, session_id DESC
     `).all().map(rowToRecord);
   }
 
@@ -63,6 +63,10 @@ export class SqliteSessionRepository implements SessionRepository {
         started_at = excluded.started_at,
         updated_at = excluded.updated_at
     `).run(record.sessionId, record.runtimeId, record.runtimeSessionId, record.title, record.cwd, record.startedAt, record.updatedAt);
+  }
+
+  async rename(sessionId: string, title: string): Promise<void> {
+    this.db.prepare("UPDATE sessions SET title = ? WHERE session_id = ?").run(title, sessionId);
   }
 
   async touch(sessionId: string, updatedAt = new Date().toISOString()): Promise<void> {

--- a/server/src/sessions/routes/sessionRoutes.ts
+++ b/server/src/sessions/routes/sessionRoutes.ts
@@ -55,6 +55,9 @@ async function ensureSessionExists(runtimeManager: AgentRuntimeManager, sessionI
   }
 }
 
+// THIS IS FOR BACKWARDS COMPATIBILITY
+// Keep the existing GET /api/sessions field names and _meta envelope while
+// adding management endpoints alongside it.
 function serializeSession(record: SessionRecord, runtimeManager: AgentRuntimeManager) {
   return {
     sessionId: record.sessionId,

--- a/server/src/sessions/routes/sessionRoutes.ts
+++ b/server/src/sessions/routes/sessionRoutes.ts
@@ -1,25 +1,31 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply } from "fastify";
 import type { AgentRuntimeManager } from "../../runtime/services/AgentRuntimeManager.js";
 import type { SessionTranscriptRepository } from "../repositories/SessionTranscriptRepository.js";
+import type { SessionRecord } from "../repositories/SessionRepository.js";
 
 /** REST session listing — session discovery lives outside the ACP WebSocket. */
 export async function registerSessionRoutes(app: FastifyInstance, runtimeManager: AgentRuntimeManager, transcriptRepository: SessionTranscriptRepository): Promise<void> {
   app.get("/api/sessions", async () => {
     const records = await runtimeManager.listSessions();
-    return {
-      sessions: records.map((record) => ({
-        sessionId: record.sessionId,
-        cwd: record.cwd,
-        title: record.title,
-        updatedAt: record.updatedAt,
-        running: runtimeManager.sessionHasRuntime(record.sessionId),
-        _meta: {
-          runtimeId: record.runtimeId,
-          startedAt: record.startedAt,
-          supportsImagePrompts: runtimeManager.supportsImagePrompts(record.runtimeId),
-        },
-      })),
-    };
+    return { sessions: records.map((record) => serializeSession(record, runtimeManager)) };
+  });
+
+  app.patch<{ Params: { sessionId: string }; Body: { title?: string } }>("/api/sessions/:sessionId", async (request, reply) => {
+    if (!await ensureSessionExists(runtimeManager, request.params.sessionId, reply)) return;
+    const record = await runtimeManager.renameSession(request.params.sessionId, typeof request.body?.title === "string" ? request.body.title : "session");
+    return serializeSession(record, runtimeManager);
+  });
+
+  app.post<{ Params: { sessionId: string } }>("/api/sessions/:sessionId/touch", async (request, reply) => {
+    if (!await ensureSessionExists(runtimeManager, request.params.sessionId, reply)) return;
+    const record = await runtimeManager.touchSession(request.params.sessionId);
+    return serializeSession(record, runtimeManager);
+  });
+
+  app.delete<{ Params: { sessionId: string } }>("/api/sessions/:sessionId", async (request, reply) => {
+    if (!await ensureSessionExists(runtimeManager, request.params.sessionId, reply)) return;
+    await runtimeManager.deleteSession(request.params.sessionId);
+    return { ok: true };
   });
 
   app.get<{ Params: { sessionId: string } }>("/api/sessions/:sessionId/transcript", async (request, reply) => {
@@ -37,4 +43,29 @@ export async function registerSessionRoutes(app: FastifyInstance, runtimeManager
       events: events.map((item) => ({ sequence: item.sequence, createdAt: item.createdAt, ...item.event })),
     };
   });
+}
+
+async function ensureSessionExists(runtimeManager: AgentRuntimeManager, sessionId: string, reply: FastifyReply): Promise<boolean> {
+  try {
+    await runtimeManager.getSession(sessionId);
+    return true;
+  } catch {
+    reply.code(404).send({ error: "Unknown session" });
+    return false;
+  }
+}
+
+function serializeSession(record: SessionRecord, runtimeManager: AgentRuntimeManager) {
+  return {
+    sessionId: record.sessionId,
+    cwd: record.cwd,
+    title: record.title,
+    updatedAt: record.updatedAt,
+    running: runtimeManager.sessionHasRuntime(record.sessionId),
+    _meta: {
+      runtimeId: record.runtimeId,
+      startedAt: record.startedAt,
+      supportsImagePrompts: runtimeManager.supportsImagePrompts(record.runtimeId),
+    },
+  };
 }


### PR DESCRIPTION
## What changed

- Added server-backed session rename, delete, and explicit recent-view operations.
- Added rename/delete menus to Mac, iPhone, iPhone Simulator, and Android session lists.
- Opening or resuming a session now touches it so it moves to the top without a prompt.
- Simplified Mac session rows by keeping the ellipsis-circle menu and hiding the redundant macOS menu indicator chevron.
- Kept deletion working when an ACP runtime does not implement optional `session/close`.

## Why it matters

Session lists are useful only if users can manage them and trust the ordering. This gives users a consistent way to rename or remove old conversations across devices, while making the most recently viewed work easy to find even when no new message was sent.

## Notes for reviewers

- The existing `GET /api/sessions` response shape remains intact; management is additive.
- Delete removes the session record, transcript, workspace projection, and active runtime.
- ACP `session/close` remains attempted when available, but an unsupported runtime method no longer blocks durable deletion.
- Backward-compatibility surfaces are marked in the relevant Swift/server blocks with `THIS IS FOR BACKWARDS COMPATIBILITY`; no other changed files retain legacy shims or migration bridges.
- A live verification against an active Pi runtime returned `200` and confirmed the session disappeared from the list.
- The full Vitest invocation was blocked on this host by an esbuild `spawn Unknown system error -88`; server typecheck and native builds passed.

## Product specification alignment

**Classification:** New concept

**Related PRODUCT/ docs:**
- [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md) — documents the shared REST session-management contract and server-owned recency semantics.
- [`PRODUCT/relationship-between-sessions-and-environments.md`](PRODUCT/relationship-between-sessions-and-environments.md) — preserves the existing public-session and per-session runtime model while making session lifecycle management explicit.
- [`PRODUCT/goals-of-rook.md`](PRODUCT/goals-of-rook.md) — supports the cross-device session contract and inspectable persistence goals.

**Documentation updates in this PR:**
- [x] [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md) — adds session rename/delete/view-touch behavior to the product protocol description.
- [x] `AS-BUILT-ARCHITECTURE/` — updates datastore, server, RookKit, Mac, and iPhone architecture notes.
- [x] `server/README.md`, `clients/mac/README.md`, `clients/iphone/README.md` — documents the public API and client affordances.

**Notes:** This fills a product gap without changing the existing explicit environment-entry or per-session runtime philosophy. Pinning and arbitrary manual reordering remain intentionally deferred.

## Architecture alignment

**Classification:** Extends

**Related docs / patterns:**
- `API → Service → Repository → Data store` in [`PRODUCT/layered-architecture.md`](PRODUCT/layered-architecture.md) — routes delegate to `AgentRuntimeManager`, which coordinates repository and workspace/transcript cleanup.
- [`AS-BUILT-ARCHITECTURE/server.md`](AS-BUILT-ARCHITECTURE/server.md) — extends the REST control plane with session management while retaining SQLite-backed session records.
- [`AS-BUILT-ARCHITECTURE/database.md`](AS-BUILT-ARCHITECTURE/database.md) — uses the existing `sessions.updated_at` field for explicit view touches without adding a schema migration.
- [`AS-BUILT-ARCHITECTURE/rookkit.md`](AS-BUILT-ARCHITECTURE/rookkit.md) — exposes the shared Apple networking helpers and raw-summary-preserving updates.

**Documentation updates in this PR:**
- [x] `AS-BUILT-ARCHITECTURE/{server,database,rookkit,mac-client,iphone-client}.md` — records the new endpoints, recency behavior, and client flow.
- [x] [`PRODUCT/agent-client-protocol.md`](PRODUCT/agent-client-protocol.md) — records REST session-management semantics at the protocol boundary.

**Notes:** No new persistence layer or protocol abstraction was introduced. The runtime manager owns destructive lifecycle coordination, while repositories remain responsible for SQLite state.

## New tests

- REST integration coverage for rename, touch ordering, delete, transcript removal, and current session-list behavior.
- Regression coverage for deleting a session when the selected ACP runtime rejects `session/close` as unsupported.
- Repository coverage for title persistence, deterministic ordering, and deletion.
- RookKit model coverage for preserving unknown session-summary fields during local updates.

## Technical touchpoints

- **Components:** `AgentRuntimeManager`, `SqliteSessionRepository`, `SessionTranscriptRepository`, `CapabilityWorkspaceManager`, `RookAPI`, Mac/iPhone/Android session models and views.
- **APIs:** `PATCH /api/sessions/:sessionId`, `POST /api/sessions/:sessionId/touch`, `DELETE /api/sessions/:sessionId`, existing `GET /api/sessions`.
- **Data:** existing `sessions.title` and `sessions.updated_at`; no schema migration.
- **Runtime boundary:** active per-session ACP subprocesses are terminated directly when optional `session/close` is unavailable.

## How to check it

- [x] Rename a session from each native session list and confirm the title persists after refresh.
- [x] Delete an active and inactive session and confirm it disappears with its transcript/workspace state.
- [x] Open an older session without prompting and confirm it moves to the top of the recents list.
- [x] Confirm Mac rows show the ellipsis-circle management menu without the redundant chevron.
- [x] Run server typecheck and the Mac/iPhone native builds.