### PR TITLE
Standardize Apple client logging

### DIFF
--- a/.agents/skills/product-architecture-pr/SKILL.md
+++ b/.agents/skills/product-architecture-pr/SKILL.md
@@ -28,6 +28,8 @@ Read [`references/pr-workflow.md`](./references/pr-workflow.md) when deciding wh
 - Prefer short, casual, scannable PR prose over exhaustive writeups. Use plain language, short bullets, and only enough context for a reviewer to orient quickly.
 - Do not include an "approaches considered" section by default. Only mention alternatives when there was a real tradeoff the reviewer should understand.
 - **After creating a PR, ask the developer whether they want it merged now.** Do not assume that opening the PR implies immediate merge.
+- **Prefer a merge commit when merging a PR.** Preserve the individual branch commits unless the developer explicitly asks for squash or rebase. Do not treat squash merging as the default.
+- **Resolve PR merge conflicts proactively.** If a PR is conflicting or behind its base, fetch the base branch, merge it into the feature branch, resolve conflicts while preserving both changes, run the relevant checks, commit the merge, and push the updated branch. Do not force-push or hide conflict resolution through a squash.
 
 ## Workflow
 
@@ -134,7 +136,7 @@ If the developer said to use branch/PR flow:
 4. `gh pr create` with title and body from template
 5. Return the PR URL
 6. Ask whether they want it merged now
-7. If yes, use an allowed merge method for the repo and follow the non-destructive local-sync guidance in [`references/pr-workflow.md`](./references/pr-workflow.md)
+7. If yes, use an allowed **merge commit** method for the repo unless the developer requests rebase or squash, and follow the non-destructive local-sync guidance in [`references/pr-workflow.md`](./references/pr-workflow.md)
 
 If the developer explicitly said to push directly to `main` / `master`, you may do so.
 
@@ -159,6 +161,19 @@ This PR format still captures the useful ADR bits — context, decision, consequ
 
 - Full PR body template: [pr-template.md](pr-template.md)
 - Repo PR expectations: [AGENTS.md](../../../AGENTS.md)
+
+## PR conflict handling
+
+When `gh pr view` reports `mergeable: CONFLICTING` or the branch is behind its base:
+
+1. Fetch the base branch.
+2. Merge `origin/<base>` into the feature branch.
+3. Resolve conflicts deliberately, preserving the feature work and the base-branch work.
+4. Run the relevant tests and builds.
+5. Commit the merge resolution as a normal merge commit.
+6. Push the feature branch and verify the PR is clean and mergeable.
+
+Do not rebase or force-push merely to resolve conflicts. Mention the merge commit and validation in the PR update.
 
 ## Local main safety
 

--- a/AS-BUILT-ARCHITECTURE/iphone-client.md
+++ b/AS-BUILT-ARCHITECTURE/iphone-client.md
@@ -110,6 +110,16 @@ Same shared contract as other clients:
 2. the app starts or updates the ActivityKit activity in the foreground
 3. tapping `rook://open` returns the user to chat
 
+## Client logging
+
+The iPhone app and shared `RookKit` networking/session layer use the centralized
+`RookLog` Unified Logging subsystem `com.rookery.Rook`. The app logs health and
+session lifecycle, while the location provider logs authorization, monitored
+regions, visit arrivals, and dwell-gate decisions. Shared REST, WebSocket,
+reconnect, transcript hydration, prompt, and run lifecycle operations include
+structured timing logs and signposts. Prompt contents, tokens, and image data
+are not logged.
+
 ## Notable architectural characteristics
 
 - the iPhone app reuses the Mac chat/network stack but replaces foreground-app context with physical-place context

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -156,7 +156,11 @@ Apple-client logging is centralized in `RookKit/Logging/RookLog.swift` and uses
 Unified Logging with subsystem `com.rookery.Rook`. The Mac app uses categories
 for app, session, network, environment, bridge, server, and performance work.
 `RookPerformance` records elapsed milliseconds and emits `OSSignposter` intervals;
-100 ms is the slow-operation threshold and 500 ms is the hang-warning threshold.
+fast successful operations are debug-level, 100 ms is the slow-operation threshold,
+and 500 ms is the hang-warning threshold. `ROOK_VERBOSE_LOGGING=1` enables
+additional polling and raw foreground-context details for a short diagnostic run;
+otherwise window titles, document paths, and URLs are summarized rather than
+logged.
 
 The Mac instruments the beachball-adjacent paths: Accessibility title/document,
 web-tree, text, and actionable-element reads; Finder AppleScript observation;

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -150,6 +150,23 @@ Via `RookKit`:
 ### Worktree development profile
 When launched from a Git worktree through `scripts/run-rook.sh`, the Mac app is built with a distinct development bundle identity and display name. It connects to the worktree's deterministic development port and can run beside the production-like app from the main checkout without sharing app preferences or server state.
 
+## Client logging and hang diagnostics
+
+Apple-client logging is centralized in `RookKit/Logging/RookLog.swift` and uses
+Unified Logging with subsystem `com.rookery.Rook`. The Mac app uses categories
+for app, session, network, environment, bridge, server, and performance work.
+`RookPerformance` records elapsed milliseconds and emits `OSSignposter` intervals;
+100 ms is the slow-operation threshold and 500 ms is the hang-warning threshold.
+
+The Mac instruments the beachball-adjacent paths: Accessibility title/document,
+web-tree, text, and actionable-element reads; Finder AppleScript observation;
+foreground/provider polling and registration; bridge routes; server supervision;
+REST health/session/environment calls; WebSocket initialization/reconnect; and
+session transcript hydration and prompt lifecycle. The in-app Rook Log viewer
+shows recent unified logs for `com.rookery.Rook`, tails them live, and includes
+the managed server log as context. Unified Logging is authoritative for client
+diagnostics.
+
 ## Notable architectural characteristics
 
 - the mac app is both a client and an environment provider

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -118,7 +118,8 @@
 
 `Logging/RookLog.swift` provides the shared `com.rookery.Rook` Unified Logging
 subsystem, stable categories, `OSSignposter` intervals, and reusable timed
-operations. `RookAPI`, `AcpSocket`, and `SessionHandle` use it to record REST
+operations. Fast successful timings are debug-level; slow and failed operations
+remain warning/error-level. `RookAPI`, `AcpSocket`, and `SessionHandle` use it to record REST
 request status/latency, WebSocket lifecycle, session creation/loading,
 transcript attachment, reconnect attempts, queued delivery, and run outcomes.
 The Mac and iPhone app-specific models add their platform-specific lifecycle,

--- a/AS-BUILT-ARCHITECTURE/rookkit.md
+++ b/AS-BUILT-ARCHITECTURE/rookkit.md
@@ -114,6 +114,16 @@
 4. `EnvironmentListPresentation` applies shared list-refresh behavior for environment metadata
 5. image prompts use standard ACP image blocks in composer order; Mac paste/drop staging never becomes part of the runtime working-directory contract
 
+## Logging and performance instrumentation
+
+`Logging/RookLog.swift` provides the shared `com.rookery.Rook` Unified Logging
+subsystem, stable categories, `OSSignposter` intervals, and reusable timed
+operations. `RookAPI`, `AcpSocket`, and `SessionHandle` use it to record REST
+request status/latency, WebSocket lifecycle, session creation/loading,
+transcript attachment, reconnect attempts, queued delivery, and run outcomes.
+The Mac and iPhone app-specific models add their platform-specific lifecycle,
+environment, location, voice, bridge, and server-supervision events on top.
+
 ## Notable architectural characteristics
 
 - RookKit is not a full app framework; it is the shared protocol + UI substrate

--- a/CHANGES/2026-08-10-apple-client-logging/TODO.md
+++ b/CHANGES/2026-08-10-apple-client-logging/TODO.md
@@ -1,0 +1,58 @@
+# Apple client logging overhaul
+
+## Context
+
+We need better logging in the Apple clients before we try to diagnose the recurring macOS beachballing. Today the mac app mixes ad-hoc `/tmp/rook.log` file appends with a small amount of `Logger` usage, and the iPhone client has almost no structured operational logging. This work standardizes client-side logging for the mac and iPhone apps, adds high-value timing/performance instrumentation around likely UI-blocking paths, and updates the client docs so we can reliably capture evidence from future hangs. The server is explicitly out of scope for this change.
+
+## Details
+
+The main affected surfaces are `clients/mac/`, `clients/iphone/`, and shared Apple-client code in `clients/RookKit/`.
+
+Current behavior and constraints:
+
+- mac foreground/environment tracing currently writes directly to `/tmp/rook.log` via `providerLog(...)`
+- some mac chat/session code already uses `Logger`, but categories are inconsistent and logging coverage is thin
+- the iPhone app shares `RookKit` networking/session code with the mac app, so a shared logging layer there gives us better coverage on both clients without duplicating code
+- the likely beachball-adjacent paths are synchronous main-actor work such as Accessibility reads, Finder AppleScript observation, foreground polling, transcript/session hydration, and connection / environment refresh orchestration
+- we want standard Apple unified logging, but the mac app still needs an inspectable log viewer story after the `/tmp/rook.log` path stops being authoritative
+- avoid changing server logging as part of this pass
+
+Important files/modules inspected up front:
+
+- `clients/mac/Sources/Services/ForegroundAppMonitor.swift`
+- `clients/mac/Sources/Services/AXReader.swift`
+- `clients/mac/Sources/Services/MacBridge.swift`
+- `clients/mac/Sources/Services/ServerController.swift`
+- `clients/mac/Sources/Models/RookMacModel.swift`
+- `clients/mac/Sources/Models/RookMacChatSessionController.swift`
+- `clients/mac/Sources/Models/RookMacSupport.swift`
+- `clients/mac/Sources/Models/EnvironmentProviders/*`
+- `clients/iphone/Sources/RookModel.swift`
+- `clients/iphone/Sources/Location/LocationProvider.swift`
+- `clients/RookKit/Sources/RookKit/Net/AcpSocket.swift`
+- `clients/RookKit/Sources/RookKit/Net/SessionHandle.swift`
+- `clients/RookKit/Sources/RookKit/Net/RookAPI.swift`
+
+## Steps
+
+- [ ] Add a shared Apple-client logging utility in `clients/RookKit/` that standardizes subsystem/category names and provides reusable performance/timing helpers for both apps.
+- [ ] Replace mac-only ad-hoc provider file logging with standard unified logging, and update the mac log-viewing path so it can still inspect the relevant logs after the change.
+- [ ] Instrument mac environment/provider code with structured logs and timing around foreground activation, AX reads, Finder observation, environment registration, bridge activity, and managed-server lifecycle events.
+- [ ] Instrument shared session/network code in `RookKit` with structured logs around REST requests, WebSocket connect/disconnect, session load/hydration, reconnects, queued prompts, and run lifecycle transitions.
+- [ ] Instrument the iPhone client and location provider with structured logs around health refresh, session resume/start, place monitoring, visit arrivals, environment identification, and voice/location state changes where useful.
+- [ ] Add or update focused tests for any new shared logging/performance helpers and keep existing Apple-client tests/builds passing.
+- [ ] Update Apple-client docs (`clients/mac/README.md`, `clients/iphone/README.md`, and any other touched README/docs) to describe the logging approach and how to capture logs for hang investigation.
+- [ ] Review the final diff for leftover backward-compatibility code, compatibility documentation, fallback paths, temporary shims, abandoned experiments, and other no-longer-needed transitional code.
+- [ ] Remove all unnecessary backward-compatibility code and compatibility documentation rather than keeping it around.
+- [ ] Update `AS-BUILT-ARCHITECTURE/` as needed.
+- [ ] Update `PRODUCT/` as needed.
+- [ ] Run the appropriate Apple-client tests/builds and confirm they pass.
+
+## Exit criteria
+
+- [ ] The mac and iPhone clients use one coherent unified-logging approach instead of mixing ad-hoc logging styles.
+- [ ] High-value beachball-adjacent paths in the mac client emit structured timing/performance logs that are practical to inspect after a hang.
+- [ ] Shared `RookKit` session/network code emits enough logs to reconstruct connection, session, and prompt lifecycle behavior on both Apple clients.
+- [ ] The mac log-viewing/documentation story reflects the new authoritative logging path.
+- [ ] Tests/builds relevant to the Apple-client changes pass.
+- [ ] Architecture/docs reflect the final logging design, and no unnecessary compatibility shims remain.

--- a/CHANGES/2026-08-10-apple-client-logging/TODO.md
+++ b/CHANGES/2026-08-10-apple-client-logging/TODO.md
@@ -42,6 +42,7 @@ Important files/modules inspected up front:
 - [x] Instrument the iPhone client and location provider with structured logs around health refresh, session resume/start, place monitoring, visit arrivals, environment identification, and voice/location state changes where useful.
 - [x] Add or update focused tests for any new shared logging/performance helpers and keep existing Apple-client tests/builds passing.
 - [x] Update Apple-client docs (`clients/mac/README.md`, `clients/iphone/README.md`, and any other touched README/docs) to describe the logging approach and how to capture logs for hang investigation.
+- [x] Reduce default log noise by moving fast timing/polling details to debug level and gate raw foreground context behind `ROOK_VERBOSE_LOGGING=1`.
 - [x] Review the final diff for leftover backward-compatibility code, compatibility documentation, fallback paths, temporary shims, abandoned experiments, and other no-longer-needed transitional code.
 - [x] Remove all unnecessary backward-compatibility code and compatibility documentation rather than keeping it around.
 - [x] Update `AS-BUILT-ARCHITECTURE/` as needed.

--- a/CHANGES/2026-08-10-apple-client-logging/TODO.md
+++ b/CHANGES/2026-08-10-apple-client-logging/TODO.md
@@ -35,24 +35,24 @@ Important files/modules inspected up front:
 
 ## Steps
 
-- [ ] Add a shared Apple-client logging utility in `clients/RookKit/` that standardizes subsystem/category names and provides reusable performance/timing helpers for both apps.
-- [ ] Replace mac-only ad-hoc provider file logging with standard unified logging, and update the mac log-viewing path so it can still inspect the relevant logs after the change.
-- [ ] Instrument mac environment/provider code with structured logs and timing around foreground activation, AX reads, Finder observation, environment registration, bridge activity, and managed-server lifecycle events.
-- [ ] Instrument shared session/network code in `RookKit` with structured logs around REST requests, WebSocket connect/disconnect, session load/hydration, reconnects, queued prompts, and run lifecycle transitions.
-- [ ] Instrument the iPhone client and location provider with structured logs around health refresh, session resume/start, place monitoring, visit arrivals, environment identification, and voice/location state changes where useful.
-- [ ] Add or update focused tests for any new shared logging/performance helpers and keep existing Apple-client tests/builds passing.
-- [ ] Update Apple-client docs (`clients/mac/README.md`, `clients/iphone/README.md`, and any other touched README/docs) to describe the logging approach and how to capture logs for hang investigation.
-- [ ] Review the final diff for leftover backward-compatibility code, compatibility documentation, fallback paths, temporary shims, abandoned experiments, and other no-longer-needed transitional code.
-- [ ] Remove all unnecessary backward-compatibility code and compatibility documentation rather than keeping it around.
-- [ ] Update `AS-BUILT-ARCHITECTURE/` as needed.
-- [ ] Update `PRODUCT/` as needed.
-- [ ] Run the appropriate Apple-client tests/builds and confirm they pass.
+- [x] Add a shared Apple-client logging utility in `clients/RookKit/` that standardizes subsystem/category names and provides reusable performance/timing helpers for both apps.
+- [x] Replace mac-only ad-hoc provider file logging with standard unified logging, and update the mac log-viewing path so it can still inspect the relevant logs after the change.
+- [x] Instrument mac environment/provider code with structured logs and timing around foreground activation, AX reads, Finder observation, environment registration, bridge activity, and managed-server lifecycle events.
+- [x] Instrument shared session/network code in `RookKit` with structured logs around REST requests, WebSocket connect/disconnect, session load/hydration, reconnects, queued prompts, and run lifecycle transitions.
+- [x] Instrument the iPhone client and location provider with structured logs around health refresh, session resume/start, place monitoring, visit arrivals, environment identification, and voice/location state changes where useful.
+- [x] Add or update focused tests for any new shared logging/performance helpers and keep existing Apple-client tests/builds passing.
+- [x] Update Apple-client docs (`clients/mac/README.md`, `clients/iphone/README.md`, and any other touched README/docs) to describe the logging approach and how to capture logs for hang investigation.
+- [x] Review the final diff for leftover backward-compatibility code, compatibility documentation, fallback paths, temporary shims, abandoned experiments, and other no-longer-needed transitional code.
+- [x] Remove all unnecessary backward-compatibility code and compatibility documentation rather than keeping it around.
+- [x] Update `AS-BUILT-ARCHITECTURE/` as needed.
+- [x] Update `PRODUCT/` as needed.
+- [x] Run the appropriate Apple-client tests/builds and confirm they pass; the iPhone app build passes, while the existing `ArrivalGateTests` target contains unrelated stale `RookModel` test references and does not compile on the starting revision.
 
 ## Exit criteria
 
-- [ ] The mac and iPhone clients use one coherent unified-logging approach instead of mixing ad-hoc logging styles.
-- [ ] High-value beachball-adjacent paths in the mac client emit structured timing/performance logs that are practical to inspect after a hang.
-- [ ] Shared `RookKit` session/network code emits enough logs to reconstruct connection, session, and prompt lifecycle behavior on both Apple clients.
-- [ ] The mac log-viewing/documentation story reflects the new authoritative logging path.
-- [ ] Tests/builds relevant to the Apple-client changes pass.
-- [ ] Architecture/docs reflect the final logging design, and no unnecessary compatibility shims remain.
+- [x] The mac and iPhone clients use one coherent unified-logging approach instead of mixing ad-hoc logging styles.
+- [x] High-value beachball-adjacent paths in the mac client emit structured timing/performance logs that are practical to inspect after a hang.
+- [x] Shared `RookKit` session/network code emits enough logs to reconstruct connection, session, and prompt lifecycle behavior on both Apple clients.
+- [x] The mac log-viewing/documentation story reflects the new authoritative logging path.
+- [x] Tests/builds relevant to the Apple-client changes pass, with the pre-existing stale iPhone test-target issue recorded above.
+- [x] Architecture/docs reflect the final logging design, and no unnecessary compatibility shims remain.

--- a/clients/RookKit/Sources/RookKit/Logging/RookLog.swift
+++ b/clients/RookKit/Sources/RookKit/Logging/RookLog.swift
@@ -1,0 +1,249 @@
+import Foundation
+import OSLog
+
+public enum RookLogCategory: String {
+    case app
+    case ui
+    case session
+    case network
+    case environment
+    case location
+    case voice
+    case bridge
+    case server
+    case performance
+}
+
+public enum RookLog {
+    public static let subsystem = "com.rookery.Rook"
+
+    public static let app = logger(.app)
+    public static let ui = logger(.ui)
+    public static let session = logger(.session)
+    public static let network = logger(.network)
+    public static let environment = logger(.environment)
+    public static let location = logger(.location)
+    public static let voice = logger(.voice)
+    public static let bridge = logger(.bridge)
+    public static let server = logger(.server)
+    public static let performance = logger(.performance)
+
+    public static let appSignposter = signposter(.app)
+    public static let uiSignposter = signposter(.ui)
+    public static let sessionSignposter = signposter(.session)
+    public static let networkSignposter = signposter(.network)
+    public static let environmentSignposter = signposter(.environment)
+    public static let locationSignposter = signposter(.location)
+    public static let voiceSignposter = signposter(.voice)
+    public static let bridgeSignposter = signposter(.bridge)
+    public static let serverSignposter = signposter(.server)
+    public static let performanceSignposter = signposter(.performance)
+
+    public static func logger(_ category: RookLogCategory) -> Logger {
+        Logger(subsystem: subsystem, category: category.rawValue)
+    }
+
+    public static func signposter(_ category: RookLogCategory) -> OSSignposter {
+        OSSignposter(logger: logger(category))
+    }
+}
+
+public enum RookPerformanceSeverity: String {
+    case info
+    case warning
+    case error
+}
+
+public final class RookTimedOperation {
+    private let logger: Logger
+    private let signposter: OSSignposter?
+    private let signpostName: StaticString
+    private let intervalState: OSSignpostIntervalState?
+    private let operation: String
+    private let description: String
+    private let startedAtNs: UInt64
+    private let slowThresholdMs: Double
+    private let hangThresholdMs: Double
+    private var finished = false
+
+    fileprivate init(
+        signpostName: StaticString,
+        operation: String,
+        description: String,
+        logger: Logger,
+        signposter: OSSignposter?,
+        slowThresholdMs: Double,
+        hangThresholdMs: Double
+    ) {
+        self.logger = logger
+        self.signposter = signposter
+        self.signpostName = signpostName
+        self.operation = operation
+        self.description = description
+        self.startedAtNs = DispatchTime.now().uptimeNanoseconds
+        self.slowThresholdMs = slowThresholdMs
+        self.hangThresholdMs = hangThresholdMs
+        if let signposter {
+            self.intervalState = signposter.beginInterval(signpostName, "\(description, privacy: .public)")
+        } else {
+            self.intervalState = nil
+        }
+    }
+
+    public func finish(details: String = "") {
+        complete(error: nil, details: details)
+    }
+
+    public func fail(_ error: Error, details: String = "") {
+        complete(error: error, details: details)
+    }
+
+    private func complete(error: Error?, details: String) {
+        guard !finished else { return }
+        finished = true
+
+        let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - startedAtNs) / 1_000_000
+        let severity = RookPerformance.severity(
+            forElapsedMs: elapsedMs,
+            slowThresholdMs: slowThresholdMs,
+            hangThresholdMs: hangThresholdMs
+        )
+        let prefix = "operation=\(self.operation) elapsedMs=\(RookPerformance.format(elapsedMs))"
+        let suffix = [description, details, error?.localizedDescription]
+            .map { $0?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "" }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        let message = suffix.isEmpty ? prefix : "\(prefix) \(suffix)"
+
+        if let signposter, let intervalState {
+            if let error {
+                signposter.endInterval(signpostName, intervalState, "\(message, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+            } else {
+                signposter.endInterval(signpostName, intervalState, "\(message, privacy: .public)")
+            }
+        }
+
+        switch (severity, error) {
+        case (_, let error?) where severity == .error:
+            logger.error("\(message, privacy: .public)")
+            logger.error("operation=\(self.operation, privacy: .public) failed error=\(error.localizedDescription, privacy: .public)")
+        case (_, let error?) where severity == .warning:
+            logger.warning("\(message, privacy: .public)")
+            logger.warning("operation=\(self.operation, privacy: .public) failed error=\(error.localizedDescription, privacy: .public)")
+        case (_, let error?):
+            logger.info("\(message, privacy: .public)")
+            logger.error("operation=\(self.operation, privacy: .public) failed error=\(error.localizedDescription, privacy: .public)")
+        case (.error, nil):
+            logger.error("\(message, privacy: .public)")
+        case (.warning, nil):
+            logger.warning("\(message, privacy: .public)")
+        case (.info, nil):
+            logger.info("\(message, privacy: .public)")
+        }
+    }
+}
+
+public enum RookPerformance {
+    public static let slowThresholdMs = 100.0
+    public static let hangThresholdMs = 500.0
+
+    public static func severity(
+        forElapsedMs elapsedMs: Double,
+        slowThresholdMs: Double = slowThresholdMs,
+        hangThresholdMs: Double = hangThresholdMs
+    ) -> RookPerformanceSeverity {
+        if elapsedMs >= hangThresholdMs {
+            return .error
+        }
+        if elapsedMs >= slowThresholdMs {
+            return .warning
+        }
+        return .info
+    }
+
+    public static func begin(
+        _ signpostName: StaticString,
+        operation: String,
+        description: String = "",
+        logger: Logger = RookLog.performance,
+        signposter: OSSignposter? = RookLog.performanceSignposter,
+        slowThresholdMs: Double = slowThresholdMs,
+        hangThresholdMs: Double = hangThresholdMs
+    ) -> RookTimedOperation {
+        RookTimedOperation(
+            signpostName: signpostName,
+            operation: operation,
+            description: description,
+            logger: logger,
+            signposter: signposter,
+            slowThresholdMs: slowThresholdMs,
+            hangThresholdMs: hangThresholdMs
+        )
+    }
+
+    @discardableResult
+    public static func measure<T>(
+        _ signpostName: StaticString,
+        operation: String,
+        description: String = "",
+        logger: Logger = RookLog.performance,
+        signposter: OSSignposter? = RookLog.performanceSignposter,
+        slowThresholdMs: Double = slowThresholdMs,
+        hangThresholdMs: Double = hangThresholdMs,
+        details: (T) -> String = { _ in "" },
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let timed = begin(
+            signpostName,
+            operation: operation,
+            description: description,
+            logger: logger,
+            signposter: signposter,
+            slowThresholdMs: slowThresholdMs,
+            hangThresholdMs: hangThresholdMs
+        )
+        do {
+            let value = try body()
+            timed.finish(details: details(value))
+            return value
+        } catch {
+            timed.fail(error)
+            throw error
+        }
+    }
+
+    @discardableResult
+    public static func measureAsync<T>(
+        _ signpostName: StaticString,
+        operation: String,
+        description: String = "",
+        logger: Logger = RookLog.performance,
+        signposter: OSSignposter? = RookLog.performanceSignposter,
+        slowThresholdMs: Double = slowThresholdMs,
+        hangThresholdMs: Double = hangThresholdMs,
+        details: (T) -> String = { _ in "" },
+        _ body: () async throws -> T
+    ) async rethrows -> T {
+        let timed = begin(
+            signpostName,
+            operation: operation,
+            description: description,
+            logger: logger,
+            signposter: signposter,
+            slowThresholdMs: slowThresholdMs,
+            hangThresholdMs: hangThresholdMs
+        )
+        do {
+            let value = try await body()
+            timed.finish(details: details(value))
+            return value
+        } catch {
+            timed.fail(error)
+            throw error
+        }
+    }
+
+    fileprivate static func format(_ elapsedMs: Double) -> String {
+        String(format: "%.2f", elapsedMs)
+    }
+}

--- a/clients/RookKit/Sources/RookKit/Logging/RookLog.swift
+++ b/clients/RookKit/Sources/RookKit/Logging/RookLog.swift
@@ -16,6 +16,7 @@ public enum RookLogCategory: String {
 
 public enum RookLog {
     public static let subsystem = "com.rookery.Rook"
+    public static let verboseEnabled = ProcessInfo.processInfo.environment["ROOK_VERBOSE_LOGGING"] == "1"
 
     public static let app = logger(.app)
     public static let ui = logger(.ui)
@@ -131,14 +132,14 @@ public final class RookTimedOperation {
             logger.warning("\(message, privacy: .public)")
             logger.warning("operation=\(self.operation, privacy: .public) failed error=\(error.localizedDescription, privacy: .public)")
         case (_, let error?):
-            logger.info("\(message, privacy: .public)")
+            logger.error("\(message, privacy: .public)")
             logger.error("operation=\(self.operation, privacy: .public) failed error=\(error.localizedDescription, privacy: .public)")
         case (.error, nil):
             logger.error("\(message, privacy: .public)")
         case (.warning, nil):
             logger.warning("\(message, privacy: .public)")
         case (.info, nil):
-            logger.info("\(message, privacy: .public)")
+            logger.debug("\(message, privacy: .public)")
         }
     }
 }

--- a/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
+++ b/clients/RookKit/Sources/RookKit/Net/AcpSocket.swift
@@ -4,6 +4,8 @@ import Foundation
 /// One logical connection can list, create, load, and prompt many sessions.
 @MainActor
 public final class AcpSocket {
+    private static let logger = RookLog.session
+
     public var onEvent: ((AcpClientEvent) -> Void)?
     public var onConnectionChange: ((Bool) -> Void)?
 
@@ -27,11 +29,14 @@ public final class AcpSocket {
 
     public func connect(request socketRequest: URLRequest) async throws -> [String: Any] {
         if let connectTask {
+            Self.logger.info("websocket connect reused pending task url=\(socketRequest.url?.absoluteString ?? "(unknown)", privacy: .public)")
             return try await connectTask.value
         }
         if task != nil {
+            Self.logger.info("websocket connect skipped existing socket url=\(socketRequest.url?.absoluteString ?? "(unknown)", privacy: .public)")
             return [:]
         }
+        Self.logger.info("websocket connect start url=\(socketRequest.url?.absoluteString ?? "(unknown)", privacy: .public)")
         let task = Task<[String: Any], Error> { @MainActor in
             let initialized = try await openAndInitialize(socketRequest: socketRequest)
             self.connectTask = nil
@@ -42,6 +47,7 @@ public final class AcpSocket {
     }
 
     public func disconnect() {
+        Self.logger.info("websocket disconnect session=\(self.currentSessionId ?? "(none)", privacy: .public) pending=\(self.pending.count, privacy: .public)")
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
         connectTask = nil
@@ -69,26 +75,52 @@ public final class AcpSocket {
     }
 
     public func createSession(runtimeId: String, title: String, cwd: String) async throws -> String {
-        let result = try await request(method: "session/new", params: [
-            "cwd": cwd,
-            "mcpServers": [],
-            "_meta": [
-                "runtimeId": runtimeId,
-                "title": title,
-            ],
-        ])
-        guard let sessionId = result["sessionId"] as? String else {
-            throw SocketError.server("Server returned no sessionId")
+        let timed = RookPerformance.begin(
+            "CreateSession",
+            operation: "acp-session-new",
+            description: "runtime=\(runtimeId) title=\(title)",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter
+        )
+        do {
+            let result = try await request(method: "session/new", params: [
+                "cwd": cwd,
+                "mcpServers": [],
+                "_meta": [
+                    "runtimeId": runtimeId,
+                    "title": title,
+                ],
+            ])
+            guard let sessionId = result["sessionId"] as? String else {
+                throw SocketError.server("Server returned no sessionId")
+            }
+            supportsImagePrompts = imagePromptCapability(from: result)
+            currentSessionId = sessionId
+            timed.finish(details: "session=\(sessionId) supportsImagePrompts=\(supportsImagePrompts)")
+            return sessionId
+        } catch {
+            timed.fail(error)
+            throw error
         }
-        supportsImagePrompts = imagePromptCapability(from: result)
-        currentSessionId = sessionId
-        return sessionId
     }
 
     public func loadSession(_ sessionId: String) async throws {
-        let result = try await request(method: "session/load", params: ["sessionId": sessionId])
-        supportsImagePrompts = imagePromptCapability(from: result)
-        currentSessionId = sessionId
+        let timed = RookPerformance.begin(
+            "LoadSession",
+            operation: "acp-session-load",
+            description: "session=\(sessionId)",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter
+        )
+        do {
+            let result = try await request(method: "session/load", params: ["sessionId": sessionId])
+            supportsImagePrompts = imagePromptCapability(from: result)
+            currentSessionId = sessionId
+            timed.finish(details: "session=\(sessionId) supportsImagePrompts=\(supportsImagePrompts)")
+        } catch {
+            timed.fail(error)
+            throw error
+        }
     }
 
     public func sendCancel() {
@@ -100,6 +132,7 @@ public final class AcpSocket {
 
     public func sendPrompt(content: [ChatPromptContent]) {
         guard let sessionId = currentSessionId else {
+            Self.logger.error("prompt send rejected no current session")
             onEvent?(.connectionError(message: "Not connected to a session"))
             return
         }
@@ -109,6 +142,7 @@ public final class AcpSocket {
         pendingPromptIds.insert(requestId)
         let text = content.textValue.trimmingCharacters(in: .whitespacesAndNewlines)
         if !text.isEmpty { pendingUserMessageEchoes.append(text) }
+        Self.logger.info("prompt send session=\(sessionId, privacy: .public) textChars=\(text.count, privacy: .public) images=\(content.images.count, privacy: .public)")
         let prompt: [[String: Any]] = content.compactMap { item in
             switch item {
             case .text(let value):
@@ -197,33 +231,48 @@ public final class AcpSocket {
 
     private func openAndInitialize(socketRequest: URLRequest) async throws -> [String: Any] {
         disconnect()
-        let task = URLSession.shared.webSocketTask(with: socketRequest)
-        self.task = task
-        task.resume()
-        receiveLoop(task)
-        let initialize = try await request(method: "initialize", params: [
-            "protocolVersion": 1,
-            "clientCapabilities": [
-                "_meta": [
-                    "com.rookkeeper": [
-                        "environmentOffers": true,
+        let timed = RookPerformance.begin(
+            "WebSocketInitialize",
+            operation: "acp-connect-initialize",
+            description: socketRequest.url?.absoluteString ?? "(unknown)",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter,
+            slowThresholdMs: 250,
+            hangThresholdMs: 1_000
+        )
+        do {
+            let task = URLSession.shared.webSocketTask(with: socketRequest)
+            self.task = task
+            task.resume()
+            receiveLoop(task)
+            let initialize = try await request(method: "initialize", params: [
+                "protocolVersion": 1,
+                "clientCapabilities": [
+                    "_meta": [
+                        "com.rookkeeper": [
+                            "environmentOffers": true,
+                        ],
                     ],
                 ],
-            ],
-            "clientInfo": ["name": "rook", "title": "Rook", "version": "0.1.0"],
-        ])
-        let meta = initialize["_meta"] as? [String: Any]
-        if let agentCapabilities = initialize["agentCapabilities"] as? [String: Any],
-           let promptCapabilities = agentCapabilities["promptCapabilities"] as? [String: Any] {
-            supportsImagePrompts = promptCapabilities["image"] as? Bool ?? false
+                "clientInfo": ["name": "rook", "title": "Rook", "version": "0.1.0"],
+            ])
+            let meta = initialize["_meta"] as? [String: Any]
+            if let agentCapabilities = initialize["agentCapabilities"] as? [String: Any],
+               let promptCapabilities = agentCapabilities["promptCapabilities"] as? [String: Any] {
+                supportsImagePrompts = promptCapabilities["image"] as? Bool ?? false
+            }
+            runtimeIDs = (meta?["runtimeIds"] as? [String]) ?? []
+            defaultRuntimeID = meta?["defaultRuntimeId"] as? String
+            if let ext = meta?["com.rookkeeper"] as? [String: Any], ext["environmentOffers"] != nil {
+                environmentOfferExtensionEnabled = true
+            }
+            setConnected(true)
+            timed.finish(details: "runtimes=\(runtimeIDs.count) defaultRuntime=\(defaultRuntimeID ?? "(none)") supportsImagePrompts=\(supportsImagePrompts)")
+            return initialize
+        } catch {
+            timed.fail(error)
+            throw error
         }
-        runtimeIDs = (meta?["runtimeIds"] as? [String]) ?? []
-        defaultRuntimeID = meta?["defaultRuntimeId"] as? String
-        if let ext = meta?["com.rookkeeper"] as? [String: Any], ext["environmentOffers"] != nil {
-            environmentOfferExtensionEnabled = true
-        }
-        setConnected(true)
-        return initialize
     }
 
     private func receiveLoop(_ task: URLSessionWebSocketTask) {
@@ -249,6 +298,7 @@ public final class AcpSocket {
 
     private func handleDisconnect(task disconnectedTask: URLSessionWebSocketTask, error: Error) {
         guard task === disconnectedTask else { return }
+        Self.logger.warning("websocket disconnected session=\(self.currentSessionId ?? "(none)", privacy: .public) error=\(error.localizedDescription, privacy: .public)")
         task = nil
         connectTask = nil
         setConnected(false)
@@ -398,10 +448,11 @@ public final class AcpSocket {
     private func setConnected(_ connected: Bool) {
         guard isConnected != connected else { return }
         isConnected = connected
+        Self.logger.info("websocket connection state connected=\(connected, privacy: .public) session=\(self.currentSessionId ?? "(none)", privacy: .public)")
         onConnectionChange?(connected)
     }
 
-    private func sendFrame(_ frame: [String: Any], over task: URLSessionWebSocketTask, completion: @escaping (Error?) -> Void = { _ in }) {
+    private func sendFrame(_ frame: [String: Any], over task: URLSessionWebSocketTask, completion: @Sendable @escaping (Error?) -> Void = { _ in }) {
         guard let data = try? JSONSerialization.data(withJSONObject: frame),
               let json = String(data: data, encoding: .utf8) else {
             completion(SocketError.encoding)

--- a/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
+++ b/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
@@ -19,6 +19,8 @@ public enum RookHealthResult: Equatable {
 
 /// REST control plane for the Rook server.
 public struct RookAPI {
+    private static let logger = RookLog.network
+
     public let baseURL: URL
     public let authToken: String?
 
@@ -51,23 +53,36 @@ public struct RookAPI {
     public func healthResult(timeout: TimeInterval = 1.5) async -> RookHealthResult {
         var request = authorizedRequest(url: baseURL.appending(path: "api/health"))
         request.timeoutInterval = timeout
+        let timed = RookPerformance.begin(
+            "HealthCheck",
+            operation: "http-health",
+            description: "GET /api/health timeout=\(timeout)",
+            logger: Self.logger,
+            signposter: RookLog.networkSignposter
+        )
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
             guard let http = response as? HTTPURLResponse else {
+                timed.finish(details: "non-http-response")
                 return .transportError("Non-HTTP response")
             }
             switch http.statusCode {
             case 200:
                 if let body = try? JSONDecoder().decode(JSONValue.self, from: data), body["ok"]?.boolValue == true {
+                    timed.finish(details: "status=200 bytes=\(data.count)")
                     return .ok
                 }
+                timed.finish(details: "status=200 malformed-body bytes=\(data.count)")
                 return .transportError("Malformed health response")
             case 401:
+                timed.finish(details: "status=401")
                 return .unauthorized
             default:
+                timed.finish(details: "status=\(http.statusCode)")
                 return .httpStatus(http.statusCode)
             }
         } catch {
+            timed.fail(error)
             return .transportError(error.localizedDescription)
         }
     }
@@ -149,7 +164,7 @@ public struct RookAPI {
         urlRequest.httpMethod = "POST"
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.httpBody = try JSONEncoder().encode(request)
-        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        let (data, response) = try await performData(for: urlRequest)
         try throwIfErrorResponse(data: data, response: response)
         return try JSONDecoder().decode(IdentifyResponse.self, from: data).candidates
     }
@@ -208,7 +223,7 @@ public struct RookAPI {
     }
 
     private func get<T: Decodable>(path: String, query: [String: String]) async throws -> T {
-        let (data, response) = try await URLSession.shared.data(for: authorizedRequest(url: requestURL(path: path, query: query)))
+        let (data, response) = try await performData(for: authorizedRequest(url: requestURL(path: path, query: query)))
         try throwIfErrorResponse(data: data, response: response)
         return try JSONDecoder().decode(T.self, from: data)
     }
@@ -218,7 +233,7 @@ public struct RookAPI {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(payload)
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await performData(for: request)
         try throwIfErrorResponse(data: data, response: response)
         return try JSONDecoder().decode(T.self, from: data)
     }
@@ -232,7 +247,7 @@ public struct RookAPI {
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONEncoder().encode(payload)
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await performData(for: request)
         try throwIfErrorResponse(data: data, response: response)
         return try JSONDecoder().decode(JSONValue.self, from: data)
     }
@@ -243,6 +258,30 @@ public struct RookAPI {
             request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
         }
         return request
+    }
+
+    private func performData(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let method = request.httpMethod ?? "GET"
+        let path = request.url?.path(percentEncoded: false) ?? request.url?.path ?? "(unknown)"
+        let timed = RookPerformance.begin(
+            "HTTPRequest",
+            operation: "http-request",
+            description: "\(method) \(path)",
+            logger: Self.logger,
+            signposter: RookLog.networkSignposter
+        )
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse {
+                timed.finish(details: "status=\(http.statusCode) bytes=\(data.count)")
+            } else {
+                timed.finish(details: "non-http-response bytes=\(data.count)")
+            }
+            return (data, response)
+        } catch {
+            timed.fail(error, details: "\(method) \(path)")
+            throw error
+        }
     }
 
     private func throwIfErrorResponse(data: Data, response: URLResponse) throws {

--- a/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
+++ b/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
@@ -5,6 +5,8 @@ import Foundation
 /// which handle the UI observes.
 @MainActor
 public final class SessionHandle {
+    private static let logger = RookLog.session
+
     public let sessionId: String
 
     public var onStateChange: (() -> Void)?
@@ -75,46 +77,93 @@ public final class SessionHandle {
     // MARK: - Lifecycle
 
     public func connectAndLoad(title: String, cwd: String) async throws {
-        try await ensureSocketConnected()
-        _ = try await socket.createSession(runtimeId: "", title: title, cwd: cwd)
-        isLoaded = true
+        let timed = RookPerformance.begin(
+            "ConnectAndLoadSessionHandle",
+            operation: "session-handle-connect-and-load",
+            description: "session=\(self.sessionId) title=\(title)",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter
+        )
+        do {
+            try await ensureSocketConnected()
+            _ = try await socket.createSession(runtimeId: "", title: title, cwd: cwd)
+            isLoaded = true
+            timed.finish(details: "session=\(self.sessionId)")
+        } catch {
+            timed.fail(error)
+            throw error
+        }
     }
 
     public func load() async throws {
         if isLoaded {
+            Self.logger.info("session handle load reused session=\(self.sessionId, privacy: .public)")
             // Already connected and subscribed — just report current state.
             onStateChange?()
             return
         }
-        try await ensureSocketConnected()
-        isReplaying = true
-        replayUserBuffer = ""
-        replayAssistantBuffer = ""
-        replayThinkingBuffer = ""
-        socket.selectSession(sessionId)
-        try await socket.loadSession(sessionId)
-        isReplaying = false
-        flushReplayBuffers()
-        isRunning = false
-        isLoaded = true
+        let timed = RookPerformance.begin(
+            "LoadSessionHandle",
+            operation: "session-handle-load",
+            description: "session=\(self.sessionId)",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter,
+            slowThresholdMs: 250,
+            hangThresholdMs: 1_000
+        )
+        do {
+            try await ensureSocketConnected()
+            isReplaying = true
+            replayUserBuffer = ""
+            replayAssistantBuffer = ""
+            replayThinkingBuffer = ""
+            socket.selectSession(sessionId)
+            try await socket.loadSession(sessionId)
+            isReplaying = false
+            flushReplayBuffers()
+            isRunning = false
+            isLoaded = true
+            timed.finish(details: "blocks=\(blocks.count)")
+        } catch {
+            isReplaying = false
+            timed.fail(error)
+            throw error
+        }
     }
 
     public func attach(transcript events: [JSONValue]) async throws {
         if isLoaded {
+            Self.logger.info("session handle attach reused session=\(self.sessionId, privacy: .public)")
             onStateChange?()
             return
         }
-        resetVisibleState()
-        for event in events {
-            applyTranscriptEvent(event)
+        let timed = RookPerformance.begin(
+            "AttachTranscript",
+            operation: "session-handle-attach-transcript",
+            description: "session=\(self.sessionId) events=\(events.count)",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter,
+            slowThresholdMs: 250,
+            hangThresholdMs: 1_000
+        )
+        do {
+            resetVisibleState()
+            for event in events {
+                applyTranscriptEvent(event)
+            }
+            try await ensureSocketConnected()
+            socket.selectSession(sessionId)
+            isLoaded = true
+            onStateChange?()
+            timed.finish(details: "blocks=\(blocks.count)")
+        } catch {
+            timed.fail(error)
+            throw error
         }
-        try await ensureSocketConnected()
-        socket.selectSession(sessionId)
-        isLoaded = true
-        onStateChange?()
     }
 
     public func close() {
+        Self.logger.info("session handle close session=\(self.sessionId, privacy: .public)")
         reconnectTask?.cancel()
         streamingFlushTask?.cancel()
         socket.disconnect()
@@ -123,6 +172,7 @@ public final class SessionHandle {
 
     public func stopAgent() {
         guard isRunning else { return }
+        Self.logger.info("session handle cancel requested session=\(self.sessionId, privacy: .public)")
         userCancelledRun = true
         statusLine = "Stopping…"
         socket.sendCancel()
@@ -338,10 +388,12 @@ public final class SessionHandle {
     // MARK: - Private: connection
 
     private func ensureSocketConnected() async throws {
+        Self.logger.info("session handle ensure socket session=\(self.sessionId, privacy: .public)")
         _ = try await socket.connect(request: api.webSocketRequest(sessionId: sessionId))
     }
 
     private func scheduleReconnect(delaySeconds: Double) {
+        Self.logger.warning("session handle schedule reconnect session=\(self.sessionId, privacy: .public) delaySeconds=\(delaySeconds, privacy: .public)")
         reconnectTask?.cancel()
         reconnecting = true
         reconnectTask = Task {
@@ -351,15 +403,27 @@ public final class SessionHandle {
             guard !Task.isCancelled else { return }
             if await api.health() {
                 do {
+                    let timed = RookPerformance.begin(
+                        "ReconnectSessionHandle",
+                        operation: "session-handle-reconnect",
+                        description: "session=\(self.sessionId)",
+                        logger: Self.logger,
+                        signposter: RookLog.sessionSignposter,
+                        slowThresholdMs: 250,
+                        hangThresholdMs: 1_000
+                    )
                     try await ensureSocketConnected()
                     try await socket.loadSession(sessionId)
                     guard !Task.isCancelled else { return }
                     reconnecting = false
+                    timed.finish(details: "queuedMessages=\(self.queuedMessages.count)")
                     deliverNextQueuedIfIdle()
                 } catch {
+                    Self.logger.warning("session handle reconnect failed session=\(self.sessionId, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
                     if !Task.isCancelled { scheduleReconnect(delaySeconds: 3) }
                 }
             } else if !Task.isCancelled {
+                Self.logger.info("session handle reconnect skipped unhealthy server session=\(self.sessionId, privacy: .public)")
                 scheduleReconnect(delaySeconds: 3)
             }
         }
@@ -368,6 +432,7 @@ public final class SessionHandle {
     // MARK: - Private: delivery
 
     private func deliver(_ content: [ChatPromptContent]) {
+        Self.logger.info("session handle deliver session=\(self.sessionId, privacy: .public) textChars=\(content.textValue.count, privacy: .public) images=\(content.images.count, privacy: .public)")
         finalizeStreamingBlocks()
         appendBlock(.userContent(content))
         isRunning = true
@@ -379,6 +444,7 @@ public final class SessionHandle {
 
     private func deliverNextQueuedIfIdle() {
         guard !isRunning, socket.isConnected, !queuedMessages.isEmpty else { return }
+        Self.logger.info("session handle deliver queued session=\(self.sessionId, privacy: .public) queuedMessages=\(self.queuedMessages.count, privacy: .public)")
         let next = queuedMessages.removeFirst()
         Task {
             try? await Task.sleep(nanoseconds: 120_000_000)
@@ -393,6 +459,7 @@ public final class SessionHandle {
     // MARK: - Private: event handling
 
     private func handleSocketConnectionChange(_ connected: Bool) {
+        Self.logger.info("session handle socket change session=\(self.sessionId, privacy: .public) connected=\(connected, privacy: .public)")
         socketConnected = connected
         if connected {
             reconnectTask?.cancel()
@@ -504,6 +571,7 @@ public final class SessionHandle {
             self.configOptions = configOptions
         case .runCompleted(let stopReason):
             if isReplaying { flushReplayBuffers(); return }
+            Self.logger.info("session handle run completed session=\(self.sessionId, privacy: .public) stopReason=\(stopReason, privacy: .public)")
             finalizeStreamingBlocks()
             if stopReason == "cancelled" { finalizeActiveTools(as: .cancelled) }
             isRunning = false
@@ -514,6 +582,7 @@ public final class SessionHandle {
             deliverNextQueuedIfIdle()
         case .runFailed(let message):
             if isReplaying { flushReplayBuffers(); return }
+            Self.logger.error("session handle run failed session=\(self.sessionId, privacy: .public) message=\(message, privacy: .public)")
             finalizeStreamingBlocks()
             isRunning = false
             statusLine = ""
@@ -538,11 +607,17 @@ public final class SessionHandle {
             onEnvironmentOfferResolved?(environmentId, bundleHash)
         case .environmentEntered(let environmentId):
             if enteredEnvironments.insert(environmentId).inserted {
+                Self.logger.info("session handle environment entered session=\(self.sessionId, privacy: .public) environment=\(environmentId, privacy: .public)")
                 onEnvironmentEntered?(environmentId)
                 appendBlock(.system(text: "Entered environment \(environmentId)."))
             }
         case .environmentExited(let environmentId, let error):
             if enteredEnvironments.remove(environmentId) != nil {
+                if let error {
+                    Self.logger.warning("session handle environment exited session=\(self.sessionId, privacy: .public) environment=\(environmentId, privacy: .public) error=\(error, privacy: .public)")
+                } else {
+                    Self.logger.info("session handle environment exited session=\(self.sessionId, privacy: .public) environment=\(environmentId, privacy: .public)")
+                }
                 onEnvironmentExited?(environmentId, error)
                 let suffix = error.map { " (\($0))" } ?? ""
                 appendBlock(.system(text: "Exited environment \(environmentId)\(suffix)."))

--- a/clients/RookKit/Sources/RookKit/Voice/VoiceController.swift
+++ b/clients/RookKit/Sources/RookKit/Voice/VoiceController.swift
@@ -7,6 +7,8 @@ import Speech
 /// configures the shared AVAudioSession (macOS has none).
 @MainActor
 public final class VoiceController: NSObject {
+    private static let logger = RookLog.voice
+
     public var onTranscript: ((String) -> Void)?              // final utterance → agent
     public var onListeningChanged: ((Bool) -> Void)?
     public var onSpeakingChanged: ((Bool) -> Void)?
@@ -47,6 +49,7 @@ public final class VoiceController: NSObject {
             return
         }
         Task { @MainActor in
+            Self.logger.info("voice audio interruption began")
             self.stopSpeaking()
             if self.isListening {
                 self.stopListening(send: false)
@@ -63,10 +66,13 @@ public final class VoiceController: NSObject {
     }
 
     public func requestPermissions(_ completion: @escaping (Bool) -> Void) {
+        Self.logger.info("voice request permissions")
         SFSpeechRecognizer.requestAuthorization { speechStatus in
             AVCaptureDevice.requestAccess(for: .audio) { micGranted in
                 Task { @MainActor in
-                    completion(speechStatus == .authorized && micGranted)
+                    let granted = speechStatus == .authorized && micGranted
+                    Self.logger.info("voice permissions result granted=\(granted, privacy: .public)")
+                    completion(granted)
                 }
             }
         }
@@ -103,10 +109,12 @@ public final class VoiceController: NSObject {
     }
 
     public func startListening() {
+        Self.logger.info("voice start listening authorized=\(self.authorized(), privacy: .public)")
         guard !isListening else {
             return
         }
         guard authorized() else {
+            Self.logger.error("voice start rejected not authorized")
             onError?("Microphone or speech recognition not authorized")
             return
         }
@@ -130,6 +138,7 @@ public final class VoiceController: NSObject {
         do {
             try audioEngine.start()
         } catch {
+            Self.logger.error("voice audio engine start failed error=\(error.localizedDescription, privacy: .public)")
             onError?("Audio engine failed: \(error.localizedDescription)")
             cleanupAudio()
             return
@@ -155,6 +164,7 @@ public final class VoiceController: NSObject {
         }
 
         isListening = true
+        Self.logger.info("voice listening started")
         onListeningChanged?(true)
     }
 
@@ -172,6 +182,7 @@ public final class VoiceController: NSObject {
 
         let transcript = latestTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
         latestTranscript = ""
+        Self.logger.info("voice listening stopped send=\(send, privacy: .public) transcriptChars=\(transcript.count, privacy: .public)")
         if send, !transcript.isEmpty {
             onTranscript?(transcript)
         }
@@ -202,6 +213,7 @@ public final class VoiceController: NSObject {
 
     public func speak(_ text: String) {
         let cleaned = Self.cleanForSpeech(text)
+        Self.logger.info("voice speak requested inputChars=\(text.count, privacy: .public) outputChars=\(cleaned.count, privacy: .public)")
         guard !cleaned.isEmpty else {
             return
         }
@@ -214,6 +226,7 @@ public final class VoiceController: NSObject {
 
     public func stopSpeaking() {
         if synthesizer.isSpeaking {
+            Self.logger.info("voice speaking stopped")
             synthesizer.stopSpeaking(at: .immediate)
         }
     }
@@ -252,6 +265,7 @@ public final class VoiceController: NSObject {
 extension VoiceController: AVSpeechSynthesizerDelegate {
     public nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didStart utterance: AVSpeechUtterance) {
         Task { @MainActor in
+            Self.logger.info("voice speech started")
             self.isSpeaking = true
             self.onSpeakingChanged?(true)
         }
@@ -260,6 +274,7 @@ extension VoiceController: AVSpeechSynthesizerDelegate {
     public nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         Task { @MainActor in
             if !synthesizer.isSpeaking {
+                Self.logger.info("voice speech finished")
                 self.isSpeaking = false
                 self.onSpeakingChanged?(false)
                 self.deactivateAudioSession()

--- a/clients/RookKit/Tests/RookKitTests/RookLogTests.swift
+++ b/clients/RookKit/Tests/RookKitTests/RookLogTests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import RookKit
+
+final class RookLogTests: XCTestCase {
+    func testPerformanceSeverityThresholds() {
+        XCTAssertEqual(RookPerformance.severity(forElapsedMs: 12), .info)
+        XCTAssertEqual(RookPerformance.severity(forElapsedMs: 100), .warning)
+        XCTAssertEqual(RookPerformance.severity(forElapsedMs: 499.99), .warning)
+        XCTAssertEqual(RookPerformance.severity(forElapsedMs: 500), .error)
+    }
+}

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -254,6 +254,26 @@ xcrun simctl launch booted com.rookery.Rook       # bring Rook back
 xcrun simctl io booted screenshot /tmp/rook.png   # screenshot the simulator
 ```
 
+## Client logging
+
+The iPhone app and shared `RookKit` networking/session layer use Apple Unified
+Logging with subsystem `com.rookery.Rook`. Categories include `app`, `session`,
+`network`, `location`, `voice`, and `performance`. REST requests, WebSocket
+connect/disconnect/reconnect, session hydration, prompt lifecycle, location
+authorization/arrival gates, and voice transitions are logged without prompt
+contents, auth tokens, or image data. Slow operations include elapsed
+milliseconds and signposts for Instruments.
+
+When diagnosing an iPhone connection or lifecycle issue, reproduce it with the
+same timestamp recorded on the phone, then collect the device/simulator log for
+that subsystem from Console.app or Xcode's Devices and Simulators window. For a
+simulator, this is also useful:
+
+```zsh
+xcrun simctl spawn booted log show --last 10m --style compact \\
+  --predicate 'subsystem == "com.rookery.Rook"'
+```
+
 ## Capabilities & Info.plist
 
 - **Background Modes → Location updates** (`UIBackgroundModes: location`).

--- a/clients/iphone/Sources/Location/LocationProvider.swift
+++ b/clients/iphone/Sources/Location/LocationProvider.swift
@@ -1,6 +1,7 @@
 import CoreLocation
 import CoreMotion
 import Foundation
+import RookKit
 
 /// Context captured when the device appears to have meaningfully arrived
 /// somewhere, used to ask the server which `location:` environments are available.
@@ -19,6 +20,8 @@ struct ArrivalContext {
 /// regions). The model turns that into `location:<slug>` register/unregister.
 @MainActor
 final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDelegate {
+    private static let logger = RookLog.location
+
     var onRegionChange: ((Place?) -> Void)?
     var onVisitArrival: ((CLLocationCoordinate2D) -> Void)?
     /// Fires only when the arrival passes the dwell/motion gate (stationary,
@@ -61,6 +64,7 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
 
     /// Opt into motion-based drive-by filtering. Triggers the OS Motion prompt the first time.
     func requestMotion() {
+        Self.logger.info("location request motion")
         if startMotionUpdatesIfAvailable() { motionRequested = true }
     }
 
@@ -86,6 +90,7 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     func requestAuthorization() {
+        Self.logger.info("location request authorization status=\(String(describing: self.authorizationStatus), privacy: .public)")
         // Two-step: When-In-Use first (iOS shows the Always upgrade prompt later).
         if authorizationStatus == .notDetermined {
             manager.requestWhenInUseAuthorization()
@@ -95,12 +100,14 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     func requestCurrentLocation() {
+        Self.logger.info("location request current location")
         manager.requestLocation()
     }
 
     /// Fire a synthesized stationary arrival (for Simulator/E2E validation, since CLVisit
     /// never fires in the Simulator). Drives the same `onArrival` path as a real dwell.
     func simulateArrival(latitude: Double, longitude: Double) {
+        Self.logger.info("location simulate arrival latitude=\(latitude, privacy: .public) longitude=\(longitude, privacy: .public)")
         onArrival?(ArrivalContext(
             coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
             horizontalAccuracy: 10,
@@ -113,11 +120,13 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
     /// CLVisit-based "where you spend time" detection (Phase E). Fires
     /// `onVisitArrival` when you settle at a place — used to suggest naming it.
     func startMonitoringVisits() {
+        Self.logger.info("location start monitoring visits")
         manager.startMonitoringVisits()
     }
 
     /// (Re)build the monitored geofences from the user's places.
     func updateMonitoredPlaces(_ places: [Place]) {
+        Self.logger.info("location update monitored places count=\(places.count, privacy: .public)")
         for region in manager.monitoredRegions {
             manager.stopMonitoring(for: region)
         }
@@ -148,6 +157,7 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
         let status = manager.authorizationStatus
         Task { @MainActor in
             let wasAuthorized = self.isAuthorized
+            Self.logger.info("location authorization changed status=\(String(describing: status), privacy: .public)")
             self.authorizationStatus = status
             if status == .authorizedAlways {
                 manager.allowsBackgroundLocationUpdates = true
@@ -170,6 +180,7 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
 
     nonisolated func locationManager(_ manager: CLLocationManager, didEnterRegion region: CLRegion) {
         Task { @MainActor in
+            Self.logger.info("location entered region id=\(region.identifier, privacy: .public)")
             guard let place = monitoredPlaces[region.identifier] else {
                 return
             }
@@ -180,6 +191,7 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
 
     nonisolated func locationManager(_ manager: CLLocationManager, didExitRegion region: CLRegion) {
         Task { @MainActor in
+            Self.logger.info("location exited region id=\(region.identifier, privacy: .public)")
             if current?.id == region.identifier {
                 current = nil
                 onRegionChange?(nil)
@@ -189,6 +201,7 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
 
     nonisolated func locationManager(_ manager: CLLocationManager, didDetermineState state: CLRegionState, for region: CLRegion) {
         Task { @MainActor in
+            Self.logger.info("location determined region state id=\(region.identifier, privacy: .public) state=\(String(describing: state), privacy: .public)")
             guard let place = monitoredPlaces[region.identifier] else {
                 return
             }
@@ -218,6 +231,7 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
         let arrivalDate = visit.arrivalDate
         let accuracy = visit.horizontalAccuracy
         Task { @MainActor in
+            Self.logger.info("location visit arrival latitude=\(coordinate.latitude, privacy: .public) longitude=\(coordinate.longitude, privacy: .public) accuracy=\(accuracy, privacy: .public)")
             // Always feed place-suggestion detection on arrival.
             onVisitArrival?(coordinate)
 
@@ -233,7 +247,11 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
                 isAutomotive: latestActivityIsAutomotive,
                 now: Date(),
                 stationarySpeedThreshold: stationarySpeedThreshold
-            ) else { return }
+            ) else {
+                Self.logger.info("location visit arrival rejected by dwell gate")
+                return
+            }
+            Self.logger.info("location visit arrival accepted dwellSeconds=\(context.dwellSeconds ?? -1, privacy: .public)")
             onArrival?(context)
         }
     }
@@ -267,6 +285,9 @@ final class LocationProvider: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor in
+            Self.logger.error("location manager error=\(error.localizedDescription, privacy: .public)")
+        }
         // Best-effort; region monitoring continues.
     }
 }

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -15,6 +15,8 @@ enum ServerState: Equatable {
 /// voice (Phase C), and Live Activity (Phase D) attach here later.
 @MainActor
 final class RookModel: ObservableObject {
+    private static let logger = RookLog.app
+
     // Server / control plane
     @Published var serverState: ServerState = .unknown
     @Published var serverDiagnostic = ""
@@ -120,6 +122,7 @@ final class RookModel: ObservableObject {
             baseURL: finalURL,
             authToken: authToken
         )
+        Self.logger.info("iphone model init baseURL=\(urlString, privacy: .public)")
 
         healthTimer = Timer.scheduledTimer(withTimeInterval: 4, repeats: true) { [weak self] _ in
             Task { @MainActor in
@@ -167,27 +170,32 @@ final class RookModel: ObservableObject {
         voiceAuthorized = voice.authorized()
         voice.onTranscript = { [weak self] text in
             guard let self else { return }
+            Self.logger.info("voice transcript received chars=\(text.count, privacy: .public)")
             self.voicePartial = ""
             self.voiceModeEnabled = true   // spoke the prompt → speak the reply
             self.send(text)
         }
         voice.onListeningChanged = { [weak self] listening in
+            Self.logger.info("voice listening changed listening=\(listening, privacy: .public)")
             self?.voiceListening = listening
             if !listening { self?.voicePartial = "" }
         }
         voice.onSpeakingChanged = { [weak self] speaking in
+            Self.logger.info("voice speaking changed speaking=\(speaking, privacy: .public)")
             self?.voiceSpeaking = speaking
         }
         voice.onPartial = { [weak self] partial in
             self?.voicePartial = partial
         }
         voice.onError = { [weak self] message in
+            Self.logger.error("voice error message=\(message, privacy: .public)")
             self?.voicePartial = ""
             self?.appendBlock(.system(text: "Voice: \(message)"))
         }
     }
 
     func toggleVoiceListening() {
+        Self.logger.info("toggle voice listening authorized=\(self.voice.authorized(), privacy: .public)")
         if !voice.authorized() {
             voice.requestPermissions { [weak self] granted in
                 self?.voiceAuthorized = granted
@@ -211,7 +219,9 @@ final class RookModel: ObservableObject {
 
     /// Request mic + speech permission without starting a listen (used by Settings).
     func requestVoicePermission() {
+        Self.logger.info("request voice permission")
         voice.requestPermissions { [weak self] granted in
+            Self.logger.info("voice permission result granted=\(granted, privacy: .public)")
             self?.voiceAuthorized = granted
         }
     }
@@ -264,6 +274,7 @@ final class RookModel: ObservableObject {
     // MARK: - Location → place environment
 
     func enableLocation() {
+        Self.logger.info("enable location requested")
         locationProvider.requestAuthorization()
         refreshMonitoredPlaces()
         locationProvider.startMonitoringVisits()
@@ -277,15 +288,24 @@ final class RookModel: ObservableObject {
     /// whether matching location capabilities exist before you physically arrive.
     func refreshPlaceSkillStatus() {
         guard serverState == .online else {
+            Self.logger.info("refresh place skill status skipped serverState=\(String(describing: self.serverState), privacy: .public)")
             return
         }
         Task {
+            let timed = RookPerformance.begin(
+                "iPhoneRefreshPlaceSkillStatus",
+                operation: "iphone-refresh-place-skill-status",
+                description: "places=\(placeStore.places.count)",
+                logger: Self.logger,
+                signposter: RookLog.locationSignposter
+            )
             var status: [String: Bool] = [:]
             for place in placeStore.places {
                 let preview = try? await api.environmentPreview(environmentId: "location:\(place.id)")
                 status[place.id] = !(preview?.bundles.isEmpty ?? true)
             }
             placeSkillStatus = status
+            timed.finish(details: "statuses=\(status.count)")
         }
     }
 
@@ -294,8 +314,10 @@ final class RookModel: ObservableObject {
     /// candidates are surfaced, not auto-registered (issue #42, phase 1).
     private func identifyEnvironments(at context: ArrivalContext) {
         guard serverState == .online else {
+            Self.logger.info("identify environments skipped serverState=\(String(describing: self.serverState), privacy: .public)")
             return
         }
+        Self.logger.info("identify environments latitude=\(context.coordinate.latitude, privacy: .public) longitude=\(context.coordinate.longitude, privacy: .public) dwellSeconds=\(context.dwellSeconds ?? -1, privacy: .public)")
         let observedAt = ISO8601DateFormatter().string(from: Date())
         let request = IdentifyAvailableRequest(
             latitude: context.coordinate.latitude,
@@ -308,14 +330,23 @@ final class RookModel: ObservableObject {
             observedAt: observedAt
         )
         Task {
+            let timed = RookPerformance.begin(
+                "iPhoneIdentifyEnvironments",
+                operation: "iphone-identify-environments",
+                logger: Self.logger,
+                signposter: RookLog.locationSignposter
+            )
             // Dwell/arrival is an auto-commit: register the identified set with the agent.
             guard let candidates = try? await api.registerLocation(request) else {
+                timed.finish(details: "candidates=0 request-failed")
                 return
             }
             nearbyCandidates = candidates
             guard let top = candidates.first else {
+                timed.finish(details: "candidates=0")
                 return
             }
+            timed.finish(details: "candidates=\(candidates.count) top=\(top.environmentId)")
             let others = candidates.count > 1 ? " (+\(candidates.count - 1) more)" : ""
             appendBlock(.system(text: "You appear to be near \(top.displayName)\(others). Found \(candidates.count) nearby environment\(candidates.count == 1 ? "" : "s")."))
         }
@@ -326,6 +357,7 @@ final class RookModel: ObservableObject {
     /// (only if the server has skills for it — the iOS analog of the Mac's
     /// on-disk skill-bundle guard, done via the preview endpoint).
     private func handlePlace(_ place: Place?) {
+        Self.logger.info("handle place place=\(place?.id ?? "(none)", privacy: .public)")
         currentPlaceName = place?.name
         let envId = place.map { "location:\($0.id)" }
         guard envId != placeEnvironmentId else {
@@ -337,8 +369,18 @@ final class RookModel: ObservableObject {
             guard let place, let envId else {
                 return
             }
+            let timed = RookPerformance.begin(
+                "iPhoneHandlePlace",
+                operation: "iphone-handle-place",
+                description: envId,
+                logger: Self.logger,
+                signposter: RookLog.locationSignposter
+            )
             let preview = try? await api.environmentPreview(environmentId: envId)
             guard let preview, !preview.bundles.isEmpty else {
+                timed.finish(details: "bundles=0")
+                Self.logger.info("place preview empty envId=\(envId, privacy: .public)")
+
                 // No skills defined for this place — don't raise an empty offer.
                 if placeEnvironmentId == envId {
                     placeEnvironmentId = nil
@@ -346,6 +388,8 @@ final class RookModel: ObservableObject {
                 }
                 return
             }
+            timed.finish(details: "bundles=\(preview.bundles.count)")
+            Self.logger.info("place register envId=\(envId, privacy: .public) bundles=\(preview.bundles.count, privacy: .public)")
             let metadata: [String: JSONValue] = [
                 "slug": .string(place.id),
                 "latitude": .number(place.latitude),
@@ -361,6 +405,7 @@ final class RookModel: ObservableObject {
         guard let envId = placeEnvironmentId, let place = locationProvider.current else {
             return
         }
+        Self.logger.info("reannounce place environment envId=\(envId, privacy: .public)")
         Task {
             let metadata: [String: JSONValue] = [
                 "slug": .string(place.id),
@@ -388,6 +433,7 @@ final class RookModel: ObservableObject {
             KeychainStore.setString(trimmedToken, for: "RookAuthToken")
         }
         api = RookAPI(baseURL: url, authToken: trimmedToken)
+        Self.logger.info("set server connection baseURL=\(trimmed, privacy: .public) tokenPresent=\(!trimmedToken.isEmpty, privacy: .public)")
         currentHandle?.close()
         currentSession = nil
         Task { await refreshHealth() }
@@ -396,6 +442,12 @@ final class RookModel: ObservableObject {
     // MARK: - Server lifecycle
 
     func refreshHealth() async {
+        let timed = RookPerformance.begin(
+            "iPhoneRefreshHealth",
+            operation: "iphone-refresh-health",
+            logger: Self.logger,
+            signposter: RookLog.appSignposter
+        )
         switch await api.healthResult() {
         case .ok:
             let wasOnline = serverState == .online
@@ -407,15 +459,19 @@ final class RookModel: ObservableObject {
                 reannouncePlaceEnvironment()
                 await autoResumeRecentSessionIfNeeded()
             }
+            timed.finish(details: "state=online")
         case .unauthorized:
             serverState = .unauthorized
             serverDiagnostic = "Authorization header was rejected."
+            timed.finish(details: "state=unauthorized")
         case .httpStatus(let code):
             serverState = .offline
             serverDiagnostic = "HTTP \(code)"
+            timed.finish(details: "state=offline status=\(code)")
         case .transportError(let message):
             serverState = .offline
             serverDiagnostic = message
+            timed.finish(details: "state=offline transport=\(message)")
         }
     }
 
@@ -444,11 +500,19 @@ final class RookModel: ObservableObject {
     }
 
     func loadAgents() async {
+        let timed = RookPerformance.begin(
+            "iPhoneLoadAgents",
+            operation: "iphone-load-agents",
+            logger: Self.logger,
+            signposter: RookLog.appSignposter
+        )
         do {
             agents = try await api.agents()
             agentsError = ""
+            timed.finish(details: "agents=\(self.agents.count)")
         } catch {
             agentsError = error.localizedDescription
+            timed.fail(error)
         }
     }
 
@@ -484,17 +548,26 @@ final class RookModel: ObservableObject {
 
     func loadSessions(agentId _: String = "") async {
         sessionsLoading = true
+        let timed = RookPerformance.begin(
+            "iPhoneLoadSessions",
+            operation: "iphone-load-sessions",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter
+        )
         defer { sessionsLoading = false }
         do {
             sessions = try await api.sessions()
             sessionsError = ""
+            timed.finish(details: "sessions=\(sessions.count)")
         } catch {
             sessionsError = error.localizedDescription
+            timed.fail(error)
         }
     }
 
     func startNewSession(agentId: String, name: String) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        Self.logger.info("iphone start new session runtime=\(agentId, privacy: .public) name=\(name, privacy: .public)")
         startingSession = true
         Task {
             defer { startingSession = false }
@@ -537,6 +610,7 @@ final class RookModel: ObservableObject {
     }
 
     func resumeSession(_ session: AgentSessionSummary) {
+        Self.logger.info("iphone resume session=\(session.id, privacy: .public) runtime=\(session.agent, privacy: .public) running=\(session.running, privacy: .public)")
         startingSession = true
         Task {
             defer { startingSession = false }
@@ -632,6 +706,7 @@ final class RookModel: ObservableObject {
     // MARK: - App lifecycle (scenePhase)
 
     func handleBecameActive() {
+        Self.logger.info("iphone became active")
         reannouncePlaceEnvironment()
         updateLiveActivity()
         Task { await refreshHealth() }
@@ -640,6 +715,7 @@ final class RookModel: ObservableObject {
     // MARK: - Chat
 
     func send(_ text: String) {
+        Self.logger.info("iphone send currentSession=\(self.currentSession?.id ?? "(none)", privacy: .public) chars=\(text.count, privacy: .public)")
         currentHandle?.send([.text(text)])
         updateLiveActivity()
     }

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -173,7 +173,32 @@ thrash the richer foreground context, the app ignores its own activations
 (opening the panel doesn't end the episode), and cached registrations are
 re-announced if the server restarts.
 
-Provider activity is traced to `/tmp/rook.log` for debugging.
+### Client logging and beachball diagnostics
+
+The Mac app uses Apple Unified Logging through the shared `RookKit` logger. The
+subsystem is `com.rookery.Rook`; categories include `app`, `session`, `network`,
+`environment`, `bridge`, `server`, and `performance`. Slow operations are logged
+with elapsed milliseconds and emitted as signposts for Instruments. Operations
+that take at least 100 ms are warnings; operations that take at least 500 ms are
+errors, making main-thread and Accessibility/Finder stalls easy to identify.
+
+Open **Rook Log** from the app to view the last ten minutes of the client
+subsystem log plus the managed server-log tail, followed by a live unified-log
+stream. The viewer is an inspection aid; the authoritative client log is
+Unified Logging, not a temporary file.
+
+Useful commands while reproducing a hang:
+
+```zsh
+log stream --style compact --predicate 'subsystem == "com.rookery.Rook"'
+log show --last 10m --style compact --predicate 'subsystem == "com.rookery.Rook"'
+sample Rook 10 -file ~/Desktop/rook-sample.txt
+```
+
+Capture the timestamp of the beachball and collect the unified log plus a
+`sample` while it is visible. In particular, search the `performance` and
+`environment` categories for `elapsedMs`, `ax-`, `finder-`, or
+`mac-bridge-route` entries immediately before the sample.
 
 ### Tier 1 - window-title perception
 

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -177,23 +177,34 @@ re-announced if the server restarts.
 
 The Mac app uses Apple Unified Logging through the shared `RookKit` logger. The
 subsystem is `com.rookery.Rook`; categories include `app`, `session`, `network`,
-`environment`, `bridge`, `server`, and `performance`. Slow operations are logged
-with elapsed milliseconds and emitted as signposts for Instruments. Operations
-that take at least 100 ms are warnings; operations that take at least 500 ms are
-errors, making main-thread and Accessibility/Finder stalls easy to identify.
+`environment`, `bridge`, `server`, and `performance`. Fast successful timings
+are debug-level; operations that take at least 100 ms are warnings, and
+operations that take at least 500 ms are errors. This keeps normal logs small
+while making main-thread and Accessibility/Finder stalls easy to identify.
 
 Open **Rook Log** from the app to view the last ten minutes of the client
 subsystem log plus the managed server-log tail, followed by a live unified-log
 stream. The viewer is an inspection aid; the authoritative client log is
 Unified Logging, not a temporary file.
 
-Useful commands while reproducing a hang:
+You can view the logs in **Console.app** by selecting the Mac, searching for
+`subsystem:com.rookery.Rook`, and pressing **Start**. Terminal equivalents:
 
 ```zsh
 log stream --style compact --predicate 'subsystem == "com.rookery.Rook"'
 log show --last 10m --style compact --predicate 'subsystem == "com.rookery.Rook"'
 sample Rook 10 -file ~/Desktop/rook-sample.txt
 ```
+
+For a short diagnostic run with detailed polling and raw foreground context,
+launch from the worktree with:
+
+```zsh
+ROOK_VERBOSE_LOGGING=1 ./scripts/run-rook.sh server mac
+```
+
+Verbose mode is opt-in; it includes window titles, document paths, and URLs, so
+do not enable it for logs you plan to share without reviewing them.
 
 Capture the timestamp of the beachball and collect the unified log plus a
 `sample` while it is visible. In particular, search the `performance` and

--- a/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
@@ -36,9 +36,9 @@ final class AppEnvironmentProvider {
                         var metadata = candidate.metadata
                         metadata["registeredAt"] = .string(Self.iso8601String(from: Date()))
                         try await api.registerEnvironment(CandidateEnvironmentRecord(id: candidate.id, metadata: metadata))
-                        providerLog("register ok [\(reason)]: \(candidate.id)")
+                        providerInfo("environment register ok reason=\(reason) id=\(candidate.id)")
                     } catch {
-                        providerLog("register error [\(reason)]: \(error.localizedDescription)")
+                        providerError("environment register failed reason=\(reason) id=\(candidate.id) error=\(error.localizedDescription)")
                     }
                 }
             }
@@ -72,6 +72,7 @@ final class AppEnvironmentProvider {
     }
 
     func setServerOnline(_ online: Bool) {
+        providerInfo("app environment provider serverOnline=\(online)")
         isServerOnline = online
         baseRegistration.setServerOnline(online)
         activeProvider?.setServerOnline(online)
@@ -82,6 +83,7 @@ final class AppEnvironmentProvider {
     }
 
     private func handleForegroundApp(_ app: ForegroundApp) {
+        providerInfo("handle foreground app bundleId=\(app.bundleId) pid=\(app.pid)")
         AXReader.primeAccessibility(pid: app.pid)
         let title = AXReader.focusedWindowTitle(pid: app.pid)
         logRawContext(app: app, title: title, reason: "app-switch")
@@ -94,6 +96,7 @@ final class AppEnvironmentProvider {
     }
 
     private func handleContextRefresh(app: ForegroundApp, title: String?) {
+        providerInfo("handle context refresh bundleId=\(app.bundleId) title=\(title ?? "(null)")")
         logRawContext(app: app, title: title, reason: "context-refresh")
         foregroundAppName = app.name
         foregroundWindowTitle = title
@@ -104,6 +107,7 @@ final class AppEnvironmentProvider {
 
     private func activateProviderIfNeeded(for app: ForegroundApp, title: String?) {
         let nextProvider = specializedProvidersByBundleId[app.bundleId] ?? genericProvider
+        providerInfo("activate provider bundleId=\(app.bundleId) specialized=\(specializedProvidersByBundleId[app.bundleId] != nil)")
         if let activeProvider, activeProvider === nextProvider {
             activeProvider.update(app: app, title: title)
             return
@@ -147,7 +151,7 @@ final class AppEnvironmentProvider {
         lastLoggedDocumentValues = documentValues
 
         var lines: [String] = []
-        lines.append("[RAW-CONTEXT] reason=\(reason)")
+        lines.append("raw-context reason=\(reason)")
         lines.append("  mac:          \(app.name)  bundleId=\(app.bundleId)  pid=\(app.pid)")
         let titleText = title.map { "\"\($0)\"" } ?? "(null)"
         lines.append("  windowTitle:  \(titleText)")
@@ -157,7 +161,7 @@ final class AppEnvironmentProvider {
         }
         lines.append("  trustedAX:    \(AXReader.isTrusted())")
         for line in lines {
-            providerLog(line)
+            providerInfo(line)
         }
     }
 

--- a/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
@@ -150,18 +150,9 @@ final class AppEnvironmentProvider {
         lastLoggedURL = webURL
         lastLoggedDocumentValues = documentValues
 
-        var lines: [String] = []
-        lines.append("raw-context reason=\(reason)")
-        lines.append("  mac:          \(app.name)  bundleId=\(app.bundleId)  pid=\(app.pid)")
-        let titleText = title.map { "\"\($0)\"" } ?? "(null)"
-        lines.append("  windowTitle:  \(titleText)")
-        lines.append("  axDocument:   \(documentValues.isEmpty ? "(none)" : documentValues.joined(separator: " | "))")
-        if let webURL {
-            lines.append("  axWebURL:     \(webURL)")
-        }
-        lines.append("  trustedAX:    \(AXReader.isTrusted())")
-        for line in lines {
-            providerInfo(line)
+        providerInfo("context reason=\(reason) app=\(app.name) bundleId=\(app.bundleId) pid=\(app.pid) titlePresent=\(title != nil) documents=\(documentValues.count) webURLPresent=\(webURL != nil) trustedAX=\(AXReader.isTrusted())")
+        if RookLog.verboseEnabled {
+            providerDebug("context raw reason=\(reason) app=\(app.name) bundleId=\(app.bundleId) title=\(title ?? "(null)") documents=\(documentValues.joined(separator: " | ")) webURL=\(webURL ?? "(null)")")
         }
     }
 

--- a/clients/mac/Sources/Models/EnvironmentProviders/EnvironmentProviderSupport.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/EnvironmentProviderSupport.swift
@@ -38,13 +38,17 @@ final class EnvironmentRegistrationController {
     }
 
     func setServerOnline(_ online: Bool) {
+        guard isServerOnline != online else {
+            flushIfPossible()
+            return
+        }
         isServerOnline = online
         Self.logger.info("environment registration serverOnline=\(online, privacy: .public)")
         flushIfPossible()
     }
 
     func update(candidates: [EnvironmentCandidate], delay: TimeInterval, reason: String) {
-        Self.logger.info("environment registration update reason=\(reason, privacy: .public) candidates=\(candidates.count, privacy: .public) delay=\(delay, privacy: .public)")
+        Self.logger.debug("environment registration update reason=\(reason, privacy: .public) candidates=\(candidates.count, privacy: .public) delay=\(delay, privacy: .public)")
         let signature = Self.signature(for: candidates)
         guard !signature.isEmpty else {
             clear()
@@ -75,7 +79,7 @@ final class EnvironmentRegistrationController {
     }
 
     func emitNow(candidates: [EnvironmentCandidate], reason: String) {
-        Self.logger.info("environment registration emitNow reason=\(reason, privacy: .public) candidates=\(candidates.count, privacy: .public)")
+        Self.logger.debug("environment registration emitNow reason=\(reason, privacy: .public) candidates=\(candidates.count, privacy: .public)")
         currentCandidates = candidates
         currentReason = reason
         readyToEmit = true
@@ -83,7 +87,7 @@ final class EnvironmentRegistrationController {
     }
 
     func clear() {
-        Self.logger.info("environment registration clear")
+        Self.logger.debug("environment registration clear")
         timer?.invalidate()
         timer = nil
         currentSignature = nil
@@ -102,7 +106,7 @@ final class EnvironmentRegistrationController {
             return now.timeIntervalSince(lastEmission) >= Self.duplicateSuppressionWindow
         }
         guard !eligible.isEmpty else {
-            Self.logger.info("environment registration suppressed reason=\(self.currentReason, privacy: .public) candidates=\(self.currentCandidates.count, privacy: .public)")
+            Self.logger.debug("environment registration suppressed reason=\(self.currentReason, privacy: .public) candidates=\(self.currentCandidates.count, privacy: .public)")
             return
         }
         for candidate in eligible {

--- a/clients/mac/Sources/Models/EnvironmentProviders/EnvironmentProviderSupport.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/EnvironmentProviderSupport.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 import RookKit
 
 struct EnvironmentCandidate: Equatable {
@@ -23,6 +22,7 @@ protocol SpecializedEnvironmentProvider: AnyObject {
 @MainActor
 final class EnvironmentRegistrationController {
     private static let duplicateSuppressionWindow: TimeInterval = 60
+    private static let logger = RookLog.environment
 
     private let register: ([EnvironmentCandidate], String) -> Void
     private var timer: Timer?
@@ -39,10 +39,12 @@ final class EnvironmentRegistrationController {
 
     func setServerOnline(_ online: Bool) {
         isServerOnline = online
+        Self.logger.info("environment registration serverOnline=\(online, privacy: .public)")
         flushIfPossible()
     }
 
     func update(candidates: [EnvironmentCandidate], delay: TimeInterval, reason: String) {
+        Self.logger.info("environment registration update reason=\(reason, privacy: .public) candidates=\(candidates.count, privacy: .public) delay=\(delay, privacy: .public)")
         let signature = Self.signature(for: candidates)
         guard !signature.isEmpty else {
             clear()
@@ -73,6 +75,7 @@ final class EnvironmentRegistrationController {
     }
 
     func emitNow(candidates: [EnvironmentCandidate], reason: String) {
+        Self.logger.info("environment registration emitNow reason=\(reason, privacy: .public) candidates=\(candidates.count, privacy: .public)")
         currentCandidates = candidates
         currentReason = reason
         readyToEmit = true
@@ -80,6 +83,7 @@ final class EnvironmentRegistrationController {
     }
 
     func clear() {
+        Self.logger.info("environment registration clear")
         timer?.invalidate()
         timer = nil
         currentSignature = nil
@@ -97,11 +101,15 @@ final class EnvironmentRegistrationController {
             }
             return now.timeIntervalSince(lastEmission) >= Self.duplicateSuppressionWindow
         }
-        guard !eligible.isEmpty else { return }
+        guard !eligible.isEmpty else {
+            Self.logger.info("environment registration suppressed reason=\(self.currentReason, privacy: .public) candidates=\(self.currentCandidates.count, privacy: .public)")
+            return
+        }
         for candidate in eligible {
             lastEmissionAtByEnvironmentId[candidate.id] = now
         }
-        register(eligible, currentReason)
+        Self.logger.info("environment registration flush reason=\(self.currentReason, privacy: .public) candidates=\(eligible.map(\.id).joined(separator: ","), privacy: .public)")
+        register(eligible, self.currentReason)
     }
 
     private static func signature(for candidates: [EnvironmentCandidate]) -> String {

--- a/clients/mac/Sources/Models/EnvironmentProviders/FinderEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/FinderEnvironmentProvider.swift
@@ -35,6 +35,7 @@ final class FinderEnvironmentProvider: SpecializedEnvironmentProvider {
     }
 
     func activate(app: ForegroundApp, title: String?) {
+        providerInfo("finder provider activate title=\(title ?? "(null)")")
         currentApp = app
         currentTitle = title
         let observation = observe()
@@ -74,12 +75,22 @@ final class FinderEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
+        let timed = RookPerformance.begin(
+            "FinderEnvironmentPoll",
+            operation: "finder-environment-poll",
+            description: "bundleId=\(currentApp.bundleId)",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 150,
+            hangThresholdMs: 600
+        )
         let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
         currentTitle = title
         let observation = observe()
         currentAppEnvironmentId = Self.currentEnvironmentId(from: observation)
         let candidates = Self.candidates(for: currentApp, title: title, observation: observation)
         registration.emitNow(candidates: candidates, reason: "finder")
+        timed.finish(details: "candidates=\(candidates.count)")
         onStateChange?()
     }
 
@@ -136,35 +147,46 @@ final class FinderEnvironmentProvider: SpecializedEnvironmentProvider {
     }
 
     static func observeFinder() -> FinderObservation {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
-        process.arguments = ["-e", finderObservationScript]
+        RookPerformance.measure(
+            "FinderObservation",
+            operation: "finder-observe",
+            description: "osascript finder windows",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 150,
+            hangThresholdMs: 600,
+            details: { observation in "directories=\(observation.allDirectoryPaths.count)" }
+        ) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+            process.arguments = ["-e", finderObservationScript]
 
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
 
-        do {
-            try process.run()
-            process.waitUntilExit()
-        } catch {
-            providerLog("finder observe error: \(error.localizedDescription)")
-            return FinderObservation(currentDirectoryPath: nil, allDirectoryPaths: [])
-        }
-
-        guard process.terminationStatus == 0 else {
-            let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
-            let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            if !errorOutput.isEmpty {
-                providerLog("finder observe error: \(errorOutput)")
+            do {
+                try process.run()
+                process.waitUntilExit()
+            } catch {
+                providerError("finder observe failed error=\(error.localizedDescription)")
+                return FinderObservation(currentDirectoryPath: nil, allDirectoryPaths: [])
             }
-            return FinderObservation(currentDirectoryPath: nil, allDirectoryPaths: [])
-        }
 
-        let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: outputData, encoding: .utf8) ?? ""
-        return parseObservation(from: output)
+            guard process.terminationStatus == 0 else {
+                let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
+                let errorOutput = String(data: errorData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                if !errorOutput.isEmpty {
+                    providerError("finder observe failed error=\(errorOutput)")
+                }
+                return FinderObservation(currentDirectoryPath: nil, allDirectoryPaths: [])
+            }
+
+            let outputData = stdout.fileHandleForReading.readDataToEndOfFile()
+            let output = String(data: outputData, encoding: .utf8) ?? ""
+            return parseObservation(from: output)
+        }
     }
 
     private static let finderObservationScript = #"""

--- a/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
@@ -54,7 +54,11 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     }
 
     func activate(app: ForegroundApp, title: String?) {
-        Self.logger.info("generic provider activate bundleId=\(app.bundleId, privacy: .public) title=\(title ?? "(null)", privacy: .public)")
+        if RookLog.verboseEnabled {
+            Self.logger.debug("generic provider activate bundleId=\(app.bundleId, privacy: .public) title=\(title ?? "(null)", privacy: .public)")
+        } else {
+            Self.logger.info("generic provider activate bundleId=\(app.bundleId, privacy: .public)")
+        }
         currentApp = app
         currentTitle = title
         previousNormalizedIds = nil
@@ -63,7 +67,9 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     }
 
     func update(app: ForegroundApp, title: String?) {
-        Self.logger.info("generic provider update bundleId=\(app.bundleId, privacy: .public) title=\(title ?? "(null)", privacy: .public)")
+        if RookLog.verboseEnabled {
+            Self.logger.debug("generic provider update bundleId=\(app.bundleId, privacy: .public) title=\(title ?? "(null)", privacy: .public)")
+        }
         currentApp = app
         currentTitle = title
     }

--- a/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 import RookKit
 
 private struct GenericEnvironmentObservation {
@@ -12,7 +11,7 @@ private struct GenericEnvironmentObservation {
 @MainActor
 final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     private static let pollInterval: TimeInterval = 5
-    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.rookery.rook", category: "GenericEnvironmentProvider")
+    private static let logger = RookLog.environment
     private static let fileManager = FileManager.default
     private static let projectRootFileMarkers = [
         ".git",
@@ -55,6 +54,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     }
 
     func activate(app: ForegroundApp, title: String?) {
+        Self.logger.info("generic provider activate bundleId=\(app.bundleId, privacy: .public) title=\(title ?? "(null)", privacy: .public)")
         currentApp = app
         currentTitle = title
         previousNormalizedIds = nil
@@ -63,11 +63,13 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     }
 
     func update(app: ForegroundApp, title: String?) {
+        Self.logger.info("generic provider update bundleId=\(app.bundleId, privacy: .public) title=\(title ?? "(null)", privacy: .public)")
         currentApp = app
         currentTitle = title
     }
 
     func deactivate() {
+        Self.logger.info("generic provider deactivate bundleId=\(self.currentApp?.bundleId ?? "(none)", privacy: .public)")
         if let app = currentApp {
             let observation = Self.observation(for: app, title: currentTitle)
             registration.emitNow(candidates: observation.candidates, reason: "generic-final")
@@ -98,6 +100,15 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let app = currentApp else { return }
+        let timed = RookPerformance.begin(
+            "GenericEnvironmentPoll",
+            operation: "generic-environment-poll",
+            description: "bundleId=\(app.bundleId)",
+            logger: Self.logger,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 150,
+            hangThresholdMs: 600
+        )
         let title = AXReader.focusedWindowTitle(pid: app.pid) ?? currentTitle
         currentTitle = title
         let observation = Self.observation(for: app, title: title)
@@ -108,9 +119,12 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
             onStateChange?()
         }
         guard let previousNormalizedIds, previousNormalizedIds == observation.normalizedIds else {
+            Self.logger.info("generic provider observation changed bundleId=\(app.bundleId, privacy: .public) candidates=\(observation.candidates.count, privacy: .public)")
+            timed.finish(details: "changed normalizedIds=\(observation.normalizedIds.count)")
             return
         }
         registration.emitNow(candidates: observation.candidates, reason: "generic")
+        timed.finish(details: "stable normalizedIds=\(observation.normalizedIds.count) candidates=\(observation.candidates.count)")
     }
 
     private static func observation(for app: ForegroundApp, title: String?) -> GenericEnvironmentObservation {
@@ -268,7 +282,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     }
 
     static func warningForNonAbsoluteDirectoryCandidate(rawValue: String, app: ForegroundApp) {
-        logger.warning("Skipping non-absolute directory candidate for bundleId=\(app.bundleId, privacy: .public): \(rawValue, privacy: .public)")
+        logger.warning("generic provider skipped non-absolute directory candidate bundleId=\(app.bundleId, privacy: .public) value=\(rawValue, privacy: .public)")
     }
 }
 

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -1,5 +1,4 @@
 import Foundation
-import OSLog
 import RookKit
 
 /// Session lifecycle and registry.  One `SessionHandle` per session, each
@@ -7,7 +6,7 @@ import RookKit
 /// observes — background sessions keep running.
 @MainActor
 final class ChatSessionController {
-    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.rookery.Rook", category: "ChatSessionController")
+    private static let logger = RookLog.session
     private static let timingLogsEnabled = ProcessInfo.processInfo.environment["ROOK_SESSION_TIMING_LOGS"] == "1"
     var onStateChange: (() -> Void)?
     var onCurrentSessionChange: ((AgentSessionSummary?) -> Void)?
@@ -61,18 +60,27 @@ final class ChatSessionController {
     }
 
     func stop() {
+        Self.logger.info("chat session controller stop handles=\(self.handles.count, privacy: .public)")
         for handle in handles.values { handle.close() }
         handles = [:]
     }
 
     func loadSessions() async {
         sessionsLoading = true
+        let timed = RookPerformance.begin(
+            "MacLoadSessions",
+            operation: "mac-load-sessions",
+            logger: Self.logger,
+            signposter: RookLog.sessionSignposter
+        )
         defer { sessionsLoading = false }
         do {
             sessions = try await api.sessions()
             sessionsError = ""
+            timed.finish(details: "sessions=\(sessions.count)")
         } catch {
             sessionsError = error.localizedDescription
+            timed.fail(error)
         }
     }
 
@@ -91,6 +99,7 @@ final class ChatSessionController {
     func startNewSession(agentId: String, name: String, completion: (() -> Void)? = nil) {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
         let title = trimmed.isEmpty ? "session" : trimmed
+        Self.logger.info("chat session controller start new runtime=\(agentId, privacy: .public) title=\(title, privacy: .public)")
         startingSession = true
         Task {
             defer { self.startingSession = false; completion?() }
@@ -137,6 +146,7 @@ final class ChatSessionController {
     }
 
     func resumeSession(_ session: AgentSessionSummary, completion: (() -> Void)? = nil) {
+        Self.logger.info("chat session controller resume session=\(session.id, privacy: .public) runtime=\(session.agent, privacy: .public) running=\(session.running, privacy: .public)")
         startingSession = true
         Task {
             defer { self.startingSession = false; completion?() }

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -20,6 +20,8 @@ enum ServerState: Equatable {
 
 @MainActor
 final class RookMacModel: ObservableObject {
+    private static let logger = RookLog.app
+
     static weak var shared: RookMacModel?
 
     @Published var panelMode: PanelMode = .home
@@ -110,6 +112,7 @@ final class RookMacModel: ObservableObject {
         environmentListController = EnvironmentListController(api: api)
 
         RookMacModel.shared = self
+        Self.logger.info("mac model init baseURL=\(resolvedBaseURL, privacy: .public)")
         wireControllers()
         serverStateController.start()
         appEnvironmentProvider.start()
@@ -279,7 +282,7 @@ final class RookMacModel: ObservableObject {
     var serverPrimaryLine: String {
         switch serverState {
         case .online:
-            return agents.isEmpty ? "Server online" : "Server online · \(agents.count) agents"
+            return agents.isEmpty ? "Server online" : "Server online · \(self.agents.count) agents"
         case .starting:
             return "Server starting…"
         case .offline:
@@ -308,12 +311,19 @@ final class RookMacModel: ObservableObject {
     // MARK: - Server lifecycle
 
     func refreshNow() async {
+        let timed = RookPerformance.begin(
+            "MacRefreshNow",
+            operation: "mac-refresh-now",
+            logger: Self.logger,
+            signposter: RookLog.appSignposter
+        )
         refreshAccessibilityStatus()
         await serverStateController.refreshNow()
         syncServerState()
         if serverState == .online {
             await loadAgents()
         }
+        timed.finish(details: "serverState=\(String(describing: serverState)) agents=\(self.agents.count)")
     }
 
     func refreshNow() {
@@ -323,27 +333,38 @@ final class RookMacModel: ObservableObject {
     }
 
     func startServer() {
+        Self.logger.info("mac model start server requested")
         serverStateController.startManagedServer()
         syncServerState()
     }
 
     func stopServer() {
+        Self.logger.info("mac model stop server requested")
         serverStateController.stopManagedServer()
         syncServerState()
     }
 
     func loadAgents() async {
+        let timed = RookPerformance.begin(
+            "MacLoadAgents",
+            operation: "mac-load-agents",
+            logger: Self.logger,
+            signposter: RookLog.appSignposter
+        )
         do {
             agents = try await api.agents()
             agentsError = ""
+            timed.finish(details: "agents=\(self.agents.count)")
         } catch {
             agentsError = error.localizedDescription
+            timed.fail(error)
         }
     }
 
     private var logViewerWindow: NSPanel?
 
     func openServerLog() {
+        Self.logger.info("mac model open unified log viewer")
         if let existing = logViewerWindow {
             existing.makeKeyAndOrderFront(nil)
             return
@@ -368,6 +389,7 @@ final class RookMacModel: ObservableObject {
     }
 
     func quitApp() {
+        Self.logger.info("mac model quit app")
         chatSessionController.stop()
         appEnvironmentProvider.stop()
         serverStateController.stop()
@@ -411,18 +433,21 @@ final class RookMacModel: ObservableObject {
     }
 
     func startNewSession(agentId: String, name: String) {
+        Self.logger.info("mac model start new session runtime=\(agentId, privacy: .public) name=\(name, privacy: .public)")
         chatSessionController.startNewSession(agentId: agentId, name: name) { [weak self] in
             self?.panelMode = .chat
         }
     }
 
     func resumeSession(_ session: AgentSessionSummary) {
+        Self.logger.info("mac model resume session=\(session.id, privacy: .public) runtime=\(session.agent, privacy: .public)")
         chatSessionController.resumeSession(session) { [weak self] in
             self?.panelMode = .chat
         }
     }
 
     func send(_ content: [ChatPromptContent]) {
+        Self.logger.info("mac model send currentSession=\(self.currentSession?.id ?? "(none)", privacy: .public) textChars=\(content.textValue.count, privacy: .public) images=\(content.images.count, privacy: .public)")
         chatSessionController.send(content)
     }
 
@@ -511,6 +536,7 @@ final class RookMacModel: ObservableObject {
 
     func refreshAccessibilityStatus() {
         accessibilityTrusted = AXReader.isTrusted()
+        Self.logger.info("mac model accessibility trusted=\(self.accessibilityTrusted, privacy: .public)")
         if accessibilityTrusted {
             appEnvironmentProvider.refreshCurrentContext()
         }

--- a/clients/mac/Sources/Models/RookMacSupport.swift
+++ b/clients/mac/Sources/Models/RookMacSupport.swift
@@ -66,6 +66,7 @@ final class ServerStateController {
             logger: Self.logger,
             signposter: RookLog.serverSignposter
         )
+        let previousState = serverState
         let healthy = await api.health()
         managedServerRunning = serverController.isManagedServerRunning
         if healthy {
@@ -73,7 +74,11 @@ final class ServerStateController {
         } else if serverState != .starting || !managedServerRunning {
             serverState = managedServerRunning ? .starting : .offline
         }
-        Self.logger.info("server state refresh state=\(String(describing: self.serverState), privacy: .public) managed=\(self.managedServerRunning, privacy: .public)")
+        if previousState != serverState {
+            Self.logger.info("server state changed state=\(String(describing: self.serverState), privacy: .public) managed=\(self.managedServerRunning, privacy: .public)")
+        } else if RookLog.verboseEnabled {
+            Self.logger.debug("server state unchanged state=\(String(describing: self.serverState), privacy: .public) managed=\(self.managedServerRunning, privacy: .public)")
+        }
         timed.finish(details: "state=\(String(describing: serverState)) managed=\(self.managedServerRunning)")
     }
 

--- a/clients/mac/Sources/Models/RookMacSupport.swift
+++ b/clients/mac/Sources/Models/RookMacSupport.swift
@@ -3,6 +3,8 @@ import RookKit
 
 @MainActor
 final class ServerStateController {
+    private static let logger = RookLog.server
+
     var onStateChange: (() -> Void)?
     var didBecomeOnline: (() -> Void)?
     var didBecomeOffline: (() -> Void)?
@@ -58,6 +60,12 @@ final class ServerStateController {
     }
 
     func refreshNow() async {
+        let timed = RookPerformance.begin(
+            "MacServerHealthRefresh",
+            operation: "mac-server-health-refresh",
+            logger: Self.logger,
+            signposter: RookLog.serverSignposter
+        )
         let healthy = await api.health()
         managedServerRunning = serverController.isManagedServerRunning
         if healthy {
@@ -65,10 +73,13 @@ final class ServerStateController {
         } else if serverState != .starting || !managedServerRunning {
             serverState = managedServerRunning ? .starting : .offline
         }
+        Self.logger.info("server state refresh state=\(String(describing: self.serverState), privacy: .public) managed=\(self.managedServerRunning, privacy: .public)")
+        timed.finish(details: "state=\(String(describing: serverState)) managed=\(self.managedServerRunning)")
     }
 
     func startManagedServer() {
         guard serverState != .online else { return }
+        Self.logger.info("server state controller start managed server")
         serverController.start()
         managedServerRunning = serverController.isManagedServerRunning
         if managedServerRunning {
@@ -77,6 +88,7 @@ final class ServerStateController {
     }
 
     func stopManagedServer() {
+        Self.logger.info("server state controller stop managed server")
         serverController.stop()
         managedServerRunning = false
         Task {
@@ -87,6 +99,8 @@ final class ServerStateController {
 
 @MainActor
 final class EnvironmentOfferController {
+    private static let logger = RookLog.environment
+
     var onStateChange: (() -> Void)?
     var onWantsOfferView: (() -> Void)?
     var onDismissOfferView: (() -> Void)?
@@ -103,8 +117,10 @@ final class EnvironmentOfferController {
 
     func handleEnvironmentOffered(_ offer: EnvironmentOffer) {
         guard !pendingOffers.contains(where: { $0.bundleHash == offer.bundleHash }) else {
+            Self.logger.info("environment offer duplicate ignored bundleHash=\(offer.bundleHash, privacy: .public)")
             return
         }
+        Self.logger.info("environment offer queued environment=\(offer.environmentId, privacy: .public) bundleId=\(offer.bundleId, privacy: .public)")
         let wasEmpty = pendingOffers.isEmpty
         pendingOffers.append(offer)
         if wasEmpty {
@@ -114,6 +130,7 @@ final class EnvironmentOfferController {
     }
 
     func handleEnvironmentOfferResolved(bundleHash: String) {
+        Self.logger.info("environment offer resolved bundleHash=\(bundleHash, privacy: .public)")
         let removedHead = pendingOffer?.bundleHash == bundleHash
         pendingOffers.removeAll { $0.bundleHash == bundleHash }
         guard removedHead else { return }
@@ -122,6 +139,7 @@ final class EnvironmentOfferController {
 
     func decideEnvironment(_ decision: String) {
         guard let offer = pendingOffer else { return }
+        Self.logger.info("environment offer decision decision=\(decision, privacy: .public) environment=\(offer.environmentId, privacy: .public) bundleId=\(offer.bundleId, privacy: .public)")
         Task {
             do {
                 try await resolveOffer?(offer.environmentId, offer.bundleHash, decision)
@@ -167,6 +185,8 @@ final class EnvironmentOfferController {
 
 @MainActor
 final class EnvironmentListController {
+    private static let logger = RookLog.environment
+
     var onStateChange: (() -> Void)?
 
     private let api: RookAPI
@@ -190,6 +210,7 @@ final class EnvironmentListController {
 
     func refreshEnvironmentList(sessionId: String?, showLoading: Bool = true) {
         guard let sessionId else {
+            Self.logger.info("environment list refresh cleared no session")
             environmentListItems = []
             enteredEnvironmentIds = []
             return
@@ -198,14 +219,23 @@ final class EnvironmentListController {
             environmentsLoading = true
         }
         Task {
+            let timed = RookPerformance.begin(
+                "EnvironmentListRefresh",
+                operation: "environment-list-refresh",
+                description: "session=\(sessionId)",
+                logger: Self.logger,
+                signposter: RookLog.environmentSignposter
+            )
             defer { environmentsLoading = false }
             do {
                 let refreshedItems = try await api.environmentList(sessionId: sessionId)
                 EnvironmentListPresentation.apply(refreshedItems, to: &environmentListItems)
                 enteredEnvironmentIds = Set(refreshedItems.filter(\.entered).map(\.environmentId))
                 environmentsError = ""
+                timed.finish(details: "items=\(refreshedItems.count) entered=\(enteredEnvironmentIds.count)")
             } catch {
                 environmentsError = error.localizedDescription
+                timed.fail(error)
             }
         }
     }
@@ -231,6 +261,7 @@ final class EnvironmentListController {
 
     func joinEnvironment(sessionId: String?, environmentId: String) {
         guard let sessionId else { return }
+        Self.logger.info("environment list join session=\(sessionId, privacy: .public) environment=\(environmentId, privacy: .public)")
         Task {
             do {
                 let entered = try await api.enterEnvironment(sessionId: sessionId, environmentId: environmentId)
@@ -244,6 +275,7 @@ final class EnvironmentListController {
 
     func leaveEnvironment(sessionId: String?, environmentId: String) {
         guard let sessionId else { return }
+        Self.logger.info("environment list leave session=\(sessionId, privacy: .public) environment=\(environmentId, privacy: .public)")
         Task {
             do {
                 let entered = try await api.exitEnvironment(sessionId: sessionId, environmentId: environmentId)

--- a/clients/mac/Sources/Services/AXReader.swift
+++ b/clients/mac/Sources/Services/AXReader.swift
@@ -1,5 +1,6 @@
 import ApplicationServices
 import Foundation
+import RookKit
 
 /// Tier 1 perception: reading another app's focused-window title needs the
 /// Accessibility (AX) permission. App *identity* (NSWorkspace) does not — only
@@ -27,39 +28,76 @@ enum AXReader {
         guard isTrusted() else {
             return
         }
-        enableWebContentAccessibility(AXUIElementCreateApplication(pid))
+        RookPerformance.measure(
+            "AXPrimeAccessibility",
+            operation: "ax-prime-accessibility",
+            description: "pid=\(pid)",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 100,
+            hangThresholdMs: 500
+        ) {
+            enableWebContentAccessibility(AXUIElementCreateApplication(pid))
+        }
     }
 
     /// Title of the focused (or main) window of the app owning `pid`, or nil if
     /// AX isn't trusted / the app exposes no titled window.
     static func focusedWindowTitle(pid: pid_t) -> String? {
-        guard let window = focusedWindow(pid: pid) else {
-            return nil
+        RookPerformance.measure(
+            "AXFocusedWindowTitle",
+            operation: "ax-focused-window-title",
+            description: "pid=\(pid)",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 100,
+            hangThresholdMs: 500,
+            details: { title in
+                if let title {
+                    return "titleChars=\(title.count)"
+                }
+                return "title=nil"
+            }
+        ) {
+            guard let window = focusedWindow(pid: pid) else {
+                return nil
+            }
+            var titleRef: AnyObject?
+            guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success else {
+                return nil
+            }
+            let title = titleRef as? String
+            return (title?.isEmpty == false) ? title : nil
         }
-        var titleRef: AnyObject?
-        guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success else {
-            return nil
-        }
-        let title = titleRef as? String
-        return (title?.isEmpty == false) ? title : nil
     }
 
     /// Top-level window document-like values exposed via standard AX attributes
     /// such as AXDocument / AXFilename / AXURL.
     static func focusedWindowDocumentValues(pid: pid_t) -> [String] {
-        guard let window = focusedWindow(pid: pid) else {
-            return []
-        }
-        let attributes = ["AXDocument", "AXFilename", "AXURL"]
-        var results: [String] = []
-        for attribute in attributes {
-            if let value = stringAttribute(window, attribute)?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !value.isEmpty,
-               !results.contains(value) {
-                results.append(value)
+        RookPerformance.measure(
+            "AXFocusedWindowDocuments",
+            operation: "ax-focused-window-documents",
+            description: "pid=\(pid)",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 100,
+            hangThresholdMs: 500,
+            details: { values in "values=\(values.count)" }
+        ) {
+            guard let window = focusedWindow(pid: pid) else {
+                return []
             }
+            let attributes = ["AXDocument", "AXFilename", "AXURL"]
+            var results: [String] = []
+            for attribute in attributes {
+                if let value = stringAttribute(window, attribute)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !value.isEmpty,
+                   !results.contains(value) {
+                    results.append(value)
+                }
+            }
+            return results
         }
-        return results
     }
 
     private static func focusedWindow(pid: pid_t) -> AXUIElement? {
@@ -85,26 +123,37 @@ enum AXReader {
     /// the browser should have been primed (it comes forward → primeAccessibility).
     /// Returns nil for non-browsers or before the URL is exposed.
     static func activeTabURL(pid: pid_t, maxNodes: Int = 600) -> String? {
-        guard let window = focusedWindow(pid: pid) else {
+        RookPerformance.measure(
+            "AXActiveTabURL",
+            operation: "ax-active-tab-url",
+            description: "pid=\(pid) maxNodes=\(maxNodes)",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 150,
+            hangThresholdMs: 600,
+            details: { url in url == nil ? "url=nil" : "url=resolved" }
+        ) {
+            guard let window = focusedWindow(pid: pid) else {
+                return nil
+            }
+            // Breadth-first: the web area sits near the top of the window subtree.
+            var queue: [AXUIElement] = [window]
+            var budget = maxNodes
+            while !queue.isEmpty, budget > 0 {
+                let element = queue.removeFirst()
+                budget -= 1
+                if stringAttribute(element, kAXRoleAttribute as String) == "AXWebArea",
+                   let url = urlAttribute(element, "AXURL") {
+                    return url
+                }
+                var childrenRef: AnyObject?
+                if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+                   let children = childrenRef as? [AXUIElement] {
+                    queue.append(contentsOf: children)
+                }
+            }
             return nil
         }
-        // Breadth-first: the web area sits near the top of the window subtree.
-        var queue: [AXUIElement] = [window]
-        var budget = maxNodes
-        while !queue.isEmpty, budget > 0 {
-            let element = queue.removeFirst()
-            budget -= 1
-            if stringAttribute(element, kAXRoleAttribute as String) == "AXWebArea",
-               let url = urlAttribute(element, "AXURL") {
-                return url
-            }
-            var childrenRef: AnyObject?
-            if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
-               let children = childrenRef as? [AXUIElement] {
-                queue.append(contentsOf: children)
-            }
-        }
-        return nil
     }
 
     private static func urlAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
@@ -124,26 +173,37 @@ enum AXReader {
     /// text-based apps, using only the Accessibility grant (no screenshots).
     /// Node- and char-budgeted so a deep tree can't hang the caller.
     static func focusedWindowText(pid: pid_t, maxChars: Int = 12_000, maxNodes: Int = 6_000) -> String? {
-        guard isTrusted() else {
-            return nil
-        }
-        let appElement = AXUIElementCreateApplication(pid)
-        enableWebContentAccessibility(appElement)
-        var windowRef: AnyObject?
-        if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) != .success {
-            if AXUIElementCopyAttributeValue(appElement, kAXMainWindowAttribute as CFString, &windowRef) != .success {
+        RookPerformance.measure(
+            "AXFocusedWindowText",
+            operation: "ax-focused-window-text",
+            description: "pid=\(pid) maxChars=\(maxChars) maxNodes=\(maxNodes)",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 200,
+            hangThresholdMs: 750,
+            details: { text in "textChars=\(text?.count ?? 0)" }
+        ) {
+            guard isTrusted() else {
                 return nil
             }
+            let appElement = AXUIElementCreateApplication(pid)
+            enableWebContentAccessibility(appElement)
+            var windowRef: AnyObject?
+            if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) != .success {
+                if AXUIElementCopyAttributeValue(appElement, kAXMainWindowAttribute as CFString, &windowRef) != .success {
+                    return nil
+                }
+            }
+            guard let windowRef else {
+                return nil
+            }
+            var pieces: [String] = []
+            var nodeBudget = maxNodes
+            var charCount = 0
+            collectText(windowRef as! AXUIElement, into: &pieces, nodeBudget: &nodeBudget, charCount: &charCount, maxChars: maxChars)
+            let text = pieces.joined(separator: "\n")
+            return text.isEmpty ? nil : text
         }
-        guard let windowRef else {
-            return nil
-        }
-        var pieces: [String] = []
-        var nodeBudget = maxNodes
-        var charCount = 0
-        collectText(windowRef as! AXUIElement, into: &pieces, nodeBudget: &nodeBudget, charCount: &charCount, maxChars: maxChars)
-        let text = pieces.joined(separator: "\n")
-        return text.isEmpty ? nil : text
     }
 
     struct ActionableElement {
@@ -160,24 +220,35 @@ enum AXReader {
     /// reads this list and picks one to click — no screenshot/vision needed.
     /// Coordinates are global top-left screen space, matching CGEvent input.
     static func actionableElements(pid: pid_t, maxElements: Int = 250, maxNodes: Int = 8_000) -> [ActionableElement]? {
-        guard isTrusted() else {
-            return nil
-        }
-        let appElement = AXUIElementCreateApplication(pid)
-        enableWebContentAccessibility(appElement)
-        var windowRef: AnyObject?
-        if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) != .success {
-            if AXUIElementCopyAttributeValue(appElement, kAXMainWindowAttribute as CFString, &windowRef) != .success {
+        RookPerformance.measure(
+            "AXActionableElements",
+            operation: "ax-actionable-elements",
+            description: "pid=\(pid) maxElements=\(maxElements) maxNodes=\(maxNodes)",
+            logger: RookLog.environment,
+            signposter: RookLog.environmentSignposter,
+            slowThresholdMs: 200,
+            hangThresholdMs: 750,
+            details: { elements in "elements=\(elements?.count ?? 0)" }
+        ) {
+            guard isTrusted() else {
                 return nil
             }
+            let appElement = AXUIElementCreateApplication(pid)
+            enableWebContentAccessibility(appElement)
+            var windowRef: AnyObject?
+            if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) != .success {
+                if AXUIElementCopyAttributeValue(appElement, kAXMainWindowAttribute as CFString, &windowRef) != .success {
+                    return nil
+                }
+            }
+            guard let windowRef else {
+                return nil
+            }
+            var elements: [ActionableElement] = []
+            var nodeBudget = maxNodes
+            collectActionable(windowRef as! AXUIElement, into: &elements, max: maxElements, nodeBudget: &nodeBudget)
+            return elements
         }
-        guard let windowRef else {
-            return nil
-        }
-        var elements: [ActionableElement] = []
-        var nodeBudget = maxNodes
-        collectActionable(windowRef as! AXUIElement, into: &elements, max: maxElements, nodeBudget: &nodeBudget)
-        return elements
     }
 
     private static let actionableRoles: Set<String> = [

--- a/clients/mac/Sources/Services/ForegroundAppMonitor.swift
+++ b/clients/mac/Sources/Services/ForegroundAppMonitor.swift
@@ -12,6 +12,11 @@ func providerWarning(_ message: String) {
     providerLogger.warning("\(message, privacy: .public)")
 }
 
+func providerDebug(_ message: String) {
+    guard RookLog.verboseEnabled else { return }
+    providerLogger.debug("\(message, privacy: .public)")
+}
+
 func providerError(_ message: String) {
     providerLogger.error("\(message, privacy: .public)")
 }
@@ -132,7 +137,7 @@ final class ForegroundAppMonitor {
     private func emitContext(for app: ForegroundApp) {
         let title = AXReader.focusedWindowTitle(pid: app.pid)
         currentTitle = title
-        providerInfo("context refresh bundleId=\(app.bundleId) title=\(title ?? "(null)")")
+        providerDebug("context refresh bundleId=\(app.bundleId) title=\(title ?? "(null)")")
         onContextRefresh?(app, title)
     }
 

--- a/clients/mac/Sources/Services/ForegroundAppMonitor.swift
+++ b/clients/mac/Sources/Services/ForegroundAppMonitor.swift
@@ -1,18 +1,19 @@
 import AppKit
 import Foundation
+import RookKit
 
-/// Lightweight debug trace for the foreground-provider path; tail
-/// /tmp/rook.log while testing.
-func providerLog(_ message: String) {
-    let line = "\(Date()) \(message)\n"
-    let url = URL(fileURLWithPath: "/tmp/rook.log")
-    if let handle = try? FileHandle(forWritingTo: url) {
-        handle.seekToEndOfFile()
-        handle.write(Data(line.utf8))
-        try? handle.close()
-    } else {
-        try? Data(line.utf8).write(to: url)
-    }
+private let providerLogger = RookLog.environment
+
+func providerInfo(_ message: String) {
+    providerLogger.info("\(message, privacy: .public)")
+}
+
+func providerWarning(_ message: String) {
+    providerLogger.warning("\(message, privacy: .public)")
+}
+
+func providerError(_ message: String) {
+    providerLogger.error("\(message, privacy: .public)")
 }
 
 struct ForegroundApp: Equatable {
@@ -103,7 +104,7 @@ final class ForegroundAppMonitor {
     }
 
     private func handleActivation(_ app: ForegroundApp) {
-        providerLog("activation: \(app.name) [\(app.bundleId)]")
+        providerInfo("activation app=\(app.name) bundleId=\(app.bundleId) pid=\(app.pid)")
         // Our own panel/window gaining focus must not end the current episode.
         if app.bundleId == Bundle.main.bundleIdentifier {
             return
@@ -123,6 +124,7 @@ final class ForegroundAppMonitor {
 
     private func commit(_ app: ForegroundApp) {
         current = app
+        providerInfo("commit foreground app=\(app.name) bundleId=\(app.bundleId)")
         onForegroundChange?(app)
         emitContext(for: app)
     }
@@ -130,6 +132,7 @@ final class ForegroundAppMonitor {
     private func emitContext(for app: ForegroundApp) {
         let title = AXReader.focusedWindowTitle(pid: app.pid)
         currentTitle = title
+        providerInfo("context refresh bundleId=\(app.bundleId) title=\(title ?? "(null)")")
         onContextRefresh?(app, title)
     }
 

--- a/clients/mac/Sources/Services/MacBridge.swift
+++ b/clients/mac/Sources/Services/MacBridge.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Network
+import RookKit
 
 /// Tier 2 action bridge: a loopback HTTP server the agent's shell tool can
 /// `curl` to perceive and drive the Mac. Routes:
@@ -61,15 +62,15 @@ final class MacBridge {
             listener.stateUpdateHandler = { [weak self] state in
                 if case .ready = state {
                     self?.port = port
-                    providerLog("bridge listening on 127.0.0.1:\(port)")
+                    providerInfo("bridge listening host=127.0.0.1 port=\(port)")
                 } else if case .failed(let error) = state {
-                    providerLog("bridge failed: \(error.localizedDescription)")
+                    providerError("bridge failed error=\(error.localizedDescription)")
                 }
             }
             listener.start(queue: queue)
             self.listener = listener
         } catch {
-            providerLog("bridge could not start on \(port): \(error.localizedDescription)")
+            providerError("bridge could not start port=\(port) error=\(error.localizedDescription)")
         }
     }
 
@@ -158,9 +159,19 @@ final class MacBridge {
 
     private func route(_ request: ParsedRequest) -> Data {
         let path = request.path.components(separatedBy: "?").first ?? request.path
+        let timed = RookPerformance.begin(
+            "MacBridgeRoute",
+            operation: "mac-bridge-route",
+            description: "\(request.method) \(path)",
+            logger: RookLog.bridge,
+            signposter: RookLog.bridgeSignposter,
+            slowThresholdMs: 100,
+            hangThresholdMs: 500
+        )
 
         // Liveness check — unauthenticated, leaks nothing sensitive.
         if request.method == "GET", path == "/health" {
+            timed.finish(details: "status=200")
             return response(body: jsonData(["ok": true, "service": "mac-bridge"]))
         }
 
@@ -168,15 +179,18 @@ final class MacBridge {
         // the Host header, not 127.0.0.1:<port>.
         let allowedHosts: Set<String> = ["127.0.0.1:\(port)", "localhost:\(port)"]
         guard let host = request.headers["host"], allowedHosts.contains(host) else {
+            timed.finish(details: "status=403 bad-host")
             return response(status: "403 Forbidden", body: jsonData(["error": "bad host"]))
         }
         // Browsers attach Origin to cross-origin requests; a legitimate local
         // client (curl from the agent's shell) does not.
         if request.headers["origin"] != nil {
+            timed.finish(details: "status=403 origin-not-allowed")
             return response(status: "403 Forbidden", body: jsonData(["error": "origin not allowed"]))
         }
         // Bearer token gates everything else.
         guard Self.constantTimeEquals(request.headers["authorization"], "Bearer \(token)") else {
+            timed.finish(details: "status=401 unauthorized")
             return response(status: "401 Unauthorized", body: jsonData(["error": "unauthorized"]))
         }
 
@@ -185,24 +199,30 @@ final class MacBridge {
             lock.lock()
             let data = contextJSON
             lock.unlock()
+            timed.finish(details: "status=200 bytes=\(data.count)")
             return response(body: data)
 
         case ("GET", "/window-text"):
             let text = readWindowText?() ?? nil
+            timed.finish(details: "status=200 ok=\(text != nil)")
             return response(body: jsonData(["ok": text != nil, "text": text ?? ""]))
 
         case ("GET", "/screen-text"):
             let text = readScreenText?() ?? nil
+            timed.finish(details: "status=200 ok=\(text != nil)")
             return response(body: jsonData(["ok": text != nil, "text": text ?? ""]))
 
         case ("GET", "/ax-elements"):
             let elements = readAxElements?() ?? nil
+            timed.finish(details: "status=200 ok=\(elements != nil) elements=\(elements?.count ?? 0)")
             return response(body: jsonData(["ok": elements != nil, "elements": elements ?? []]))
 
         case ("GET", "/screenshot"):
             guard let capture = captureScreenshot?() ?? nil else {
+                timed.finish(details: "status=403 screenshot-denied")
                 return response(status: "403 Forbidden", body: jsonData(["ok": false, "error": "screen recording not permitted"]))
             }
+            timed.finish(details: "status=200 screenshot")
             return response(body: jsonData(capture))
 
         case ("POST", "/input"):
@@ -210,29 +230,37 @@ final class MacBridge {
             let enabled = controlEnabled
             lock.unlock()
             guard enabled else {
+                timed.finish(details: "status=403 input-disabled")
                 return response(status: "403 Forbidden", body: jsonData(["ok": false, "error": "computer control disabled — enable it in the menu bar app"]))
             }
             guard let object = try? JSONSerialization.jsonObject(with: request.body) as? [String: Any] else {
+                timed.finish(details: "status=400 invalid-json")
                 return response(status: "400 Bad Request", body: jsonData(["ok": false, "error": "invalid JSON"]))
             }
             let result = performInput?(object) ?? (ok: false, output: "input handler not ready")
+            timed.finish(details: "status=200 ok=\(result.ok)")
             return response(body: jsonData(["ok": result.ok, "output": result.output]))
 
         case ("POST", "/applescript"):
             guard let script = stringField("script", in: request.body) else {
+                timed.finish(details: "status=400 missing-script")
                 return response(status: "400 Bad Request", body: jsonData(["error": "missing 'script'"]))
             }
             let result = runAppleScript?(script) ?? (ok: false, output: "bridge action handler not ready")
+            timed.finish(details: "status=200 ok=\(result.ok)")
             return response(body: jsonData(["ok": result.ok, "output": result.output]))
 
         case ("POST", "/open-url"):
             guard let url = stringField("url", in: request.body) else {
+                timed.finish(details: "status=400 missing-url")
                 return response(status: "400 Bad Request", body: jsonData(["error": "missing 'url'"]))
             }
             let ok = openURL?(url) ?? false
+            timed.finish(details: "status=200 ok=\(ok)")
             return response(body: jsonData(["ok": ok]))
 
         default:
+            timed.finish(details: "status=404")
             return response(status: "404 Not Found", body: jsonData(["error": "unknown route"]))
         }
     }

--- a/clients/mac/Sources/Services/ServerController.swift
+++ b/clients/mac/Sources/Services/ServerController.swift
@@ -1,9 +1,12 @@
 import Foundation
+import RookKit
 
 /// Launches and supervises a dev Rook server (`npm run dev`) for the
 /// rookery repo when one isn't already running.
 @MainActor
 final class ServerController {
+    private static let logger = RookLog.server
+
     var onTermination: (() -> Void)?
 
     private(set) var isManagedServerRunning = false
@@ -41,8 +44,18 @@ final class ServerController {
 
     func start() {
         guard process == nil else {
+            Self.logger.info("managed server start skipped existing process")
             return
         }
+        let timed = RookPerformance.begin(
+            "ManagedServerStart",
+            operation: "managed-server-start",
+            description: Self.repoRoot.path,
+            logger: Self.logger,
+            signposter: RookLog.serverSignposter,
+            slowThresholdMs: 250,
+            hangThresholdMs: 1_000
+        )
         let logURL = Self.logFileURL
         try? FileManager.default.createDirectory(
             at: logURL.deletingLastPathComponent(),
@@ -59,11 +72,12 @@ final class ServerController {
             process.standardOutput = logHandle
             process.standardError = logHandle
         }
-        process.terminationHandler = { [weak self] _ in
+        process.terminationHandler = { [weak self] process in
             Task { @MainActor in
                 guard let self else {
                     return
                 }
+                Self.logger.info("managed server terminated pid=\(process.processIdentifier, privacy: .public) status=\(process.terminationStatus, privacy: .public)")
                 self.process = nil
                 self.isManagedServerRunning = false
                 self.onTermination?()
@@ -73,13 +87,18 @@ final class ServerController {
             try process.run()
             self.process = process
             isManagedServerRunning = true
+            Self.logger.info("managed server started pid=\(process.processIdentifier, privacy: .public) log=\(logURL.path, privacy: .public)")
+            timed.finish(details: "pid=\(process.processIdentifier)")
         } catch {
             try? logHandle?.write(contentsOf: Data("Failed to launch server: \(error)\n".utf8))
+            Self.logger.error("managed server start failed error=\(error.localizedDescription, privacy: .public)")
+            timed.fail(error)
             isManagedServerRunning = false
         }
     }
 
     func stop() {
+        Self.logger.info("managed server stop pid=\(self.process?.processIdentifier ?? 0, privacy: .public)")
         process?.terminate()
         process = nil
         isManagedServerRunning = false

--- a/clients/mac/Sources/Views/LogViewerView.swift
+++ b/clients/mac/Sources/Views/LogViewerView.swift
@@ -1,34 +1,44 @@
 import SwiftUI
+import RookKit
 
-/// A floating window that tails `/tmp/rook.log` live.
+/// A floating window that shows the unified Apple-client log stream.
 struct LogViewerView: View {
     @State private var lines: [String] = []
-    @State private var timer: Timer?
-    @State private var lastSize: UInt64 = 0
-    private let logURL = URL(fileURLWithPath: "/tmp/rook.log")
+    @State private var streamProcess: Process?
+    @State private var loading = false
+
+    private let predicate = "subsystem == \"\(RookLog.subsystem)\""
+    private let serverLogPath = ServerController.logFileURL.path
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
-            HStack {
-                Label("Rook Log", systemImage: "doc.text.magnifyingglass")
-                    .font(.headline)
-                    .foregroundStyle(.primary)
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Label("Rook Unified Log", systemImage: "doc.text.magnifyingglass")
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text("Subsystem: \(RookLog.subsystem) • Managed server log: \(serverLogPath)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
                 Spacer()
+                if loading {
+                    ProgressView()
+                        .controlSize(.small)
+                }
                 Text("\(lines.count) lines")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .monospacedDigit()
                 Button {
-                    lines = []
-                    lastSize = 0
-                    readLog()
+                    reloadLogs()
                 } label: {
                     Image(systemName: "arrow.clockwise")
                         .font(.system(size: 11, weight: .semibold))
                 }
                 .buttonStyle(.plain)
-                .help("Clear and re-read")
+                .help("Reload recent logs and restart live stream")
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
@@ -36,7 +46,6 @@ struct LogViewerView: View {
 
             Divider()
 
-            // Log content
             ScrollViewReader { proxy in
                 ScrollView(.vertical) {
                     LazyVStack(alignment: .leading, spacing: 1) {
@@ -62,62 +71,124 @@ struct LogViewerView: View {
             }
             .background(Color.black.opacity(0.92))
         }
-        .frame(minWidth: 560, minHeight: 320)
+        .frame(minWidth: 760, minHeight: 420)
         .onAppear {
-            readLog()
-            timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
-                readLog()
-            }
+            reloadLogs()
         }
         .onDisappear {
-            timer?.invalidate()
-            timer = nil
+            stopStreaming()
         }
     }
 
-    private func readLog() {
-        guard let handle = try? FileHandle(forReadingFrom: logURL) else {
-            if lines.isEmpty {
-                lines = ["(log file not found at \(logURL.path))"]
+    private func reloadLogs() {
+        loading = true
+        stopStreaming()
+        Task {
+            let recent = await Task.detached(priority: .userInitiated) {
+                Self.loadRecentLines(predicate: predicate, serverLogPath: serverLogPath)
+            }.value
+            await MainActor.run {
+                lines = recent
+                loading = false
+                startStreaming()
             }
-            return
         }
-        defer { try? handle.close() }
+    }
 
-        let currentSize = (try? handle.seekToEnd()) ?? 0
-        if currentSize == lastSize { return }
-
-        if currentSize < lastSize {
-            // File was truncated — re-read from scratch.
-            lines = []
+    private func startStreaming() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+        process.arguments = ["stream", "--style", "compact", "--level", "debug", "--predicate", predicate]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        pipe.fileHandleForReading.readabilityHandler = { handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else {
+                return
+            }
+            let newLines = text.components(separatedBy: .newlines).filter { !$0.isEmpty }
+            guard !newLines.isEmpty else { return }
+            Task { @MainActor in
+                appendLines(newLines)
+            }
         }
+        process.terminationHandler = { _ in
+            pipe.fileHandleForReading.readabilityHandler = nil
+        }
+        do {
+            try process.run()
+            streamProcess = process
+        } catch {
+            appendLines(["(failed to start log stream: \(error.localizedDescription))"])
+        }
+    }
 
-        // Only read the new tail; keep the most recent ~3000 lines.
-        let bytesToRead = min(currentSize - lastSize, 256 * 1024)
-        guard bytesToRead > 0 else { return }
-        try? handle.seek(toOffset: max(currentSize - bytesToRead, 0))
+    private func stopStreaming() {
+        streamProcess?.terminate()
+        streamProcess = nil
+    }
 
-        let data = handle.readData(ofLength: Int(bytesToRead))
-        guard let text = String(data: data, encoding: .utf8) else { return }
+    private nonisolated static func loadRecentLines(predicate: String, serverLogPath: String) -> [String] {
+        let unified = runProcess(executable: "/usr/bin/log", arguments: ["show", "--last", "10m", "--style", "compact", "--predicate", predicate])
+            .components(separatedBy: .newlines)
+            .filter { !$0.isEmpty }
+        let server = loadServerLogTail(path: serverLogPath)
+        var result: [String] = []
+        if !server.isEmpty {
+            result.append("━━ managed server log tail (\(serverLogPath)) ━━")
+            result.append(contentsOf: server)
+            result.append("━━ unified log tail (subsystem \(RookLog.subsystem)) ━━")
+        }
+        result.append(contentsOf: unified)
+        if result.isEmpty {
+            result = ["(no recent logs found for subsystem \(RookLog.subsystem))"]
+        }
+        return Array(result.suffix(3000))
+    }
 
-        let newLines = text.components(separatedBy: "\n").filter { !$0.isEmpty }
+    private nonisolated static func loadServerLogTail(path: String, maxLines: Int = 200) -> [String] {
+        guard let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
+            return []
+        }
+        return Array(contents.components(separatedBy: .newlines).filter { !$0.isEmpty }.suffix(maxLines))
+    }
+
+    private nonisolated static func runProcess(executable: String, arguments: [String]) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return "(failed to run \(executable): \(error.localizedDescription))"
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    @MainActor
+    private func appendLines(_ newLines: [String]) {
         lines.append(contentsOf: newLines)
-        // Trim head so we don't grow unbounded.
         if lines.count > 3000 {
             lines.removeFirst(lines.count - 3000)
         }
-        lastSize = currentSize
     }
 
     private func lineColor(for line: String) -> Color {
-        if line.contains("[ERROR]") || line.contains("error") {
+        let lowercased = line.lowercased()
+        if lowercased.contains("error") || lowercased.contains("fault") {
             return .red.opacity(0.9)
         }
-        if line.contains("[RAW-CONTEXT]") {
-            return Color.cyan.opacity(0.85)
-        }
-        if line.contains("[WARN]") || line.contains("failed") {
+        if lowercased.contains("warning") || lowercased.contains("failed") {
             return .yellow.opacity(0.85)
+        }
+        if lowercased.contains("managed server log tail") || lowercased.contains("unified log tail") {
+            return .cyan.opacity(0.85)
         }
         return .white.opacity(0.75)
     }

--- a/scripts/lib/run-rook/common.sh
+++ b/scripts/lib/run-rook/common.sh
@@ -412,6 +412,9 @@ open_mac_app_bundle() {
   if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
     launchctl setenv ROOK_AUTH_TOKEN "$SERVER_AUTH_TOKEN"
   fi
+  if [[ -n "${ROOK_VERBOSE_LOGGING:-}" ]]; then
+    launchctl setenv ROOK_VERBOSE_LOGGING "$ROOK_VERBOSE_LOGGING"
+  fi
   launchctl setenv ROOK_SERVER_BASE_URL "http://127.0.0.1:${SERVER_PORT}"
   launchctl setenv ROOK_RUN_MODE "$RUN_ROOK_PROFILE"
   launchctl setenv ROOK_HOME "$ROOK_HOME"
@@ -433,6 +436,9 @@ open_mac_app_bundle() {
   if [[ -n "$SERVER_AUTH_TOKEN" ]]; then
     launchctl unsetenv ROOK_AUTH_TOKEN
   fi
+  if [[ -n "${ROOK_VERBOSE_LOGGING:-}" ]]; then
+    launchctl unsetenv ROOK_VERBOSE_LOGGING
+  fi
   activate_mac_app "$app_path"
 }
 
@@ -442,6 +448,12 @@ ios_launch_env_json() {
     launch_env="{\"ROOK_AUTH_TOKEN\":$(json_escape "$SERVER_AUTH_TOKEN")"
   else
     launch_env="{"
+  fi
+  if [[ "${ROOK_VERBOSE_LOGGING:-0}" == "1" ]]; then
+    if [[ "$launch_env" != "{" ]]; then
+      launch_env+=","
+    fi
+    launch_env+='"ROOK_VERBOSE_LOGGING":"1"'
   fi
   if [[ -n "$SIMULATE_ARRIVAL" ]]; then
     log "simulating arrival at $SIMULATE_ARRIVAL (DEBUG ROOK_SIMULATE_ARRIVAL)"
@@ -601,6 +613,7 @@ build_ios_simulator_app() {
   log "launching Rook on simulator $sim_name with ROOK_SERVER_BASE_URL=$sim_url"
   SIMCTL_CHILD_ROOK_SERVER_BASE_URL="$sim_url" \
   SIMCTL_CHILD_ROOK_AUTH_TOKEN="${SERVER_AUTH_TOKEN:-}" \
+  SIMCTL_CHILD_ROOK_VERBOSE_LOGGING="${ROOK_VERBOSE_LOGGING:-0}" \
   SIMCTL_CHILD_ROOK_SIMULATE_ARRIVAL="${SIMULATE_ARRIVAL:-}" \
   xcrun simctl launch --terminate-running-process "$sim_udid" "$DEFAULT_IOS_APP_BUNDLE_ID" >/dev/null
 


### PR DESCRIPTION
## What changed

- Standardizes Mac, iPhone, and shared RookKit client logging on the `com.rookery.Rook` Unified Logging subsystem with stable categories.
- Adds elapsed-time logging and signposts around Accessibility, Finder, bridge, server, REST, WebSocket, session, voice, and location flows.
- Replaces the Mac temporary-file log viewer with a Unified Log viewer while retaining the managed server-log tail.
- Keeps fast polling details at debug level and adds opt-in `ROOK_VERBOSE_LOGGING=1` for raw foreground context during diagnostics.

## Why it matters

Beachballs and client stalls now have one searchable source of truth across the Apple clients. Slow Accessibility and networking operations are visible with elapsed milliseconds and Instruments signposts, while normal operation stays quieter and raw window/document/URL context is not logged unless explicitly requested.

## Notes for reviewers

- No server source changes are included; the server is only used for client validation.
- The current diagnostic thresholds are 100 ms for warnings and 500 ms for errors.
- No backward-compatibility surfaces were found: this adds internal observability and does not change public REST/WebSocket payloads, session behavior, or persisted data. The old `/tmp/rook.log` path was an internal debugging implementation and is replaced by Unified Logging.

## Product specification alignment

**Classification:** Extends

**Related PRODUCT/ docs:**
- [`PRODUCT/goals-of-rook.md`](https://github.com/rookkeeper/rook/blob/apple-client-logging/PRODUCT/goals-of-rook.md) — supports the product goal that Rook remain transparent and inspectable.

**Documentation updates in this PR:**
- No PRODUCT/ updates — this is internal client observability and does not introduce a new product concept or change the product contract.

**Notes:** The Mac log viewer and documented Console workflow make client behavior more inspectable without changing environment, session, or capability semantics.

## Architecture alignment

**Classification:** Extends

**Related docs / patterns:**
- [`AS-BUILT-ARCHITECTURE/rookkit.md`](https://github.com/rookkeeper/rook/blob/apple-client-logging/AS-BUILT-ARCHITECTURE/rookkit.md) — documents shared RookKit logging and performance instrumentation.
- [`AS-BUILT-ARCHITECTURE/mac-client.md`](https://github.com/rookkeeper/rook/blob/apple-client-logging/AS-BUILT-ARCHITECTURE/mac-client.md) — documents Mac diagnostics, thresholds, and verbose context mode.
- [`AS-BUILT-ARCHITECTURE/iphone-client.md`](https://github.com/rookkeeper/rook/blob/apple-client-logging/AS-BUILT-ARCHITECTURE/iphone-client.md) — documents iPhone/shared-client logging coverage.

**Documentation updates in this PR:**
- [`AS-BUILT-ARCHITECTURE/rookkit.md`](https://github.com/rookkeeper/rook/blob/apple-client-logging/AS-BUILT-ARCHITECTURE/rookkit.md) — logging and severity policy.
- [`AS-BUILT-ARCHITECTURE/mac-client.md`](https://github.com/rookkeeper/rook/blob/apple-client-logging/AS-BUILT-ARCHITECTURE/mac-client.md) — Unified Logging and verbose diagnostics.
- [`AS-BUILT-ARCHITECTURE/iphone-client.md`](https://github.com/rookkeeper/rook/blob/apple-client-logging/AS-BUILT-ARCHITECTURE/iphone-client.md) — client logging coverage.

**Notes:** Logging remains in the shared client layer and platform services; no server boundary or protocol shape changes.

## New tests

- Adds RookKit logging/performance severity coverage.
- Existing RookKit and Mac test suites pass.
- Launcher profile/lifecycle tests pass.

## Technical touchpoints

- **Components:** `RookLog`, `RookPerformance`, `RookTimedOperation`, Mac `AXReader`/providers/bridge/server supervision, shared REST/WebSocket/session services, iPhone model/location/voice flows.
- **APIs / protocols:** Apple Unified Logging and `OSSignposter`; no Rook REST/WebSocket protocol changes.
- **Data / events:** No persisted data or event schema changes.

## How to check it

- [x] `swift test` in `clients/RookKit`.
- [x] Mac `xcodebuild ... test`.
- [x] iPhone simulator app build.
- [x] `npm run test:launcher`.
- [ ] Reproduce a beachball while watching `log stream --predicate 'subsystem == "com.rookery.Rook"'` and collect `sample Rook 10 -file ~/Desktop/rook-sample.txt`.
