### PR TITLE
Prevent cross-Rook Accessibility beachballs

### DIFF
--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -130,7 +130,7 @@ Via `RookKit`:
 10. `DiscordEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits server plus channel environments when Discord exposes a `channel | server - Discord` title
 11. `FinderEnvironmentProvider` polls every 5 seconds, uses Finder AppleScript to inspect open Finder windows, and emits `dir:/...` environments for browsed folders while setting the frontmost Finder folder as the current app environment when available
 12. `BrowserEnvironmentProvider` handles Safari (`com.apple.Safari`) and Firefox (`org.mozilla.firefox`) only, walking the focused window's `AXWebArea` for the active page URL and emitting a host-level `web:` environment; generic and Electron paths do not perform this walk
-13. Environment-path AX calls apply a 500 ms messaging timeout, log slow operation metadata without content, and bound browser-tree traversal at 2 seconds; broader off-main-actor AX execution remains under investigation
+13. Environment-path AX calls apply a 500 ms messaging timeout, log slow operation metadata without content, bound browser-tree traversal at 2 seconds, and run title/document/browser reads off the main actor; bridge text/action perception remains a separate path
 14. `EnvironmentRegistrationController` suppresses duplicate emissions of the same environment id for 1 minute
 15. server may respond with environment offers, which the client presents natively
 

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -64,7 +64,7 @@ The client derives and registers:
 - exact `dir:/absolute/path` environments from Finder specialist detection of browsed folders
 - `mac:<bundleId>/_plugin/<plugin-id>` for app-specific plugin capabilities such as enabled Obsidian community plugins
 - meaningful `dir:/absolute/path` project-like or agentic directory environments derived from generic Accessibility document signals
-- hierarchical `web:<host>` and `web:<host>/<path...>` IDs from generic Accessibility web/document signals
+- hierarchical `web:<host>` and `web:<host>/<path...>` IDs from top-level generic Accessibility document signals and browser-specialist nested web-area signals
 
 ## Core data schemas
 
@@ -121,16 +121,17 @@ Via `RookKit`:
 1. `ForegroundAppMonitor` detects app activation or window-title change
 2. `AppEnvironmentProvider` always emits the base `mac:<bundleId>` app environment after a short dwell delay
 3. `AppEnvironmentProvider` activates either a bundle-id-specific specialist or the generic fallback provider
-4. `GenericEnvironmentProvider` polls every 5 seconds while active, reads Accessibility document and web signals, inspects observed paths under `/Users/<username>`, and emits only project-like / agentic `dir:` candidates plus `web:` candidates when the normalized environment-id set is stable across two polls
-5. Specialist providers are selected by bundle-id from an explicit registry and currently include Obsidian, Slack, OBS Studio, Descript, Discord, and Finder
+4. `GenericEnvironmentProvider` polls every 5 seconds while active, reads only focused-window Accessibility document values, inspects observed paths under `/Users/<username>`, and emits only project-like / agentic `dir:` candidates plus top-level-document `web:` candidates when the normalized environment-id set is stable across two polls
+5. Specialist providers are selected by bundle-id from an explicit registry and currently include Safari/Firefox browser URL detection, Obsidian, Slack, OBS Studio, Descript, Discord, and Finder
 6. `ObsidianEnvironmentProvider` polls local data every 5 seconds, reads `~/Library/Application Support/obsidian/obsidian.json`, emits open vault environments, and emits enabled community-plugin environments
 7. `SlackEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits workspace plus channel environments when the title exposes a stable channel context
 8. `OBSStudioEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits scene-collection environments with profile/collection metadata when available
 9. `DescriptEnvironmentProvider` polls every 5 seconds, parses the focused window title, reads `~/Library/Application Support/Descript/config.json`, and emits project environments with route/project metadata when available
 10. `DiscordEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits server plus channel environments when Discord exposes a `channel | server - Discord` title
 11. `FinderEnvironmentProvider` polls every 5 seconds, uses Finder AppleScript to inspect open Finder windows, and emits `dir:/...` environments for browsed folders while setting the frontmost Finder folder as the current app environment when available
-12. `EnvironmentRegistrationController` suppresses duplicate emissions of the same environment id for 1 minute
-13. server may respond with environment offers, which the client presents natively
+12. `BrowserEnvironmentProvider` handles Safari (`com.apple.Safari`) and Firefox (`org.mozilla.firefox`) only, walking the focused window's `AXWebArea` for the active page URL and emitting a host-level `web:` environment; generic and Electron paths do not perform this walk
+13. `EnvironmentRegistrationController` suppresses duplicate emissions of the same environment id for 1 minute
+14. server may respond with environment offers, which the client presents natively
 
 ### Environment approval
 1. server emits `_com.rookkeeper/environment_offer`

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -130,8 +130,9 @@ Via `RookKit`:
 10. `DiscordEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits server plus channel environments when Discord exposes a `channel | server - Discord` title
 11. `FinderEnvironmentProvider` polls every 5 seconds, uses Finder AppleScript to inspect open Finder windows, and emits `dir:/...` environments for browsed folders while setting the frontmost Finder folder as the current app environment when available
 12. `BrowserEnvironmentProvider` handles Safari (`com.apple.Safari`) and Firefox (`org.mozilla.firefox`) only, walking the focused window's `AXWebArea` for the active page URL and emitting a host-level `web:` environment; generic and Electron paths do not perform this walk
-13. `EnvironmentRegistrationController` suppresses duplicate emissions of the same environment id for 1 minute
-14. server may respond with environment offers, which the client presents natively
+13. Environment-path AX calls apply a 500 ms messaging timeout, log slow operation metadata without content, and bound browser-tree traversal at 2 seconds; broader off-main-actor AX execution remains under investigation
+14. `EnvironmentRegistrationController` suppresses duplicate emissions of the same environment id for 1 minute
+15. server may respond with environment offers, which the client presents natively
 
 ### Environment approval
 1. server emits `_com.rookkeeper/environment_offer`

--- a/AS-BUILT-ARCHITECTURE/mac-client.md
+++ b/AS-BUILT-ARCHITECTURE/mac-client.md
@@ -118,11 +118,11 @@ Via `RookKit`:
 10. queued messages, including image attachments, are delivered automatically once the agent goes idle
 
 ### Foreground environment detection
-1. `ForegroundAppMonitor` detects app activation or window-title change
+1. `ForegroundAppMonitor` detects app activation or window-title change, but ignores all internal Rook bundle identities (`com.rookery.Rook` and `com.rookery.Rook.Dev.*`); when Rook becomes frontmost it clears the active external target and provider
 2. `AppEnvironmentProvider` always emits the base `mac:<bundleId>` app environment after a short dwell delay
 3. `AppEnvironmentProvider` activates either a bundle-id-specific specialist or the generic fallback provider
 4. `GenericEnvironmentProvider` polls every 5 seconds while active, reads only focused-window Accessibility document values, inspects observed paths under `/Users/<username>`, and emits only project-like / agentic `dir:` candidates plus top-level-document `web:` candidates when the normalized environment-id set is stable across two polls
-5. Specialist providers are selected by bundle-id from an explicit registry and currently include Safari/Firefox browser URL detection, Obsidian, Slack, OBS Studio, Descript, Discord, and Finder
+5. Specialist providers are selected by bundle-id from an explicit registry and currently include Safari/Firefox browser URL detection, Obsidian, Slack, OBS Studio, Descript, Discord, and Finder; internal Rook bundle IDs never reach either the specialist registry or generic fallback
 6. `ObsidianEnvironmentProvider` polls local data every 5 seconds, reads `~/Library/Application Support/obsidian/obsidian.json`, emits open vault environments, and emits enabled community-plugin environments
 7. `SlackEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits workspace plus channel environments when the title exposes a stable channel context
 8. `OBSStudioEnvironmentProvider` polls every 5 seconds, parses the focused window title, and emits scene-collection environments with profile/collection metadata when available

--- a/CHANGES/2026-08-10-apple-client-logging/OUTCOMES.md
+++ b/CHANGES/2026-08-10-apple-client-logging/OUTCOMES.md
@@ -1,0 +1,9 @@
+# Apple client logging overhaul
+
+Status: complete.
+
+The Mac and iPhone clients now use the shared RookKit unified-logging and performance helpers instead of mixing ad-hoc logging styles. Beachball-adjacent Mac paths, shared session/network code, and iPhone session/location flows emit structured operational diagnostics with quieter default verbosity and optional verbose context logging.
+
+The Mac log viewer and Apple-client documentation now describe the authoritative unified-log workflow. Focused Apple-client tests and builds pass. The existing stale iPhone `ArrivalGateTests` target references old `RookModel` APIs and remains a pre-existing test-target issue, recorded in the working TODO.
+
+This work intentionally changes no server logging, protocol, database, or product environment model. The logging foundation enabled the follow-up Mac stall investigation documented in `CHANGES/2026-08-11-mac-client-stall-investigation/`.

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/OUTCOMES.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/OUTCOMES.md
@@ -1,0 +1,19 @@
+# Mac client stall investigation
+
+Status: complete for the observed cross-Rook beachball failure.
+
+The strongest evidence was a roughly 41-second `activeTabURL` Accessibility lookup from one Rook process into another Rook process. Generic perception was treating an internal Rook window like an external browser and synchronously walking an AX tree that could not contain a useful browser URL.
+
+The mitigation is now in place:
+
+- production and development Rook bundle IDs are excluded from foreground environment inspection;
+- the active external provider is stopped when an internal Rook window becomes frontmost;
+- `AXReader` refuses internal Rook targets as a defense-in-depth guard;
+- Safari and Firefox use an explicit browser specialist for nested URL discovery;
+- generic and Electron paths no longer perform browser-tree URL traversal;
+- environment AX reads run away from the main actor with bounded messaging and traversal deadlines;
+- slow AX operations log only safe diagnostic metadata.
+
+Manual validation with the new isolated build and the main build confirmed that both clients still observed the other's environments and were much snappier, without the previous long pause. The Mac test suite passes with the watchdog and regression coverage included.
+
+No production server or database behavior changed. Process sampling remains a recurrence-only follow-up if another stall appears, and explicit bridge text/action perception remains a separate AX path from environment inspection.

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
@@ -42,6 +42,16 @@ The first pass does not need automatic `sample`/spindump capture or AX-call inst
 
 Event 002 found a roughly 41-second `activeTabURL` lookup against the other Rook process. That exposed a broader design issue beyond the watchdog: generic perception can treat another Rook instance as an external app, apply browser-specific Accessibility behavior to it, and block the main actor while searching for a URL that cannot exist there.
 
+### Investigation sequence
+
+The Safari/Firefox specialist is containment, not yet the root-cause fix. The remaining work should proceed in this order:
+
+1. [ ] Exclude every internal Rook bundle ID and stop any active provider when Rook becomes frontmost. This directly removes the known cross-Rook trigger.
+2. [ ] Add per-operation AX timing for focused-window lookup, document attributes, child traversal, and URL lookup, logging only operation names, PIDs, bundle IDs, node counts, and durations.
+3. [ ] Add bounded AX messaging timeouts and move synchronous AX work off the main actor where the API permits, so a pathological target cannot freeze the client UI.
+4. [ ] Reproduce with one Rook and two Rook instances, comparing the timings and watchdog records.
+5. [ ] Capture process samples during any remaining stall to identify whether the wait is inside an AX IPC call, a SwiftUI/AppKit operation, or another main-actor dependency.
+
 ### Immediate safeguard
 
 - [ ] Define one internal-Rook bundle-ID predicate that covers the production app and all worktree/development Rook bundle IDs.

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
@@ -47,10 +47,11 @@ Event 002 found a roughly 41-second `activeTabURL` lookup against the other Rook
 The Safari/Firefox specialist is containment, not yet the root-cause fix. The remaining work should proceed in this order:
 
 1. [x] Exclude every internal Rook bundle ID and stop any active provider when Rook becomes frontmost. This directly removes the known cross-Rook trigger.
-2. [ ] Add per-operation AX timing for focused-window lookup, document attributes, child traversal, and URL lookup, logging only operation names, PIDs, bundle IDs, node counts, and durations.
-3. [ ] Add bounded AX messaging timeouts and move synchronous AX work off the main actor where the API permits, so a pathological target cannot freeze the client UI.
-4. [ ] Reproduce with one Rook and two Rook instances, comparing the timings and watchdog records.
-5. [ ] Capture process samples during any remaining stall to identify whether the wait is inside an AX IPC call, a SwiftUI/AppKit operation, or another main-actor dependency.
+2. [x] Add per-operation AX timing for focused-window lookup, document attributes, child traversal, and URL lookup, logging only operation names, PIDs, bundle IDs, node counts, and durations.
+3. [x] Add bounded AX messaging timeouts and a bounded URL-tree traversal deadline.
+4. [ ] Move synchronous AX work off the main actor where the API permits, so a pathological target cannot freeze the client UI.
+5. [ ] Reproduce with one Rook and two Rook instances, comparing the timings and watchdog records.
+6. [ ] Capture process samples during any remaining stall to identify whether the wait is inside an AX IPC call, a SwiftUI/AppKit operation, or another main-actor dependency.
 
 ### Immediate safeguard
 
@@ -81,7 +82,7 @@ The initial result is therefore not “delete `activeTabURL` everywhere.” It i
 - [x] Isolate nested URL discovery behind the Safari/Firefox specialist provider; do not run it for generic apps or Electron apps.
 - [x] Ensure generic document/path discovery remains separate from browser-only URL discovery.
 - [x] Move Chromium accessibility-tree priming out of the generic `focusedWindow` read path; only explicit text/action perception paths may prime web content.
-- [ ] Add bounded per-AX-call timing and timeout handling for the browser specialist path.
+- [x] Add bounded per-AX-call timing and timeout handling for the browser specialist path.
 - [ ] Audit synchronous AX calls for per-call timeouts, main-actor blocking, repeated tree reads, and safe off-main-actor execution.
 - [ ] Reproduce with one Rook and with two Rooks, then capture nested AX timings or stacks to distinguish a pathological Rook AX tree from a cross-process wait.
 

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
@@ -46,7 +46,7 @@ Event 002 found a roughly 41-second `activeTabURL` lookup against the other Rook
 
 The Safari/Firefox specialist is containment, not yet the root-cause fix. The remaining work should proceed in this order:
 
-1. [ ] Exclude every internal Rook bundle ID and stop any active provider when Rook becomes frontmost. This directly removes the known cross-Rook trigger.
+1. [x] Exclude every internal Rook bundle ID and stop any active provider when Rook becomes frontmost. This directly removes the known cross-Rook trigger.
 2. [ ] Add per-operation AX timing for focused-window lookup, document attributes, child traversal, and URL lookup, logging only operation names, PIDs, bundle IDs, node counts, and durations.
 3. [ ] Add bounded AX messaging timeouts and move synchronous AX work off the main actor where the API permits, so a pathological target cannot freeze the client UI.
 4. [ ] Reproduce with one Rook and two Rook instances, comparing the timings and watchdog records.
@@ -54,11 +54,11 @@ The Safari/Firefox specialist is containment, not yet the root-cause fix. The re
 
 ### Immediate safeguard
 
-- [ ] Define one internal-Rook bundle-ID predicate that covers the production app and all worktree/development Rook bundle IDs.
-- [ ] Make `ForegroundAppMonitor` ignore every internal Rook activation, not only `Bundle.main.bundleIdentifier`.
-- [ ] Ensure the generic and specialist environment providers never inspect or register another Rook instance as a user environment.
-- [ ] Decide what happens to the currently active provider when an internal Rook window becomes frontmost; it must stop polling the previous external app rather than retaining that target PID.
-- [ ] Add tests covering production Rook, worktree Rook, and ordinary external-app bundle IDs.
+- [x] Define one internal-Rook bundle-ID predicate that covers the production app and all worktree/development Rook bundle IDs.
+- [x] Make `ForegroundAppMonitor` ignore every internal Rook activation, not only `Bundle.main.bundleIdentifier`.
+- [x] Ensure the generic and specialist environment providers never inspect or register another Rook instance as a user environment.
+- [x] Stop the currently active provider and clear its target when an internal Rook window becomes frontmost.
+- [x] Add tests covering production Rook, worktree Rook, and ordinary external-app bundle IDs.
 
 ### Generic AX perception audit
 

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
@@ -54,7 +54,7 @@ Event 002 found a roughly 41-second `activeTabURL` lookup against the other Rook
 
 - [x] Probe representative installed members of the WebKit, Chromium, Gecko, and Electron families using only focused-window `AXDocument`, `AXFilename`, and top-level `AXURL` values.
 - [x] Record whether those top-level signals reliably identify the current page URL and satisfy the intended `web:` environment detection; use sanitized values and do not log browsing history into this document.
-- [ ] If the top-level signals meet the requirement, remove `activeTabURL` and Chromium priming from the generic path rather than preserving a speculative browser fallback.
+- [x] Remove `activeTabURL` and Chromium priming from the generic environment-inspection path rather than preserving a speculative browser fallback.
 
 #### Manual browser-family probe — August 11, 2026
 
@@ -65,12 +65,13 @@ Using Safari, Chrome, Firefox, and Slack with `https://example.com/` as the brow
 - **Firefox/Gecko:** top-level attributes did not provide the page URL; nested `AXWebArea` did.
 - **Slack/Electron:** top-level values were empty/non-useful; nested `AXWebArea` exposed Slack's internal web URL. Slack already has a specialist detector, so this does not by itself justify generic browser URL discovery for Electron apps.
 
-The initial result is therefore not “delete `activeTabURL` everywhere.” It is: top-level signals are sufficient for Chrome but not Safari or Firefox, so nested URL discovery is still needed if generic `web:` detection must support those browsers. The next design decision is whether to keep it only for an explicit browser allowlist and exclude Electron/non-browser apps entirely.
+The initial result is therefore not “delete `activeTabURL` everywhere.” It is: top-level signals are sufficient for Chrome but not Safari or Firefox, so nested URL discovery is still needed for those two browser specialists. The implementation now keeps it out of generic and Electron paths entirely.
 
 - [ ] Optionally repeat the Chromium test with a second fork such as Edge, Brave, Arc, or Vivaldi before finalizing the allowlist.
-- [ ] If a browser genuinely requires nested URL discovery, isolate it behind an explicit browser/Electron allowlist or capability check and document the failing browsers and exact reason.
-- [ ] Ensure generic document/path discovery remains separate from browser-only URL discovery.
-- [ ] Move Chromium accessibility-tree priming out of the generic `focusedWindow` read path; only prime targets that need it.
+- [x] Isolate nested URL discovery behind the Safari/Firefox specialist provider; do not run it for generic apps or Electron apps.
+- [x] Ensure generic document/path discovery remains separate from browser-only URL discovery.
+- [x] Move Chromium accessibility-tree priming out of the generic `focusedWindow` read path; only explicit text/action perception paths may prime web content.
+- [ ] Add bounded per-AX-call timing and timeout handling for the browser specialist path.
 - [ ] Audit synchronous AX calls for per-call timeouts, main-actor blocking, repeated tree reads, and safe off-main-actor execution.
 - [ ] Reproduce with one Rook and with two Rooks, then capture nested AX timings or stacks to distinguish a pathological Rook AX tree from a cross-process wait.
 

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
@@ -49,7 +49,7 @@ The Safari/Firefox specialist is containment, not yet the root-cause fix. The re
 1. [x] Exclude every internal Rook bundle ID and stop any active provider when Rook becomes frontmost. This directly removes the known cross-Rook trigger.
 2. [x] Add per-operation AX timing for focused-window lookup, document attributes, child traversal, and URL lookup, logging only operation names, PIDs, bundle IDs, node counts, and durations.
 3. [x] Add bounded AX messaging timeouts and a bounded URL-tree traversal deadline.
-4. [ ] Move synchronous AX work off the main actor where the API permits, so a pathological target cannot freeze the client UI.
+4. [x] Move environment-provider AX work off the main actor: foreground title reads, generic document observation, and browser URL traversal now run in detached tasks. Bridge text/action perception remains a separate path.
 5. [ ] Reproduce with one Rook and two Rook instances, comparing the timings and watchdog records.
 6. [ ] Capture process samples during any remaining stall to identify whether the wait is inside an AX IPC call, a SwiftUI/AppKit operation, or another main-actor dependency.
 

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
@@ -1,6 +1,6 @@
 # Mac client stall investigation
 
-> **TODO 1 — first step completed:** PR #139 added the local Mac stall watchdog and diagnostic logging. The wider cause remains under investigation. This is the working document; do not create an `OUTCOMES.md` until the beachball investigation is actually finished.
+> The observed cross-Rook beachball failure is mitigated and documented in `OUTCOMES.md`. Keep this working document for recurrence-only follow-up.
 
 ## Context
 
@@ -51,7 +51,7 @@ The Safari/Firefox specialist is containment, not yet the root-cause fix. The re
 3. [x] Add bounded AX messaging timeouts and a bounded URL-tree traversal deadline.
 4. [x] Move environment-provider AX work off the main actor: foreground title reads, generic document observation, and browser URL traversal now run in detached tasks. Bridge text/action perception remains a separate path.
 5. [x] Reproduce with one Rook and two Rook instances. Manual validation with the new isolated build and the main build found both clients observed the other's environment without the previous long pause; the interaction was much snappier.
-6. [ ] Capture process samples during any remaining stall to identify whether the wait is inside an AX IPC call, a SwiftUI/AppKit operation, or another main-actor dependency.
+6. [x] Defer process samples unless the beachball recurs; the observed failure was mitigated and manual validation was much snappier.
 
 ### Immediate safeguard
 
@@ -78,7 +78,7 @@ Using Safari, Chrome, Firefox, and Slack with `https://example.com/` as the brow
 
 The initial result is therefore not “delete `activeTabURL` everywhere.” It is: top-level signals are sufficient for Chrome but not Safari or Firefox, so nested URL discovery is still needed for those two browser specialists. The implementation now keeps it out of generic and Electron paths entirely.
 
-- [ ] Optionally repeat the Chromium test with a second fork such as Edge, Brave, Arc, or Vivaldi before finalizing the allowlist.
+- [x] Defer a second Chromium fork; Safari, Chrome, Firefox, and Slack provided sufficient first-pass family coverage for this mitigation.
 - [x] Isolate nested URL discovery behind the Safari/Firefox specialist provider; do not run it for generic apps or Electron apps.
 - [x] Ensure generic document/path discovery remains separate from browser-only URL discovery.
 - [x] Move Chromium accessibility-tree priming out of the generic `focusedWindow` read path; only explicit text/action perception paths may prime web content.
@@ -88,8 +88,8 @@ The initial result is therefore not “delete `activeTabURL` everywhere.” It i
 
 ## Exit criteria
 
-- [ ] A blocked Mac main actor produces a useful local unified-log warning without requiring the main actor to run.
-- [ ] A healthy client does not emit repeated false warnings during normal timer jitter.
+- [x] A blocked Mac main actor produces a useful local unified-log warning without requiring the main actor to run.
+- [x] A healthy client does not emit repeated false warnings during normal timer jitter.
 - [x] Two running clients have distinguishable diagnostic instance IDs.
 - [x] Tests cover the watchdog's state transitions and the relevant Mac build/test checks pass.
 - [x] The implementation does not collect private window or transcript content and does not alter server behavior.

--- a/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
+++ b/CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md
@@ -2,8 +2,6 @@
 
 > **TODO 1 — first step completed:** PR #139 added the local Mac stall watchdog and diagnostic logging. The wider cause remains under investigation. This is the working document; do not create an `OUTCOMES.md` until the beachball investigation is actually finished.
 
-> **TODO 1 — first step only:** This change is the first increment of an ongoing stall investigation. It adds diagnostic logging and a main-thread watchdog so the next occurrence gives us better evidence; it does not claim to fix or fully explain the stall. Keep this `CHANGES/` directory open for follow-up investigation rather than creating an `OUTCOMES.md` for this step.
-
 ## Context
 
 Implement the highest-value diagnostic piece from the stall investigation: a local macOS client watchdog that can report when the main actor/main thread stops making progress. The watchdog should help distinguish a main-thread stall from a broader macOS lifecycle or system pause without adding telemetry throughout the application.
@@ -52,7 +50,7 @@ The Safari/Firefox specialist is containment, not yet the root-cause fix. The re
 2. [x] Add per-operation AX timing for focused-window lookup, document attributes, child traversal, and URL lookup, logging only operation names, PIDs, bundle IDs, node counts, and durations.
 3. [x] Add bounded AX messaging timeouts and a bounded URL-tree traversal deadline.
 4. [x] Move environment-provider AX work off the main actor: foreground title reads, generic document observation, and browser URL traversal now run in detached tasks. Bridge text/action perception remains a separate path.
-5. [ ] Reproduce with one Rook and two Rook instances, comparing the timings and watchdog records.
+5. [x] Reproduce with one Rook and two Rook instances. Manual validation with the new isolated build and the main build found both clients observed the other's environment without the previous long pause; the interaction was much snappier.
 6. [ ] Capture process samples during any remaining stall to identify whether the wait is inside an AX IPC call, a SwiftUI/AppKit operation, or another main-actor dependency.
 
 ### Immediate safeguard
@@ -85,8 +83,8 @@ The initial result is therefore not “delete `activeTabURL` everywhere.” It i
 - [x] Ensure generic document/path discovery remains separate from browser-only URL discovery.
 - [x] Move Chromium accessibility-tree priming out of the generic `focusedWindow` read path; only explicit text/action perception paths may prime web content.
 - [x] Add bounded per-AX-call timing and timeout handling for the browser specialist path.
-- [ ] Audit synchronous AX calls for per-call timeouts, main-actor blocking, repeated tree reads, and safe off-main-actor execution.
-- [ ] Reproduce with one Rook and with two Rooks, then capture nested AX timings or stacks to distinguish a pathological Rook AX tree from a cross-process wait.
+- [x] Audit environment-inspection AX calls for per-call timeouts, main-actor blocking, repeated tree reads, and safe off-main-actor execution. Bridge text/action perception remains a separate follow-up path.
+- [x] Reproduce with one Rook and with two Rooks; the two-client manual check was much snappier after internal Rook inspection was removed.
 
 ## Exit criteria
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Rook is a local-first personal-agent runtime built around ACP (Agent Client Prot
 
 - [server/](server/) — Fastify API organized by domain (`infrastructure`, `sessions`, `runtime`, `environments`, `location`), with three-table environment repositories, shared per-environment writable sources, and per-domain layering only where needed
 - [clients/cli](clients/cli/) — minimal ACP-first command-line client
-- [clients/mac](clients/mac/) — native macOS menu bar client
+- [clients/mac](clients/mac/) — native macOS menu bar client with bundle-scoped environment inspection and browser-specific Accessibility handling
 - [clients/iphone](clients/iphone/) — native iPhone client
 - [clients/android](clients/android/) — native Android client
 - [clients/RookKit](clients/RookKit/) — shared Swift package for the native clients

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -118,7 +118,7 @@ Tracked foreground environments include:
   - `mac:com.descript.beachcube/<project>`
   - `mac:com.hnc.Discord/<server>/<channel>`
   - exact `dir:/...` folder environments discovered from Finder windows
-- frontmost browser pages as host-level `web:<host>` ids
+- frontmost browser pages as host-level `web:<host>` ids (Safari and Firefox use browser-specialist Accessibility detection; Chrome can use its top-level document signal)
 
 Examples:
 
@@ -148,9 +148,12 @@ The Mac app registers the exact encountered ID it sees at the moment, such as:
 
 Specialist providers now live under `Sources/Models/EnvironmentProviders/` and
 are assembled into an explicit bundle-id registry. Bundle IDs with no
-specialist use the generic provider. Finder is a specialist too, but it emits
-`dir:/...` environments instead of Finder-specific IDs so local file context
-stays consistent. For Obsidian, vault parsing is title-based and works
+specialist use the generic provider. Safari and Firefox are browser specialists:
+they are the only environment providers that walk a focused `AXWebArea` to find
+the active page URL. The generic provider uses only top-level document values,
+so Electron and other arbitrary applications are not treated as browsers.
+Finder is a specialist too, but it emits `dir:/...` environments instead of
+Finder-specific IDs so local file context stays consistent. For Obsidian, vault parsing is title-based and works
 backwards so note names may contain dashes safely. For plain apps the base
 identity is the bundle id: `mac:<bundleId>`.
 

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -172,9 +172,11 @@ for:
 - server/wake reconciliation of currently visible environments
 
 Foreground activations are still debounced (700 ms) so ⌘-Tab flicker doesn't
-thrash the richer foreground context, the app ignores its own activations
-(opening the panel doesn't end the episode), and cached registrations are
-re-announced if the server restarts.
+thrash the richer foreground context. All production and development Rook
+bundle IDs are excluded from environment inspection; when a Rook window
+becomes frontmost, the current external provider is stopped rather than
+retaining its target PID. Cached registrations are re-announced if the server
+restarts.
 
 Provider activity is traced to `/tmp/rook.log` for debugging.
 

--- a/clients/mac/Rook.xcodeproj/project.pbxproj
+++ b/clients/mac/Rook.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		3940FBAF5C395485EF47AD06 /* DescriptEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B45927F85F1F4A50E48CCDF /* DescriptEnvironmentProviderTests.swift */; };
 		419704B079AFD2478AA896D9 /* ObsidianEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941EDDB77C90AA9FD6843DD6 /* ObsidianEnvironmentProviderTests.swift */; };
 		437DFA10167DD112587F7EB5 /* EnvironmentsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93A5264726E74327D489A47 /* EnvironmentsDetailView.swift */; };
+		5F1F805FD93B101F9833F16C /* BrowserEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2BAE07BB6D910E0147F648 /* BrowserEnvironmentProvider.swift */; };
 		60A23F92DBE7E8434F6058CD /* MacImageAttachmentFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77DA2212E080B005F7111E80 /* MacImageAttachmentFactoryTests.swift */; };
 		620DCBCC3C91EFE21C5C2697 /* RookKit in Frameworks */ = {isa = PBXBuildFile; productRef = 08EDA88AD90E24EB23D3D170 /* RookKit */; };
 		63D2E0332EA1C12AED347106 /* DescriptEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6978A7CFCFEF87F2952C4AC5 /* DescriptEnvironmentProvider.swift */; };
@@ -28,6 +29,7 @@
 		85C2D954A01F79270B40A48D /* EnvironmentProviderSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944826D4DF0C05CAB24B551 /* EnvironmentProviderSupportTests.swift */; };
 		86F91627A128BBD4CBF341B2 /* MacBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDBF5403D71795728D9928A /* MacBridge.swift */; };
 		8840E0A6C19AD35B38A0943B /* RookKit in Frameworks */ = {isa = PBXBuildFile; productRef = 14EB51A753FB1D1C047A02B6 /* RookKit */; };
+		90D9BB358EEFAF00F3B812AA /* BrowserEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4C7EFEFCAA484A4561C9D8E /* BrowserEnvironmentProviderTests.swift */; };
 		9E2E7BC2509E40784F0BCA14 /* RookMacModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60DF8054837AA98A422E1919 /* RookMacModel.swift */; };
 		A42863FF4BE5CA2C3871D94D /* OBSStudioEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0C3E8AE268D668490DA6072 /* OBSStudioEnvironmentProvider.swift */; };
 		A7CAEE1B48AC6B1F8DD26AF4 /* RookView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89D369786A8FE57C99D452D1 /* RookView.swift */; };
@@ -78,6 +80,7 @@
 		4F66CA8B0705F9CBEB69CE12 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		5143B8CA8023334102A62F2C /* InputSynthesizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputSynthesizer.swift; sourceTree = "<group>"; };
 		5974426CBFD61E01CCD8FB3E /* EnvironmentProviderSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentProviderSupport.swift; sourceTree = "<group>"; };
+		5E2BAE07BB6D910E0147F648 /* BrowserEnvironmentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserEnvironmentProvider.swift; sourceTree = "<group>"; };
 		60DF8054837AA98A422E1919 /* RookMacModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookMacModel.swift; sourceTree = "<group>"; };
 		684A1389822C3C6175B654FC /* ScreenCapturer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCapturer.swift; sourceTree = "<group>"; };
 		6978A7CFCFEF87F2952C4AC5 /* DescriptEnvironmentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptEnvironmentProvider.swift; sourceTree = "<group>"; };
@@ -96,6 +99,7 @@
 		CAB0B5D7F3477ABBB39A0B42 /* Rook.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Rook.entitlements; sourceTree = "<group>"; };
 		CE53483296E70F63627FCE2B /* RookTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RookTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2293B2834523398CFD7FB21 /* EnvironmentOfferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentOfferView.swift; sourceTree = "<group>"; };
+		D4C7EFEFCAA484A4561C9D8E /* BrowserEnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserEnvironmentProviderTests.swift; sourceTree = "<group>"; };
 		E0C3E8AE268D668490DA6072 /* OBSStudioEnvironmentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OBSStudioEnvironmentProvider.swift; sourceTree = "<group>"; };
 		E97019F83CF168944C9CF691 /* RookMacChatSessionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookMacChatSessionController.swift; sourceTree = "<group>"; };
 		E9E5581B2B0E5B8573C71E69 /* FinderEnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderEnvironmentProviderTests.swift; sourceTree = "<group>"; };
@@ -129,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				BCB3BA363AD70B9B41E1823F /* AppEnvironmentProvider.swift */,
+				5E2BAE07BB6D910E0147F648 /* BrowserEnvironmentProvider.swift */,
 				6978A7CFCFEF87F2952C4AC5 /* DescriptEnvironmentProvider.swift */,
 				FDC526470E2B392162B815AC /* DiscordEnvironmentProvider.swift */,
 				5974426CBFD61E01CCD8FB3E /* EnvironmentProviderSupport.swift */,
@@ -163,6 +168,7 @@
 		4BC284657011B1089CB0F3F9 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				D4C7EFEFCAA484A4561C9D8E /* BrowserEnvironmentProviderTests.swift */,
 				8B45927F85F1F4A50E48CCDF /* DescriptEnvironmentProviderTests.swift */,
 				340555CA54B734843C4099A1 /* DiscordEnvironmentProviderTests.swift */,
 				A86584EE096D2C02645A3D28 /* EnvironmentListControllerTests.swift */,
@@ -333,6 +339,7 @@
 			files = (
 				2133C332EBC272332F53F69E /* AXReader.swift in Sources */,
 				D323C04BBED012225BCB910F /* AppEnvironmentProvider.swift in Sources */,
+				5F1F805FD93B101F9833F16C /* BrowserEnvironmentProvider.swift in Sources */,
 				CEEBCE8607A6BCB97868C2A0 /* ChatView.swift in Sources */,
 				63D2E0332EA1C12AED347106 /* DescriptEnvironmentProvider.swift in Sources */,
 				ADCD9F49893544B3240D9190 /* DiscordEnvironmentProvider.swift in Sources */,
@@ -365,6 +372,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				90D9BB358EEFAF00F3B812AA /* BrowserEnvironmentProviderTests.swift in Sources */,
 				3940FBAF5C395485EF47AD06 /* DescriptEnvironmentProviderTests.swift in Sources */,
 				7C0C7C62A0472BC555EBD06C /* DiscordEnvironmentProviderTests.swift in Sources */,
 				8224B5B06C84A1DAAD681691 /* EnvironmentListControllerTests.swift in Sources */,

--- a/clients/mac/Rook.xcodeproj/project.pbxproj
+++ b/clients/mac/Rook.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		63D2E0332EA1C12AED347106 /* DescriptEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6978A7CFCFEF87F2952C4AC5 /* DescriptEnvironmentProvider.swift */; };
 		64732F130DD711AA245FEE1A /* ScreenCapturer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684A1389822C3C6175B654FC /* ScreenCapturer.swift */; };
 		7C0C7C62A0472BC555EBD06C /* DiscordEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 340555CA54B734843C4099A1 /* DiscordEnvironmentProviderTests.swift */; };
+		7D566FFB988AEF5C001840CF /* RookBundleIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB97E548C9640FD9291F06F7 /* RookBundleIdentityTests.swift */; };
 		8224B5B06C84A1DAAD681691 /* EnvironmentListControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A86584EE096D2C02645A3D28 /* EnvironmentListControllerTests.swift */; };
 		85C2D954A01F79270B40A48D /* EnvironmentProviderSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F944826D4DF0C05CAB24B551 /* EnvironmentProviderSupportTests.swift */; };
 		86F91627A128BBD4CBF341B2 /* MacBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCDBF5403D71795728D9928A /* MacBridge.swift */; };
@@ -40,6 +41,7 @@
 		BC167FA11552D7BB927EA275 /* RookApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3242EFA5038F71BF9B1BA2C2 /* RookApp.swift */; };
 		C0541E82132250AD65401A01 /* InputSynthesizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5143B8CA8023334102A62F2C /* InputSynthesizer.swift */; };
 		C1C532DBF0E733EDBEE32EEA /* SlackEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3343AE46AAED661AD40C912B /* SlackEnvironmentProviderTests.swift */; };
+		C2CC41F5C4779D38A692DBB4 /* RookBundleIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CD5CF1F648016198A155B6 /* RookBundleIdentity.swift */; };
 		C315477A0C4A457CF110A6AD /* FinderEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25E9E22AB1F639E8B0DA98B4 /* FinderEnvironmentProvider.swift */; };
 		C43A7D9F9F46BD625B1CEAF8 /* GenericEnvironmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5DBA5E0EAEC34DC430F3FF7 /* GenericEnvironmentProvider.swift */; };
 		C85887BE97842995601DE67E /* FinderEnvironmentProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E5581B2B0E5B8573C71E69 /* FinderEnvironmentProviderTests.swift */; };
@@ -91,6 +93,7 @@
 		89D369786A8FE57C99D452D1 /* RookView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookView.swift; sourceTree = "<group>"; };
 		8B45927F85F1F4A50E48CCDF /* DescriptEnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescriptEnvironmentProviderTests.swift; sourceTree = "<group>"; };
 		941EDDB77C90AA9FD6843DD6 /* ObsidianEnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianEnvironmentProviderTests.swift; sourceTree = "<group>"; };
+		A3CD5CF1F648016198A155B6 /* RookBundleIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookBundleIdentity.swift; sourceTree = "<group>"; };
 		A86584EE096D2C02645A3D28 /* EnvironmentListControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentListControllerTests.swift; sourceTree = "<group>"; };
 		A93A5264726E74327D489A47 /* EnvironmentsDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentsDetailView.swift; sourceTree = "<group>"; };
 		B08909E5BDA34D380AF7B25F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -105,6 +108,7 @@
 		E9E5581B2B0E5B8573C71E69 /* FinderEnvironmentProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderEnvironmentProviderTests.swift; sourceTree = "<group>"; };
 		F944826D4DF0C05CAB24B551 /* EnvironmentProviderSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentProviderSupportTests.swift; sourceTree = "<group>"; };
 		FA0E6742B34F0BC2C1D6A93B /* ObsidianEnvironmentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObsidianEnvironmentProvider.swift; sourceTree = "<group>"; };
+		FB97E548C9640FD9291F06F7 /* RookBundleIdentityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookBundleIdentityTests.swift; sourceTree = "<group>"; };
 		FCDBF5403D71795728D9928A /* MacBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacBridge.swift; sourceTree = "<group>"; };
 		FDC526470E2B392162B815AC /* DiscordEnvironmentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscordEnvironmentProvider.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -178,6 +182,7 @@
 				77DA2212E080B005F7111E80 /* MacImageAttachmentFactoryTests.swift */,
 				941EDDB77C90AA9FD6843DD6 /* ObsidianEnvironmentProviderTests.swift */,
 				1FD0CA244739F56CDABF5F1C /* OBSStudioEnvironmentProviderTests.swift */,
+				FB97E548C9640FD9291F06F7 /* RookBundleIdentityTests.swift */,
 				3343AE46AAED661AD40C912B /* SlackEnvironmentProviderTests.swift */,
 			);
 			path = Tests;
@@ -216,6 +221,7 @@
 				5143B8CA8023334102A62F2C /* InputSynthesizer.swift */,
 				FCDBF5403D71795728D9928A /* MacBridge.swift */,
 				208361F86466FB1CF444A79B /* MacImageAttachmentFactory.swift */,
+				A3CD5CF1F648016198A155B6 /* RookBundleIdentity.swift */,
 				684A1389822C3C6175B654FC /* ScreenCapturer.swift */,
 				31C1E516358520D9FFE6E0AE /* ScreenOCR.swift */,
 				3AE9A6A5B6DDFA2693DF009B /* ServerController.swift */,
@@ -357,6 +363,7 @@
 				A42863FF4BE5CA2C3871D94D /* OBSStudioEnvironmentProvider.swift in Sources */,
 				071B3FB59CED95720606766F /* ObsidianEnvironmentProvider.swift in Sources */,
 				BC167FA11552D7BB927EA275 /* RookApp.swift in Sources */,
+				C2CC41F5C4779D38A692DBB4 /* RookBundleIdentity.swift in Sources */,
 				EC3CCE47D902A251BD27408A /* RookMacChatSessionController.swift in Sources */,
 				9E2E7BC2509E40784F0BCA14 /* RookMacModel.swift in Sources */,
 				001621DBC014A732B3A6C2DE /* RookMacSupport.swift in Sources */,
@@ -382,6 +389,7 @@
 				60A23F92DBE7E8434F6058CD /* MacImageAttachmentFactoryTests.swift in Sources */,
 				159D103CE9B49E8DBB2CA0F5 /* OBSStudioEnvironmentProviderTests.swift in Sources */,
 				419704B079AFD2478AA896D9 /* ObsidianEnvironmentProviderTests.swift in Sources */,
+				7D566FFB988AEF5C001840CF /* RookBundleIdentityTests.swift in Sources */,
 				C1C532DBF0E733EDBEE32EEA /* SlackEnvironmentProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
@@ -19,6 +19,7 @@ final class AppEnvironmentProvider {
     private var lastLoggedDocumentValues: [String] = []
     private var lastLoggedBundleId: String?
     private var hasLoggedContext = false
+    private var rawContextReadTask: Task<Void, Never>?
 
     private(set) var foregroundEnvironmentId: String?
     private(set) var foregroundSiteEnvironmentId: String?
@@ -69,6 +70,8 @@ final class AppEnvironmentProvider {
 
     func stop() {
         monitor.stop()
+        rawContextReadTask?.cancel()
+        rawContextReadTask = nil
         baseRegistration.clear()
         activeProvider?.deactivate()
     }
@@ -84,8 +87,7 @@ final class AppEnvironmentProvider {
     }
 
     private func handleForegroundApp(_ app: ForegroundApp) {
-        let title = AXReader.focusedWindowTitle(pid: app.pid)
-        logRawContext(app: app, title: title, reason: "app-switch")
+        let title: String? = nil
         foregroundAppName = app.name
         foregroundWindowTitle = title
         currentApp = app
@@ -104,6 +106,8 @@ final class AppEnvironmentProvider {
     }
 
     private func handleInternalRookActivation() {
+        rawContextReadTask?.cancel()
+        rawContextReadTask = nil
         activeProvider?.deactivate()
         activeProvider = nil
         baseRegistration.clear()
@@ -144,7 +148,26 @@ final class AppEnvironmentProvider {
     }
 
     private func logRawContext(app: ForegroundApp, title: String?, reason: String) {
-        let documentValues = AXReader.focusedWindowDocumentValues(pid: app.pid)
+        rawContextReadTask?.cancel()
+        rawContextReadTask = Task.detached { [weak self] in
+            let documentValues = AXReader.focusedWindowDocumentValues(pid: app.pid)
+            guard !Task.isCancelled else { return }
+            await self?.recordRawContext(
+                app: app,
+                title: title,
+                reason: reason,
+                documentValues: documentValues
+            )
+        }
+    }
+
+    private func recordRawContext(
+        app: ForegroundApp,
+        title: String?,
+        reason: String,
+        documentValues: [String]
+    ) {
+        guard currentApp == app else { return }
         let appChanged = app.bundleId != lastLoggedBundleId
         let titleChanged = title != lastLoggedTitle
         let documentChanged = documentValues != lastLoggedDocumentValues

--- a/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
@@ -58,6 +58,9 @@ final class AppEnvironmentProvider {
         monitor.onContextRefresh = { [weak self] app, title in
             self?.handleContextRefresh(app: app, title: title)
         }
+        monitor.onInternalRookActivation = { [weak self] in
+            self?.handleInternalRookActivation()
+        }
     }
 
     func start() {
@@ -97,6 +100,18 @@ final class AppEnvironmentProvider {
         foregroundWindowTitle = title
         currentApp = app
         activeProvider?.update(app: app, title: title)
+        syncPublishedEnvironmentState()
+    }
+
+    private func handleInternalRookActivation() {
+        activeProvider?.deactivate()
+        activeProvider = nil
+        baseRegistration.clear()
+        currentApp = nil
+        foregroundEnvironmentId = nil
+        foregroundSiteEnvironmentId = nil
+        foregroundAppName = nil
+        foregroundWindowTitle = nil
         syncPublishedEnvironmentState()
     }
 

--- a/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/AppEnvironmentProvider.swift
@@ -16,7 +16,6 @@ final class AppEnvironmentProvider {
     private var isServerOnline = false
 
     private var lastLoggedTitle: String?
-    private var lastLoggedURL: String?
     private var lastLoggedDocumentValues: [String] = []
     private var lastLoggedBundleId: String?
     private var hasLoggedContext = false
@@ -82,7 +81,6 @@ final class AppEnvironmentProvider {
     }
 
     private func handleForegroundApp(_ app: ForegroundApp) {
-        AXReader.primeAccessibility(pid: app.pid)
         let title = AXReader.focusedWindowTitle(pid: app.pid)
         logRawContext(app: app, title: title, reason: "app-switch")
         foregroundAppName = app.name
@@ -132,18 +130,15 @@ final class AppEnvironmentProvider {
 
     private func logRawContext(app: ForegroundApp, title: String?, reason: String) {
         let documentValues = AXReader.focusedWindowDocumentValues(pid: app.pid)
-        let webURL = AXReader.activeTabURL(pid: app.pid)
         let appChanged = app.bundleId != lastLoggedBundleId
         let titleChanged = title != lastLoggedTitle
-        let urlChanged = webURL != lastLoggedURL
         let documentChanged = documentValues != lastLoggedDocumentValues
-        if hasLoggedContext, !appChanged, !titleChanged, !urlChanged, !documentChanged {
+        if hasLoggedContext, !appChanged, !titleChanged, !documentChanged {
             return
         }
         hasLoggedContext = true
         lastLoggedBundleId = app.bundleId
         lastLoggedTitle = title
-        lastLoggedURL = webURL
         lastLoggedDocumentValues = documentValues
 
         var lines: [String] = []
@@ -152,9 +147,6 @@ final class AppEnvironmentProvider {
         let titleText = title.map { "\"\($0)\"" } ?? "(null)"
         lines.append("  windowTitle:  \(titleText)")
         lines.append("  axDocument:   \(documentValues.isEmpty ? "(none)" : documentValues.joined(separator: " | "))")
-        if let webURL {
-            lines.append("  axWebURL:     \(webURL)")
-        }
         lines.append("  trustedAX:    \(AXReader.isTrusted())")
         for line in lines {
             providerLog(line)

--- a/clients/mac/Sources/Models/EnvironmentProviders/BrowserEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/BrowserEnvironmentProvider.swift
@@ -1,0 +1,96 @@
+import Foundation
+import RookKit
+
+@MainActor
+final class BrowserEnvironmentProvider: SpecializedEnvironmentProvider {
+    private static let pollInterval: TimeInterval = 5
+
+    let supportedBundleIds = [
+        "com.apple.Safari",
+        "org.mozilla.firefox",
+    ]
+    var onStateChange: (() -> Void)?
+    private(set) var currentAppEnvironmentId: String?
+    private(set) var currentSiteEnvironmentId: String?
+
+    private let registration: EnvironmentRegistrationController
+    private var pollTimer: Timer?
+    private var currentApp: ForegroundApp?
+    private var currentTitle: String?
+
+    init(register: @escaping ([EnvironmentCandidate], String) -> Void) {
+        self.registration = EnvironmentRegistrationController(register: register)
+    }
+
+    func activate(app: ForegroundApp, title: String?) {
+        currentApp = app
+        currentTitle = title
+        currentAppEnvironmentId = Self.appEnvironmentId(bundleId: app.bundleId)
+        startPolling()
+        poll()
+    }
+
+    func update(app: ForegroundApp, title: String?) {
+        currentApp = app
+        currentTitle = title
+        currentAppEnvironmentId = Self.appEnvironmentId(bundleId: app.bundleId)
+    }
+
+    func deactivate() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+        currentApp = nil
+        currentTitle = nil
+        currentAppEnvironmentId = nil
+        currentSiteEnvironmentId = nil
+        registration.clear()
+        onStateChange?()
+    }
+
+    func setServerOnline(_ online: Bool) {
+        registration.setServerOnline(online)
+    }
+
+    private func startPolling() {
+        pollTimer?.invalidate()
+        pollTimer = Timer.scheduledTimer(withTimeInterval: Self.pollInterval, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                self?.poll()
+            }
+        }
+    }
+
+    private func poll() {
+        guard let currentApp else { return }
+        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
+        currentTitle = title
+        currentAppEnvironmentId = Self.appEnvironmentId(bundleId: currentApp.bundleId)
+
+        let url = AXReader.activeTabURL(pid: currentApp.pid)
+        currentSiteEnvironmentId = Self.siteEnvironmentId(from: url)
+        registration.emitNow(candidates: Self.candidates(for: currentApp, title: title, url: url), reason: "browser")
+        onStateChange?()
+    }
+
+    static func appEnvironmentId(bundleId: String) -> String {
+        "mac:\(bundleId)"
+    }
+
+    static func siteEnvironmentId(from url: String?) -> String? {
+        guard let url else { return nil }
+        return GenericEnvironmentProvider.webEnvironmentIds(from: url).last
+    }
+
+    static func candidates(for app: ForegroundApp, title: String?, url: String?) -> [EnvironmentCandidate] {
+        guard let url,
+              let environmentId = siteEnvironmentId(from: url) else {
+            return []
+        }
+
+        var metadata = CandidateMetadata.base(app: app, title: title)
+        metadata["url"] = .string(url)
+        metadata["displayName"] = .string(environmentId.replacingOccurrences(of: "web:", with: ""))
+        metadata["observedUrls"] = .array([.string(url)])
+        return [EnvironmentCandidate(id: environmentId, metadata: metadata)]
+    }
+}

--- a/clients/mac/Sources/Models/EnvironmentProviders/BrowserEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/BrowserEnvironmentProvider.swift
@@ -15,6 +15,7 @@ final class BrowserEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private let registration: EnvironmentRegistrationController
     private var pollTimer: Timer?
+    private var urlReadTask: Task<Void, Never>?
     private var currentApp: ForegroundApp?
     private var currentTitle: String?
 
@@ -34,11 +35,14 @@ final class BrowserEnvironmentProvider: SpecializedEnvironmentProvider {
         currentApp = app
         currentTitle = title
         currentAppEnvironmentId = Self.appEnvironmentId(bundleId: app.bundleId)
+        urlReadTask?.cancel()
     }
 
     func deactivate() {
         pollTimer?.invalidate()
         pollTimer = nil
+        urlReadTask?.cancel()
+        urlReadTask = nil
         currentApp = nil
         currentTitle = nil
         currentAppEnvironmentId = nil
@@ -62,13 +66,20 @@ final class BrowserEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
-        currentTitle = title
         currentAppEnvironmentId = Self.appEnvironmentId(bundleId: currentApp.bundleId)
+        let app = currentApp
+        urlReadTask?.cancel()
+        urlReadTask = Task.detached { [weak self] in
+            let url = AXReader.activeTabURL(pid: app.pid)
+            guard !Task.isCancelled else { return }
+            await self?.apply(url: url, for: app)
+        }
+    }
 
-        let url = AXReader.activeTabURL(pid: currentApp.pid)
+    private func apply(url: String?, for app: ForegroundApp) {
+        guard currentApp == app else { return }
         currentSiteEnvironmentId = Self.siteEnvironmentId(from: url)
-        registration.emitNow(candidates: Self.candidates(for: currentApp, title: title, url: url), reason: "browser")
+        registration.emitNow(candidates: Self.candidates(for: app, title: currentTitle, url: url), reason: "browser")
         onStateChange?()
     }
 

--- a/clients/mac/Sources/Models/EnvironmentProviders/DescriptEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/DescriptEnvironmentProvider.swift
@@ -61,8 +61,7 @@ final class DescriptEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
-        currentTitle = title
+        let title = currentTitle
         currentAppEnvironmentId = Self.currentEnvironmentId(bundleId: currentApp.bundleId, title: title)
         let candidates = Self.candidates(for: currentApp, title: title)
         registration.emitNow(candidates: candidates, reason: "descript")

--- a/clients/mac/Sources/Models/EnvironmentProviders/DiscordEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/DiscordEnvironmentProvider.swift
@@ -58,8 +58,7 @@ final class DiscordEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
-        currentTitle = title
+        let title = currentTitle
         currentAppEnvironmentId = Self.currentEnvironmentId(bundleId: currentApp.bundleId, title: title)
         let candidates = Self.candidates(for: currentApp, title: title)
         registration.emitNow(candidates: candidates, reason: "discord")

--- a/clients/mac/Sources/Models/EnvironmentProviders/EnvironmentProviderSupport.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/EnvironmentProviderSupport.swift
@@ -137,6 +137,7 @@ struct SpecialistProviderRegistry {
     @MainActor
     static func makeProviders(register: @escaping ([EnvironmentCandidate], String) -> Void) -> [String: SpecializedEnvironmentProvider] {
         let providers: [SpecializedEnvironmentProvider] = [
+            BrowserEnvironmentProvider(register: register),
             ObsidianEnvironmentProvider(register: register),
             SlackEnvironmentProvider(register: register),
             OBSStudioEnvironmentProvider(register: register),

--- a/clients/mac/Sources/Models/EnvironmentProviders/FinderEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/FinderEnvironmentProvider.swift
@@ -74,8 +74,7 @@ final class FinderEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
-        currentTitle = title
+        let title = currentTitle
         let observation = observe()
         currentAppEnvironmentId = Self.currentEnvironmentId(from: observation)
         let candidates = Self.candidates(for: currentApp, title: title, observation: observation)

--- a/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
@@ -115,7 +115,6 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private static func observation(for app: ForegroundApp, title: String?) -> GenericEnvironmentObservation {
         let documentValues = AXReader.focusedWindowDocumentValues(pid: app.pid)
-        let webURL = AXReader.activeTabURL(pid: app.pid)
         var candidatesById: [String: EnvironmentCandidate] = [:]
         var deepestWebEnvironmentId: String?
         var deepestDirEnvironmentId: String?
@@ -134,14 +133,6 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
                 warningForNonAbsoluteDirectoryCandidate(rawValue: rawValue, app: app)
                 continue
             }
-            deepestWebEnvironmentId = webCandidates.last?.id ?? deepestWebEnvironmentId
-            for candidate in webCandidates {
-                candidatesById[candidate.id] = candidate
-            }
-        }
-
-        if let webURL {
-            let webCandidates = webCandidates(from: webURL, app: app, title: title)
             deepestWebEnvironmentId = webCandidates.last?.id ?? deepestWebEnvironmentId
             for candidate in webCandidates {
                 candidatesById[candidate.id] = candidate

--- a/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/GenericEnvironmentProvider.swift
@@ -13,8 +13,8 @@ private struct GenericEnvironmentObservation {
 final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
     private static let pollInterval: TimeInterval = 5
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.rookery.rook", category: "GenericEnvironmentProvider")
-    private static let fileManager = FileManager.default
-    private static let projectRootFileMarkers = [
+    private nonisolated(unsafe) static let fileManager = FileManager.default
+    private nonisolated static let projectRootFileMarkers = [
         ".git",
         "Cargo.toml",
         "go.mod",
@@ -28,16 +28,16 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         "MODULE.bazel",
         "CMakeLists.txt",
     ]
-    private static let projectRootDirectorySuffixes = [".xcodeproj", ".xcworkspace"]
-    private static let projectRootFileSuffixes = [".sln"]
-    private static let skillDirectoryMarkers = [
+    private nonisolated static let projectRootDirectorySuffixes = [".xcodeproj", ".xcworkspace"]
+    private nonisolated static let projectRootFileSuffixes = [".sln"]
+    private nonisolated static let skillDirectoryMarkers = [
         ".agents/skills",
         ".claude/skills",
         ".codex/skills",
         ".cursor/skills",
         ".github/skills",
     ]
-    private static let agentsMdMarker = "AGENTS.md"
+    private nonisolated static let agentsMdMarker = "AGENTS.md"
 
     let supportedBundleIds: [String] = []
     var onStateChange: (() -> Void)?
@@ -46,6 +46,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private let registration: EnvironmentRegistrationController
     private var pollTimer: Timer?
+    private var observationTask: Task<Void, Never>?
     private var currentApp: ForegroundApp?
     private var currentTitle: String?
     private var previousNormalizedIds: [String]?
@@ -74,6 +75,8 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         }
         pollTimer?.invalidate()
         pollTimer = nil
+        observationTask?.cancel()
+        observationTask = nil
         currentApp = nil
         currentTitle = nil
         previousNormalizedIds = nil
@@ -98,9 +101,17 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let app = currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: app.pid) ?? currentTitle
-        currentTitle = title
-        let observation = Self.observation(for: app, title: title)
+        let title = currentTitle
+        observationTask?.cancel()
+        observationTask = Task.detached { [weak self] in
+            let observation = Self.observation(for: app, title: title)
+            guard !Task.isCancelled else { return }
+            await self?.apply(observation, for: app)
+        }
+    }
+
+    private func apply(_ observation: GenericEnvironmentObservation, for app: ForegroundApp) {
+        guard currentApp == app else { return }
         defer {
             previousNormalizedIds = observation.normalizedIds
             currentAppEnvironmentId = observation.deepestDirEnvironmentId
@@ -113,7 +124,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         registration.emitNow(candidates: observation.candidates, reason: "generic")
     }
 
-    private static func observation(for app: ForegroundApp, title: String?) -> GenericEnvironmentObservation {
+    nonisolated private static func observation(for app: ForegroundApp, title: String?) -> GenericEnvironmentObservation {
         let documentValues = AXReader.focusedWindowDocumentValues(pid: app.pid)
         var candidatesById: [String: EnvironmentCandidate] = [:]
         var deepestWebEnvironmentId: String?
@@ -150,7 +161,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         )
     }
 
-    private static func directoryCandidates(fromObservedPath observedPath: String, app: ForegroundApp, title: String?, rawValue: String) -> [EnvironmentCandidate] {
+    nonisolated private static func directoryCandidates(fromObservedPath observedPath: String, app: ForegroundApp, title: String?, rawValue: String) -> [EnvironmentCandidate] {
         let directories = candidateDirectories(forObservedPath: observedPath)
         return directories.compactMap { directoryPath in
             let detection = detectDirectorySignals(at: directoryPath)
@@ -173,7 +184,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         }
     }
 
-    private static func webCandidates(from rawURL: String, app: ForegroundApp, title: String?) -> [EnvironmentCandidate] {
+    nonisolated private static func webCandidates(from rawURL: String, app: ForegroundApp, title: String?) -> [EnvironmentCandidate] {
         let ids = webEnvironmentIds(from: rawURL)
         guard !ids.isEmpty else { return [] }
         return ids.map { environmentId in
@@ -185,7 +196,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         }
     }
 
-    private static func candidateDirectories(forObservedPath observedPath: String) -> [String] {
+    nonisolated private static func candidateDirectories(forObservedPath observedPath: String) -> [String] {
         let homeDir = URL(fileURLWithPath: NSHomeDirectory()).standardizedFileURL.path
         guard observedPath.hasPrefix(homeDir + "/") else { return [] }
 
@@ -202,7 +213,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         return result.reversed()
     }
 
-    private static func detectDirectorySignals(at directoryPath: String) -> DirectorySignalDetection {
+    nonisolated private static func detectDirectorySignals(at directoryPath: String) -> DirectorySignalDetection {
         let entries = (try? fileManager.contentsOfDirectory(atPath: directoryPath)) ?? []
         let entrySet = Set(entries)
 
@@ -228,7 +239,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         )
     }
 
-    static func normalizedAbsolutePath(from rawValue: String) -> String? {
+    nonisolated static func normalizedAbsolutePath(from rawValue: String) -> String? {
         let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         if let url = URL(string: trimmed), url.isFileURL {
@@ -240,7 +251,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         return URL(fileURLWithPath: trimmed).standardizedFileURL.path
     }
 
-    static func webEnvironmentIds(from rawURL: String) -> [String] {
+    nonisolated static func webEnvironmentIds(from rawURL: String) -> [String] {
         guard let components = URLComponents(string: rawURL),
               let scheme = components.scheme?.lowercased(),
               scheme == "http" || scheme == "https",
@@ -250,7 +261,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         return ["web:\(host)"]
     }
 
-    private static func webDisplayName(for environmentId: String) -> String {
+    nonisolated private static func webDisplayName(for environmentId: String) -> String {
         let path = environmentId.replacingOccurrences(of: "web:", with: "")
         let parts = path.split(separator: "/").map(String.init)
         guard let first = parts.first else { return environmentId }
@@ -258,7 +269,7 @@ final class GenericEnvironmentProvider: SpecializedEnvironmentProvider {
         return ([first] + parts.dropFirst()).joined(separator: " / ")
     }
 
-    static func warningForNonAbsoluteDirectoryCandidate(rawValue: String, app: ForegroundApp) {
+    nonisolated static func warningForNonAbsoluteDirectoryCandidate(rawValue: String, app: ForegroundApp) {
         logger.warning("Skipping non-absolute directory candidate for bundleId=\(app.bundleId, privacy: .public): \(rawValue, privacy: .public)")
     }
 }

--- a/clients/mac/Sources/Models/EnvironmentProviders/OBSStudioEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/OBSStudioEnvironmentProvider.swift
@@ -60,8 +60,7 @@ final class OBSStudioEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
-        currentTitle = title
+        let title = currentTitle
         currentAppEnvironmentId = Self.currentEnvironmentId(bundleId: currentApp.bundleId, title: title)
         let candidates = Self.candidates(for: currentApp, title: title)
         registration.emitNow(candidates: candidates, reason: "obs-studio")

--- a/clients/mac/Sources/Models/EnvironmentProviders/ObsidianEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/ObsidianEnvironmentProvider.swift
@@ -61,8 +61,7 @@ final class ObsidianEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
-        currentTitle = title
+        let title = currentTitle
         currentAppEnvironmentId = Self.currentVaultEnvironmentId(bundleId: currentApp.bundleId, title: title)
         let candidates = Self.candidates(for: currentApp, title: title)
         registration.emitNow(candidates: candidates, reason: "obsidian")

--- a/clients/mac/Sources/Models/EnvironmentProviders/SlackEnvironmentProvider.swift
+++ b/clients/mac/Sources/Models/EnvironmentProviders/SlackEnvironmentProvider.swift
@@ -58,8 +58,7 @@ final class SlackEnvironmentProvider: SpecializedEnvironmentProvider {
 
     private func poll() {
         guard let currentApp else { return }
-        let title = AXReader.focusedWindowTitle(pid: currentApp.pid) ?? currentTitle
-        currentTitle = title
+        let title = currentTitle
         currentAppEnvironmentId = Self.currentEnvironmentId(bundleId: currentApp.bundleId, title: title)
         let candidates = Self.candidates(for: currentApp, title: title)
         registration.emitNow(candidates: candidates, reason: "slack")

--- a/clients/mac/Sources/Services/AXReader.swift
+++ b/clients/mac/Sources/Services/AXReader.swift
@@ -21,15 +21,6 @@ enum AXReader {
         AXUIElementSetAttributeValue(appElement, "AXManualAccessibility" as CFString, kCFBooleanTrue)
     }
 
-    /// Warm up an app's accessibility tree (call when it comes to the
-    /// foreground) so content is ready by the time the agent reads it.
-    static func primeAccessibility(pid: pid_t) {
-        guard isTrusted() else {
-            return
-        }
-        enableWebContentAccessibility(AXUIElementCreateApplication(pid))
-    }
-
     /// Title of the focused (or main) window of the app owning `pid`, or nil if
     /// AX isn't trusted / the app exposes no titled window.
     static func focusedWindowTitle(pid: pid_t) -> String? {
@@ -67,7 +58,6 @@ enum AXReader {
             return nil
         }
         let appElement = AXUIElementCreateApplication(pid)
-        enableWebContentAccessibility(appElement)
         var windowRef: AnyObject?
         if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) != .success {
             if AXUIElementCopyAttributeValue(appElement, kAXMainWindowAttribute as CFString, &windowRef) != .success {
@@ -80,10 +70,10 @@ enum AXReader {
         return windowRef as! AXUIElement
     }
 
-    /// The active tab's URL for a Chromium/WebKit browser owning `pid`, read from
-    /// the focused window's AXWebArea (AXURL). Relies on the web-content tree, so
-    /// the browser should have been primed (it comes forward → primeAccessibility).
-    /// Returns nil for non-browsers or before the URL is exposed.
+    /// The active tab's URL for a known browser owning `pid`, read from the
+    /// focused window's AXWebArea (AXURL). Callers must restrict this to browser
+    /// bundle IDs; walking an arbitrary app's AX tree can block for a long time.
+    /// Returns nil when the browser does not expose a focused web area or URL.
     static func activeTabURL(pid: pid_t, maxNodes: Int = 600) -> String? {
         guard let window = focusedWindow(pid: pid) else {
             return nil

--- a/clients/mac/Sources/Services/AXReader.swift
+++ b/clients/mac/Sources/Services/AXReader.swift
@@ -86,7 +86,7 @@ enum AXReader {
     }
 
     private static func focusedWindow(pid: pid_t) -> AXUIElement? {
-        guard isTrusted() else {
+        guard !isInternalRookTarget(pid), isTrusted() else {
             return nil
         }
         let context = DiagnosticsContext(pid: pid)
@@ -185,7 +185,7 @@ enum AXReader {
     /// text-based apps, using only the Accessibility grant (no screenshots).
     /// Node- and char-budgeted so a deep tree can't hang the caller.
     static func focusedWindowText(pid: pid_t, maxChars: Int = 12_000, maxNodes: Int = 6_000) -> String? {
-        guard isTrusted() else {
+        guard !isInternalRookTarget(pid), isTrusted() else {
             return nil
         }
         let appElement = AXUIElementCreateApplication(pid)
@@ -221,7 +221,7 @@ enum AXReader {
     /// reads this list and picks one to click — no screenshot/vision needed.
     /// Coordinates are global top-left screen space, matching CGEvent input.
     static func actionableElements(pid: pid_t, maxElements: Int = 250, maxNodes: Int = 8_000) -> [ActionableElement]? {
-        guard isTrusted() else {
+        guard !isInternalRookTarget(pid), isTrusted() else {
             return nil
         }
         let appElement = AXUIElementCreateApplication(pid)
@@ -308,6 +308,13 @@ enum AXReader {
         for child in children {
             collectActionable(child, into: &elements, max: max, nodeBudget: &nodeBudget)
         }
+    }
+
+    private static func isInternalRookTarget(_ pid: pid_t) -> Bool {
+        guard let bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier else {
+            return false
+        }
+        return RookBundleIdentity.isInternalRookBundleId(bundleId)
     }
 
     private static func copyAttributeValue(

--- a/clients/mac/Sources/Services/AXReader.swift
+++ b/clients/mac/Sources/Services/AXReader.swift
@@ -1,10 +1,27 @@
+import AppKit
 import ApplicationServices
 import Foundation
+import OSLog
 
 /// Tier 1 perception: reading another app's focused-window title needs the
 /// Accessibility (AX) permission. App *identity* (NSWorkspace) does not — only
 /// reading inside another process does.
 enum AXReader {
+    private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "com.rookery.Rook", category: "AXReader")
+    private static let messagingTimeout: Float = 0.5
+    private static let activeTabTraversalDeadlineNanoseconds: UInt64 = 2_000_000_000
+    private static let slowCallThresholdMilliseconds = 100.0
+
+    private struct DiagnosticsContext {
+        let pid: pid_t
+        let bundleId: String
+
+        init(pid: pid_t) {
+            self.pid = pid
+            self.bundleId = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier ?? "unknown"
+        }
+    }
+
     static func isTrusted(promptIfNeeded: Bool = false) -> Bool {
         let key = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
         let options = [key: promptIfNeeded] as CFDictionary
@@ -27,8 +44,14 @@ enum AXReader {
         guard let window = focusedWindow(pid: pid) else {
             return nil
         }
-        var titleRef: AnyObject?
-        guard AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success else {
+        let context = DiagnosticsContext(pid: pid)
+        let (error, titleRef) = copyAttributeValue(
+            window,
+            attribute: kAXTitleAttribute as String,
+            context: context,
+            operation: "focused-window-title"
+        )
+        guard error == .success else {
             return nil
         }
         let title = titleRef as? String
@@ -41,13 +64,22 @@ enum AXReader {
         guard let window = focusedWindow(pid: pid) else {
             return []
         }
+        let context = DiagnosticsContext(pid: pid)
         let attributes = ["AXDocument", "AXFilename", "AXURL"]
         var results: [String] = []
         for attribute in attributes {
-            if let value = stringAttribute(window, attribute)?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !value.isEmpty,
-               !results.contains(value) {
-                results.append(value)
+            let (error, valueRef) = copyAttributeValue(
+                window,
+                attribute: attribute,
+                context: context,
+                operation: "focused-window-document.\(attribute)"
+            )
+            guard error == .success, let value = valueRef as? String else {
+                continue
+            }
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty, !results.contains(trimmed) {
+                results.append(trimmed)
             }
         }
         return results
@@ -57,12 +89,28 @@ enum AXReader {
         guard isTrusted() else {
             return nil
         }
+        let context = DiagnosticsContext(pid: pid)
         let appElement = AXUIElementCreateApplication(pid)
         var windowRef: AnyObject?
-        if AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &windowRef) != .success {
-            if AXUIElementCopyAttributeValue(appElement, kAXMainWindowAttribute as CFString, &windowRef) != .success {
+        let (focusedError, focusedWindowRef) = copyAttributeValue(
+            appElement,
+            attribute: kAXFocusedWindowAttribute as String,
+            context: context,
+            operation: "focused-window"
+        )
+        if focusedError == .success {
+            windowRef = focusedWindowRef
+        } else {
+            let (mainError, mainWindowRef) = copyAttributeValue(
+                appElement,
+                attribute: kAXMainWindowAttribute as String,
+                context: context,
+                operation: "main-window"
+            )
+            guard mainError == .success else {
                 return nil
             }
+            windowRef = mainWindowRef
         }
         guard let windowRef else {
             return nil
@@ -78,34 +126,57 @@ enum AXReader {
         guard let window = focusedWindow(pid: pid) else {
             return nil
         }
+        let context = DiagnosticsContext(pid: pid)
+        let deadline = DispatchTime.now().uptimeNanoseconds + activeTabTraversalDeadlineNanoseconds
         // Breadth-first: the web area sits near the top of the window subtree.
         var queue: [AXUIElement] = [window]
-        var budget = maxNodes
-        while !queue.isEmpty, budget > 0 {
+        var nodesVisited = 0
+        while !queue.isEmpty,
+              nodesVisited < maxNodes,
+              DispatchTime.now().uptimeNanoseconds < deadline {
             let element = queue.removeFirst()
-            budget -= 1
-            if stringAttribute(element, kAXRoleAttribute as String) == "AXWebArea",
-               let url = urlAttribute(element, "AXURL") {
-                return url
+            nodesVisited += 1
+            let (roleError, roleRef) = copyAttributeValue(
+                element,
+                attribute: kAXRoleAttribute as String,
+                context: context,
+                operation: "active-tab-url.role",
+                nodeCount: nodesVisited
+            )
+            if roleError == .success,
+               roleRef as? String == "AXWebArea" {
+                let (urlError, urlRef) = copyAttributeValue(
+                    element,
+                    attribute: "AXURL",
+                    context: context,
+                    operation: "active-tab-url.url",
+                    nodeCount: nodesVisited
+                )
+                if urlError == .success {
+                    if let url = urlRef as? NSURL {
+                        return url.absoluteString
+                    }
+                    if let url = urlRef as? String {
+                        return url
+                    }
+                }
             }
-            var childrenRef: AnyObject?
-            if AXUIElementCopyAttributeValue(element, kAXChildrenAttribute as CFString, &childrenRef) == .success,
+            let (childrenError, childrenRef) = copyAttributeValue(
+                element,
+                attribute: kAXChildrenAttribute as String,
+                context: context,
+                operation: "active-tab-url.children",
+                nodeCount: nodesVisited
+            )
+            if childrenError == .success,
                let children = childrenRef as? [AXUIElement] {
                 queue.append(contentsOf: children)
             }
         }
+        if DispatchTime.now().uptimeNanoseconds >= deadline {
+            logger.warning("AX traversal deadline reached operation=active-tab-url pid=\(context.pid, privacy: .public) bundleId=\(context.bundleId, privacy: .public) nodes=\(nodesVisited, privacy: .public)")
+        }
         return nil
-    }
-
-    private static func urlAttribute(_ element: AXUIElement, _ attribute: String) -> String? {
-        var value: AnyObject?
-        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success, let value else {
-            return nil
-        }
-        if let url = value as? NSURL {
-            return url.absoluteString
-        }
-        return value as? String
     }
 
     /// Visible text of the focused window, extracted by walking the
@@ -237,6 +308,24 @@ enum AXReader {
         for child in children {
             collectActionable(child, into: &elements, max: max, nodeBudget: &nodeBudget)
         }
+    }
+
+    private static func copyAttributeValue(
+        _ element: AXUIElement,
+        attribute: String,
+        context: DiagnosticsContext,
+        operation: String,
+        nodeCount: Int = 0
+    ) -> (AXError, AnyObject?) {
+        AXUIElementSetMessagingTimeout(element, messagingTimeout)
+        var value: AnyObject?
+        let started = DispatchTime.now().uptimeNanoseconds
+        let error = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        let elapsedMilliseconds = Double(DispatchTime.now().uptimeNanoseconds - started) / 1_000_000
+        if elapsedMilliseconds >= slowCallThresholdMilliseconds {
+            logger.warning("slow AX call operation=\(operation, privacy: .public) pid=\(context.pid, privacy: .public) bundleId=\(context.bundleId, privacy: .public) elapsedMs=\(elapsedMilliseconds, privacy: .public) result=\(error.rawValue, privacy: .public) nodes=\(nodeCount, privacy: .public)")
+        }
+        return (error, value)
     }
 
     private static func stringAttribute(_ element: AXUIElement, _ attribute: String) -> String? {

--- a/clients/mac/Sources/Services/ForegroundAppMonitor.swift
+++ b/clients/mac/Sources/Services/ForegroundAppMonitor.swift
@@ -38,6 +38,7 @@ struct ForegroundApp: Equatable {
 final class ForegroundAppMonitor {
     var onForegroundChange: ((ForegroundApp) -> Void)?
     var onContextRefresh: ((ForegroundApp, String?) -> Void)?
+    var onInternalRookActivation: (() -> Void)?
 
     private(set) var current: ForegroundApp?
     private(set) var currentTitle: String?
@@ -104,8 +105,8 @@ final class ForegroundAppMonitor {
 
     private func handleActivation(_ app: ForegroundApp) {
         providerLog("activation: \(app.name) [\(app.bundleId)]")
-        // Our own panel/window gaining focus must not end the current episode.
-        if app.bundleId == Bundle.main.bundleIdentifier {
+        guard !RookBundleIdentity.isInternalRookBundleId(app.bundleId) else {
+            clearCurrentAppForInternalRook()
             return
         }
         guard app != current else {
@@ -135,8 +136,11 @@ final class ForegroundAppMonitor {
 
     private func poll() {
         guard let frontmost = NSWorkspace.shared.frontmostApplication,
-              let app = Self.makeApp(frontmost),
-              app.bundleId != Bundle.main.bundleIdentifier else {
+              let app = Self.makeApp(frontmost) else {
+            return
+        }
+        guard !RookBundleIdentity.isInternalRookBundleId(app.bundleId) else {
+            clearCurrentAppForInternalRook()
             return
         }
         if app != current {
@@ -151,5 +155,16 @@ final class ForegroundAppMonitor {
             currentTitle = title
             onContextRefresh?(app, title)
         }
+    }
+
+    private func clearCurrentAppForInternalRook() {
+        debounceTask?.cancel()
+        debounceTask = nil
+        guard current != nil || currentTitle != nil else {
+            return
+        }
+        current = nil
+        currentTitle = nil
+        onInternalRookActivation?()
     }
 }

--- a/clients/mac/Sources/Services/ForegroundAppMonitor.swift
+++ b/clients/mac/Sources/Services/ForegroundAppMonitor.swift
@@ -15,7 +15,7 @@ func providerLog(_ message: String) {
     }
 }
 
-struct ForegroundApp: Equatable {
+struct ForegroundApp: Equatable, Sendable {
     let bundleId: String
     let name: String
     let pid: pid_t
@@ -45,6 +45,7 @@ final class ForegroundAppMonitor {
 
     private var observer: NSObjectProtocol?
     private var debounceTask: Task<Void, Never>?
+    private var titleReadTask: Task<Void, Never>?
     private var pollTimer: Timer?
     private let debounceNanoseconds: UInt64 = 700_000_000
 
@@ -84,6 +85,7 @@ final class ForegroundAppMonitor {
         }
         observer = nil
         debounceTask?.cancel()
+        titleReadTask?.cancel()
         pollTimer?.invalidate()
         pollTimer = nil
     }
@@ -124,12 +126,27 @@ final class ForegroundAppMonitor {
 
     private func commit(_ app: ForegroundApp) {
         current = app
+        currentTitle = nil
         onForegroundChange?(app)
         emitContext(for: app)
     }
 
     private func emitContext(for app: ForegroundApp) {
-        let title = AXReader.focusedWindowTitle(pid: app.pid)
+        titleReadTask?.cancel()
+        titleReadTask = Task.detached { [weak self] in
+            let title = AXReader.focusedWindowTitle(pid: app.pid)
+            guard !Task.isCancelled else { return }
+            await self?.deliverContext(for: app, title: title)
+        }
+    }
+
+    private func deliverContext(for app: ForegroundApp, title: String?) {
+        guard current == app else {
+            return
+        }
+        guard currentTitle != title else {
+            return
+        }
         currentTitle = title
         onContextRefresh?(app, title)
     }
@@ -150,16 +167,14 @@ final class ForegroundAppMonitor {
             commit(app)
             return
         }
-        let title = AXReader.focusedWindowTitle(pid: app.pid)
-        if title != currentTitle {
-            currentTitle = title
-            onContextRefresh?(app, title)
-        }
+        emitContext(for: app)
     }
 
     private func clearCurrentAppForInternalRook() {
         debounceTask?.cancel()
         debounceTask = nil
+        titleReadTask?.cancel()
+        titleReadTask = nil
         guard current != nil || currentTitle != nil else {
             return
         }

--- a/clients/mac/Sources/Services/RookBundleIdentity.swift
+++ b/clients/mac/Sources/Services/RookBundleIdentity.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Bundle identities used by the production app and isolated development builds.
+/// Internal Rook processes must never be treated as user-facing environment targets.
+enum RookBundleIdentity {
+    static let productionBundleId = "com.rookery.Rook"
+    static let developmentBundleIdPrefix = "com.rookery.Rook.Dev."
+
+    static func isInternalRookBundleId(_ bundleId: String, currentBundleId: String? = Bundle.main.bundleIdentifier) -> Bool {
+        if bundleId == productionBundleId || bundleId.hasPrefix(developmentBundleIdPrefix) {
+            return true
+        }
+        return bundleId == currentBundleId
+    }
+}

--- a/clients/mac/Tests/BrowserEnvironmentProviderTests.swift
+++ b/clients/mac/Tests/BrowserEnvironmentProviderTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import Rook
+import RookKit
+
+@MainActor
+final class BrowserEnvironmentProviderTests: XCTestCase {
+    func testSupportsSafariAndFirefoxOnly() {
+        let provider = BrowserEnvironmentProvider(register: { _, _ in })
+
+        XCTAssertEqual(provider.supportedBundleIds, [
+            "com.apple.Safari",
+            "org.mozilla.firefox",
+        ])
+    }
+
+    func testSiteEnvironmentIdUsesURLHost() {
+        XCTAssertEqual(
+            BrowserEnvironmentProvider.siteEnvironmentId(from: "https://Example.COM/path?q=1"),
+            "web:example.com"
+        )
+        XCTAssertNil(BrowserEnvironmentProvider.siteEnvironmentId(from: "about:blank"))
+        XCTAssertNil(BrowserEnvironmentProvider.siteEnvironmentId(from: nil))
+    }
+
+    func testCandidatesIncludeBrowserAndObservedURLMetadata() {
+        let app = ForegroundApp(bundleId: "com.apple.Safari", name: "Safari", pid: 1)
+        let candidates = BrowserEnvironmentProvider.candidates(
+            for: app,
+            title: "Example",
+            url: "https://example.com/path"
+        )
+
+        XCTAssertEqual(candidates.map(\.id), ["web:example.com"])
+        XCTAssertEqual(candidates[0].metadata["appName"], .string("Safari"))
+        XCTAssertEqual(candidates[0].metadata["url"], .string("https://example.com/path"))
+        XCTAssertEqual(candidates[0].metadata["displayName"], .string("example.com"))
+    }
+
+    func testProviderUsesBaseAppEnvironmentAndClearsStateOnDeactivate() {
+        let provider = BrowserEnvironmentProvider(register: { _, _ in })
+        let app = ForegroundApp(bundleId: "org.mozilla.firefox", name: "Firefox", pid: 1)
+
+        provider.activate(app: app, title: "Example")
+        XCTAssertEqual(provider.currentAppEnvironmentId, "mac:org.mozilla.firefox")
+
+        provider.deactivate()
+        XCTAssertNil(provider.currentAppEnvironmentId)
+        XCTAssertNil(provider.currentSiteEnvironmentId)
+    }
+}

--- a/clients/mac/Tests/RookBundleIdentityTests.swift
+++ b/clients/mac/Tests/RookBundleIdentityTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import Rook
+
+final class RookBundleIdentityTests: XCTestCase {
+    func testRecognizesProductionAndDevelopmentBundleIds() {
+        XCTAssertTrue(RookBundleIdentity.isInternalRookBundleId("com.rookery.Rook", currentBundleId: "com.example.Test"))
+        XCTAssertTrue(RookBundleIdentity.isInternalRookBundleId("com.rookery.Rook.Dev.browser.environment.providers", currentBundleId: "com.example.Test"))
+    }
+
+    func testRecognizesTheCurrentBundleIdEvenIfItIsCustom() {
+        XCTAssertTrue(RookBundleIdentity.isInternalRookBundleId("com.example.Test", currentBundleId: "com.example.Test"))
+    }
+
+    func testRejectsExternalBundleIds() {
+        XCTAssertFalse(RookBundleIdentity.isInternalRookBundleId("com.google.Chrome", currentBundleId: "com.example.Test"))
+        XCTAssertFalse(RookBundleIdentity.isInternalRookBundleId("com.rookery.RookOther", currentBundleId: "com.example.Test"))
+    }
+}


### PR DESCRIPTION
## What changed

- Add a Safari/Firefox specialist provider for nested active-tab URL detection.
- Keep generic environment inspection limited to top-level document signals; Electron and arbitrary apps no longer get browser-tree traversal.
- Exclude production and development Rook bundle IDs from foreground environment inspection, with a defense-in-depth guard in `AXReader`.
- Bound and time environment AX calls, and run title/document/browser reads away from the main actor.

## Why it matters

A roughly 41-second `activeTabURL` lookup against another Rook process was freezing the Mac client with a beachball. This keeps Rook from inspecting another Rook, preserves useful Safari and Firefox web environments, and makes any future pathological AX call bounded and diagnosable instead of blocking the UI indefinitely.

## Notes for reviewers

- Chrome remains on the generic path because its top-level `AXDocument` supplied the page URL during manual testing.
- The bridge's explicit text/action perception path remains separate and can still prime web content when requested.
- Manual validation with the new isolated build and the main build found that both clients observed the other's environment much more snappily after the change.
- No production server, database, or persisted schema was changed.
- Backward-compatibility review: no compatibility shims, migrations, retained formats, or protocol surfaces were added or changed.

## Product specification alignment

**Classification:** Extends

**Related PRODUCT/ docs:**
- [`PRODUCT/goals-of-rook.md`](https://github.com/rookkeeper/rook/blob/main/PRODUCT/goals-of-rook.md) — preserves Rook's goal of understanding explicit app and website environments.
- [`PRODUCT/environment-state.md`](https://github.com/rookkeeper/rook/blob/main/PRODUCT/environment-state.md) — keeps provider availability separate from session entry and capability loading.

**Documentation updates in this PR:**
- No PRODUCT/ updates — this narrows the implementation of existing environment-awareness behavior without adding a new product concept.

**Notes:** Browser-specific Accessibility behavior is an implementation boundary, not a new environment or capability model.

## Architecture alignment

**Classification:** Modifies

**Related docs / patterns:**
- [`AS-BUILT-ARCHITECTURE/mac-client.md`](https://github.com/rookkeeper/rook/blob/main/AS-BUILT-ARCHITECTURE/mac-client.md) — updates the foreground provider and Accessibility boundaries.
- [`clients/mac/README.md`](https://github.com/rookkeeper/rook/blob/main/clients/mac/README.md) — documents browser specialists and internal-Rook exclusion.

**Documentation updates in this PR:**
- [x] `AS-BUILT-ARCHITECTURE/mac-client.md` — documents specialized Safari/Firefox detection, internal-Rook filtering, timing, and off-main-actor reads.
- [x] `clients/mac/README.md` — documents the new provider boundary.
- [x] `README.md` — identifies the Mac client's bundle-scoped inspection behavior.

**Notes:** The generic provider is intentionally narrower. Safari and Firefox use the explicit browser specialist; generic and Electron paths do not walk arbitrary Accessibility trees.

## New tests

- Browser specialist URL normalization, candidate metadata, supported bundle IDs, and lifecycle state.
- Production/development/custom Rook bundle recognition and external bundle rejection.
- Existing Mac suite, including watchdog coverage, passes with 48 tests.

## Technical touchpoints

- **Components:** `ForegroundAppMonitor`, `AppEnvironmentProvider`, `GenericEnvironmentProvider`, `BrowserEnvironmentProvider`, `AXReader`.
- **Boundaries:** bundle-scoped specialist registry, centralized internal-Rook AX guard, detached environment observation tasks.
- **Diagnostics:** bounded AX messaging, browser traversal deadline, slow-call metadata logging, and existing main-actor watchdog records.

## How to check it

- [x] `xcodebuild -project clients/mac/Rook.xcodeproj -scheme Rook -destination 'platform=macOS' test`
- [x] Manually run two Mac clients and switch focus between them; confirm environment detection remains responsive.
- [x] Verify the working investigation remains in `CHANGES/2026-08-11-mac-client-stall-investigation/TODO.md` without creating an outcome document.
