### PR TITLE
Remove remaining compatibility residue

### DIFF
--- a/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
+++ b/clients/RookKit/Sources/RookKit/Net/SessionHandle.swift
@@ -480,14 +480,14 @@ public final class SessionHandle {
         switch event {
         case .userMessageChunk(let text):
             if isReplaying {
-                replayFlushIncompatibleSection("user")
+                replayFlushMismatchedSection("user")
                 replayUserBuffer += text
             } else {
                 appendBlock(.user(text: text))
             }
         case .agentMessageChunk(let text):
             if isReplaying {
-                replayFlushIncompatibleSection("assistant")
+                replayFlushMismatchedSection("assistant")
                 replayAssistantBuffer += text
             } else {
                 statusLine = "Responding…"
@@ -496,7 +496,7 @@ public final class SessionHandle {
             }
         case .agentThoughtChunk(let text):
             if isReplaying {
-                replayFlushIncompatibleSection("thinking")
+                replayFlushMismatchedSection("thinking")
                 replayThinkingBuffer += text
             } else {
                 statusLine = "Thinking…"
@@ -504,9 +504,9 @@ public final class SessionHandle {
             }
         case .toolCallStarted(let toolCallId, let title, let kind, let status, let rawInput):
             if isReplaying {
-                replayFlushIncompatibleSection("tool")
+                replayFlushMismatchedSection("tool")
             } else {
-                flushLiveIncompatibleSection()
+                flushLiveMismatchedSection()
                 statusLine = "Using tool: \(title)"
             }
             let state = ToolBlockState(
@@ -520,9 +520,9 @@ public final class SessionHandle {
             appendBlock(.tool(state), id: "tool-\(toolCallId)-\(blockCounter)")
         case .toolCallUpdate(let toolCallId, let status, let toolName, let output):
             if isReplaying {
-                replayFlushIncompatibleSection("tool")
+                replayFlushMismatchedSection("tool")
             } else {
-                flushLiveIncompatibleSection()
+                flushLiveMismatchedSection()
             }
             updateTool(toolCallId) { tool in
                 if let toolName, tool.title.isEmpty { tool.title = toolName }
@@ -545,7 +545,7 @@ public final class SessionHandle {
             scheduleStreamingFlush()
         case .toolCallReady(let toolCallId, _):
             if isReplaying { updateTool(toolCallId) { advanceToolStatus(&$0, to: .ready) }; return }
-            flushLiveIncompatibleSection()
+            flushLiveMismatchedSection()
             updateTool(toolCallId) { advanceToolStatus(&$0, to: .ready) }
         case .toolOutputSnapshot(let toolCallId, _, let text):
             if isReplaying { updateTool(toolCallId) { $0.output = text }; return }
@@ -658,7 +658,7 @@ public final class SessionHandle {
         }
     }
 
-    private func flushLiveIncompatibleSection() {
+    private func flushLiveMismatchedSection() {
         streamingFlushTask?.cancel()
         streamingFlushTask = nil
         applyStreamingFlush()
@@ -705,7 +705,7 @@ public final class SessionHandle {
     }
 
     private func finalizeStreamingBlocks() {
-        flushLiveIncompatibleSection()
+        flushLiveMismatchedSection()
         streamingTextAccumulator = ""
         toolArgBuffers = [:]
         toolOutputBuffers = [:]
@@ -759,7 +759,7 @@ public final class SessionHandle {
         if !replayAssistantBuffer.isEmpty { appendBlock(.assistantText(text: replayAssistantBuffer, streaming: false)); replayAssistantBuffer = "" }
     }
 
-    private func replayFlushIncompatibleSection(_ next: String) {
+    private func replayFlushMismatchedSection(_ next: String) {
         switch next {
         case "user":
             if !replayAssistantBuffer.isEmpty { flushReplaySection("assistant") }

--- a/clients/android/app/src/main/java/com/rookery/rook/ui/chat/ChatBlockView.kt
+++ b/clients/android/app/src/main/java/com/rookery/rook/ui/chat/ChatBlockView.kt
@@ -1,7 +1,7 @@
 // Mirrors clients/RookKit/Sources/RookKit/Design/ChatBlockViews.swift
 //
 // AssistantText renders plain Text even once streaming is done, not styled Markdown — the
-// Phase 2 plan's markdown-renderer dependency has no release compatible with this project's
+// Phase 2 plan's markdown-renderer dependency has no release available for this project's
 // Kotlin 2.0.21 / compileSdk 35 toolchain (every maintained tag needs Kotlin 2.2+ /
 // compileSdk 36+), so it was dropped rather than bumping the whole toolchain. Revisit if the
 // toolchain moves.

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -158,8 +158,8 @@ they are the only environment providers that walk a focused `AXWebArea` to find
 the active page URL. The generic provider uses only top-level document values,
 so Electron and other arbitrary applications are not treated as browsers.
 Finder is a specialist too, but it emits `dir:/...` environments instead of
-Finder-specific IDs so local file context stays consistent. For Obsidian, vault parsing is title-based and works
-backwards so note names may contain dashes safely. For plain apps the base
+Finder-specific IDs so local file context stays consistent. For Obsidian, vault parsing is title-based and scans from the end so note names may contain
+dashes safely. For plain apps the base
 identity is the bundle id: `mac:<bundleId>`.
 
 Each newly encountered environment registers with a fresh `registeredAt`

--- a/scripts/lib/dump-environment-decisions/dump-environment-decisions.ts
+++ b/scripts/lib/dump-environment-decisions/dump-environment-decisions.ts
@@ -31,7 +31,7 @@ const db = new DatabaseSync(dbPath);
 type Row = {
   bundle_hash: string;
   environment_id: string;
-  bundle_id: string | null;
+  bundle_id: string;
   decision: string;
   updated_at: string;
 };
@@ -50,7 +50,7 @@ if (rows.length === 0) {
 // Column widths
 const hashW = Math.max(12, ...rows.map((r) => r.bundle_hash.length));
 const envW = Math.max(14, ...rows.map((r) => r.environment_id.length));
-const bundleW = Math.max(9, ...rows.map((r) => (r.bundle_id ?? "(none)").length));
+const bundleW = Math.max(9, ...rows.map((r) => r.bundle_id.length));
 const decW = 8;
 const timeW = 20;
 
@@ -71,7 +71,7 @@ for (const row of rows) {
     ? row.bundle_hash.slice(0, 16) + "…"
     : row.bundle_hash;
   console.log(
-    `${pad(shortHash, hashW)}  ${pad(row.environment_id, envW)}  ${pad(row.bundle_id ?? "(none)", bundleW)}  ${pad(row.decision, decW)}  ${pad(row.updated_at.replace("T", " ").slice(0, 19), timeW)}`,
+    `${pad(shortHash, hashW)}  ${pad(row.environment_id, envW)}  ${pad(row.bundle_id, bundleW)}  ${pad(row.decision, decW)}  ${pad(row.updated_at.replace("T", " ").slice(0, 19), timeW)}`,
   );
 }
 

--- a/server/src/environments/repositories/ProjectDirectoryEnvironmentRepository.test.ts
+++ b/server/src/environments/repositories/ProjectDirectoryEnvironmentRepository.test.ts
@@ -55,10 +55,6 @@ describe("ProjectDirectoryEnvironmentRepository", () => {
     const skill = path.join(project, ".agents", "skills", "deploy");
     await mkdir(skill, { recursive: true });
     await writeFile(path.join(skill, "SKILL.md"), "Deploy carefully.");
-    const ignored = path.join(project, ".claude", "skills", "ignored");
-    await mkdir(ignored, { recursive: true });
-    await writeFile(path.join(ignored, "SKILL.md"), "Not discovered.");
-
     const repository = new ProjectDirectoryEnvironmentRepository();
     const result = await repository.getBundles(`dir:${project}`);
 


### PR DESCRIPTION
## What changed

Remove the remaining compatibility residue from the current product paths.

- Rename replay helpers that described mismatched sections as incompatible.
- Remove obsolete wording from Android and Mac documentation.
- Make the environment-decision dump use the active profile database and required bundle ids.
- Keep project-directory tests focused on the canonical `.agents/skills` source.

## Why it matters

The main cleanup is already in the current branch. This PR finishes the remaining source, test, and documentation residue so the live paths describe only the current behavior.

## Product specification alignment

- [ ] No PRODUCT/ changes — this PR removes implementation residue without changing the documented product behavior.

## Architecture alignment

- [ ] No architecture changes — the canonical runtime and project-source boundaries remain unchanged.

## New tests

- Existing full server test suite passes: 136 passed, 5 skipped.
- RookKit Swift tests pass: 65 passed.
- TypeScript typecheck passes.

## How to check it

- `npm run typecheck`
- `npm test`
- `cd clients/RookKit && swift test`