### PR TITLE
Add server-authoritative session activity indicators

### DIFF
--- a/AS-BUILT-ARCHITECTURE/database.md
+++ b/AS-BUILT-ARCHITECTURE/database.md
@@ -10,7 +10,7 @@ Rook's durable server state is split across SQLite databases:
 
 The application database remains separate from environment repositories. This database is intentionally small: it stores session persistence and durable environment decisions. Runtime processes, active/recent environment caches, subscribers, and workspace projections remain transient. By default it lives under `ROOK_HOME/rook.sqlite` (`~/.rook/rook.sqlite` for the main checkout and `~/.rook-<worktree-slug>/rook.sqlite` for development worktrees), with `ROOK_DATABASE_PATH` as an explicit override.
 
-For session recency, no extra table or column was added: the existing `sessions.updated_at` field now represents both prompt activity and explicit client-side view/touch events, so opening a session can reorder the shared recents list without synthesizing transcript content.
+For session recency, the existing `sessions.updated_at` field represents both prompt activity and explicit client-side view/touch events. The sessions table also stores `attention_status`, a CHECK-constrained enum of `clear`, `ready`, or `error`. Active-turn state and view presence remain transient server state; the API combines them with the durable enum to return `activityStatus` as `active`, `ready`, `error`, `on`, or `off`.
 
 ## Session transcript persistence
 

--- a/AS-BUILT-ARCHITECTURE/server.md
+++ b/AS-BUILT-ARCHITECTURE/server.md
@@ -89,7 +89,8 @@ See also: [database.md](./database.md)
 - `GET /api/agent_runtimes`
 - `GET /api/sessions` — session listing over REST
 - `PATCH /api/sessions/:sessionId` — rename one session without changing recency ordering
-- `POST /api/sessions/:sessionId/touch` — mark one session as recently viewed so it sorts to the top
+- `POST /api/sessions/:sessionId/touch` — acknowledge pending attention, mark one session as recently viewed, and keep it open for activity acknowledgment
+- `POST /api/sessions/:sessionId/unview` — leave the session view so later completed turns can become pending attention
 - `DELETE /api/sessions/:sessionId` — delete one session plus transcript/workspace state
 - `GET /api/sessions/:sessionId/transcript` — server-owned normalized transcript for hydrators / second viewers
 - `POST /api/environments/register`
@@ -132,10 +133,13 @@ Persisted in SQLite:
 - `cwd`
 - `startedAt`
 - `updatedAt`
+- `attentionStatus` — durable `clear`, `ready`, or `error` enum constrained in SQLite
 
-The `GET /api/sessions` response additionally includes a `running` boolean
-(derived from whether a `SessionRuntime` is active for that session).
-`updatedAt` is used for both prompt activity and explicit view/touch operations,
+The `GET /api/sessions` response additionally includes `running` and the
+server-authoritative `activityStatus` (`active`, `ready`, `error`, `on`, or
+`off`). `active` is an in-flight ACP prompt; `ready` and `error` are durable
+pending attention states; `on` and `off` reflect live runtime liveness after
+attention precedence is applied. `updatedAt` is used for both prompt activity and explicit view/touch operations,
 so entering a session can move it to the top of the shared recents list without
 creating a synthetic prompt.
 

--- a/CHANGES/2026-08-12-session-activity-indicator/TODO-v2.md
+++ b/CHANGES/2026-08-12-session-activity-indicator/TODO-v2.md
@@ -27,5 +27,5 @@ Show reliable background activity on the session-selection page without changing
 - [x] Remove activity polling and activity presentation from per-agent session pages and chat views.
 - [x] Add quiet 5-second selection-page refreshes that update existing rows without loading/repaint glitches.
 - [x] Preserve existing chat status text and tool-call reporting.
-- [x] Add focused tests for state precedence, acknowledgment, active polling visibility, and server-provided client rendering.
+- [x] Add focused tests for state precedence, acknowledgment, active polling visibility, server-provided client rendering, and recency sorting.
 - [x] Run server, shared-client, and available native-client validation; Android validation is blocked by the unavailable Java runtime.

--- a/CHANGES/2026-08-12-session-activity-indicator/TODO-v2.md
+++ b/CHANGES/2026-08-12-session-activity-indicator/TODO-v2.md
@@ -1,0 +1,31 @@
+# Session selection activity pill
+
+## Context
+
+Show reliable background activity on the session-selection page without changing the chat experience.
+
+## Implementation lessons
+
+- Keep activity presentation exclusively in the session-selection list.
+- Leave the chat footer/status line unchanged; it remains the place for live protocol details such as tool calls.
+- Poll the visible main session-selection list every 5 seconds; do not poll from per-agent lists or chat views.
+- Refresh rows in place without showing a loading state or repainting the surrounding screen.
+- Keep the per-agent session list free of activity pills; its rows only select a session.
+- Let the server provide the state. Clients must not infer it from selection or socket state.
+
+## Decisions
+
+- The session pill displays `Active`, `Ready`, `Error`, `On`, or `Off` from `activityStatus`.
+- `Active` has priority over pending attention; `Ready` and `Error` persist until the user opens the session.
+- Opening a session acknowledges pending attention. Automatic resume does not.
+- The server derives the status from turn lifecycle, runtime liveness, and durable attention state.
+
+## Work checklist
+
+- [ ] Keep server turn tracking, durable attention, touch acknowledgment, and activity-status API behavior.
+- [ ] Keep the pill only on the main session-selection page across supported clients.
+- [ ] Remove activity polling and activity presentation from per-agent session pages and chat views.
+- [ ] Add quiet 10-second selection-page refreshes that update existing rows without loading/repaint glitches.
+- [ ] Preserve existing chat status text and tool-call reporting.
+- [ ] Add focused tests for state precedence, acknowledgment, polling updates, and stable selection-page rendering.
+- [ ] Run server, shared-client, and available native-client validation.

--- a/CHANGES/2026-08-12-session-activity-indicator/TODO-v2.md
+++ b/CHANGES/2026-08-12-session-activity-indicator/TODO-v2.md
@@ -22,10 +22,10 @@ Show reliable background activity on the session-selection page without changing
 
 ## Work checklist
 
-- [ ] Keep server turn tracking, durable attention, touch acknowledgment, and activity-status API behavior.
-- [ ] Keep the pill only on the main session-selection page across supported clients.
-- [ ] Remove activity polling and activity presentation from per-agent session pages and chat views.
-- [ ] Add quiet 10-second selection-page refreshes that update existing rows without loading/repaint glitches.
-- [ ] Preserve existing chat status text and tool-call reporting.
-- [ ] Add focused tests for state precedence, acknowledgment, polling updates, and stable selection-page rendering.
-- [ ] Run server, shared-client, and available native-client validation.
+- [x] Keep server turn tracking, durable attention, touch acknowledgment, and activity-status API behavior.
+- [x] Keep the pill only on the main session-selection page across supported clients.
+- [x] Remove activity polling and activity presentation from per-agent session pages and chat views.
+- [x] Add quiet 5-second selection-page refreshes that update existing rows without loading/repaint glitches.
+- [x] Preserve existing chat status text and tool-call reporting.
+- [x] Add focused tests for state precedence, acknowledgment, active polling visibility, and server-provided client rendering.
+- [x] Run server, shared-client, and available native-client validation; Android validation is blocked by the unavailable Java runtime.

--- a/CHANGES/2026-08-12-session-activity-indicator/WORKSTEPS.md
+++ b/CHANGES/2026-08-12-session-activity-indicator/WORKSTEPS.md
@@ -6,11 +6,11 @@
 - [x] Create the change directory and lifecycle record
 - [x] Brainstorm to work, or bypass because the work is simple or obvious; do not mark complete until the developer confirms the direction
 - [x] Record the agreed decision and TODO after the explicit decision gate
-- [ ] Prepare the implementation workspace after the planning commit
-- [ ] Implement and test
-- [ ] Mark compatibility surfaces
-- [ ] Maintain product and architecture documentation
-- [ ] Run final validation
+- [x] Prepare the implementation workspace after the planning commit
+- [x] Implement and test
+- [x] Mark compatibility surfaces
+- [x] Maintain product and architecture documentation
+- [x] Run final validation
 - [ ] Synchronize with main before submitting
 - [ ] Open and validate the PR
 - [ ] Merge with approval

--- a/CHANGES/2026-08-12-session-activity-indicator/WORKSTEPS.md
+++ b/CHANGES/2026-08-12-session-activity-indicator/WORKSTEPS.md
@@ -11,7 +11,7 @@
 - [x] Mark compatibility surfaces
 - [x] Maintain product and architecture documentation
 - [x] Run final validation
-- [ ] Synchronize with main before submitting
+- [x] Synchronize with main before submitting
 - [ ] Open and validate the PR
 - [ ] Merge with approval
 - [ ] Record outcomes and clean up

--- a/CHANGES/2026-08-12-session-activity-indicator/WORKSTEPS.md
+++ b/CHANGES/2026-08-12-session-activity-indicator/WORKSTEPS.md
@@ -12,6 +12,6 @@
 - [x] Maintain product and architecture documentation
 - [x] Run final validation
 - [x] Synchronize with main before submitting
-- [ ] Open and validate the PR
-- [ ] Merge with approval
+- [x] Open and validate the PR
+- [x] Merge with approval
 - [ ] Record outcomes and clean up

--- a/PRODUCT/relationship-between-sessions-and-environments.md
+++ b/PRODUCT/relationship-between-sessions-and-environments.md
@@ -2,6 +2,18 @@
 
 A session is one public Rook conversation backed by one ACP runtime subprocess. An environment is a context such as a website, physical location, app surface, or project directory. A session may explicitly enter multiple environments.
 
+## Session-selection activity
+
+The session-selection list displays the server-authoritative `activityStatus`:
+
+- `Active` — an ACP turn is in progress.
+- `Ready` — a turn completed successfully and has not been acknowledged.
+- `Error` — a turn failed and has not been acknowledged.
+- `On` — the runtime is alive with no pending attention.
+- `Off` — the runtime is not alive with no pending attention.
+
+The precedence is `Active` > `Ready` > `Error` > `On` > `Off`. Opening a session acknowledges `Ready` or `Error`; automatic resume does not. The visible main selection list refreshes quietly every five seconds. Chat status text and tool-call details remain separate from this pill.
+
 ## Bundle decisions
 
 The user decides on bundles, not individual capabilities. Decisions are keyed by the exact canonical content hash:

--- a/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
@@ -14,12 +14,16 @@ public struct AgentDefinition: Codable, Equatable, Identifiable {
 /// ACP session summaries plus Rook `_meta` fields, including fields this app doesn't model.
 public enum SessionSelectionStatus: String, Equatable {
     case active
+    case ready
+    case error
     case on
     case off
 
     public var label: String {
         switch self {
         case .active: return "Active"
+        case .ready: return "Ready"
+        case .error: return "Error"
         case .on: return "On"
         case .off: return "Off"
         }
@@ -38,16 +42,17 @@ public struct AgentSessionSummary: Equatable, Identifiable {
     public var supportsImagePrompts: Bool { raw["supportsImagePrompts"]?.boolValue ?? false }
     public var name: String { raw["title"]?.stringValue ?? "session" }
     public var running: Bool { raw["running"]?.boolValue ?? false }
+    public var activityStatus: SessionSelectionStatus {
+        if let value = raw["activityStatus"]?.stringValue, let status = SessionSelectionStatus(rawValue: value) {
+            return status
+        }
+        // THIS IS FOR BACKWARDS COMPATIBILITY
+        // Older servers only expose running, so retain their non-selection-derived fallback during rollout.
+        return running ? .on : .off
+    }
     public var connectedClients: Int { Int(raw["connectedClients"]?.numberValue ?? 0) }
     public var updatedAtISO: String? { raw["updatedAt"]?.stringValue }
     public var startedAtISO: String? { raw["startedAt"]?.stringValue }
-
-    public func selectionStatus(currentSessionId: String?) -> SessionSelectionStatus {
-        if running, currentSessionId == id {
-            return .active
-        }
-        return running ? .on : .off
-    }
 
     public var createdAt: Date? {
         guard let iso = startedAtISO else {
@@ -80,6 +85,7 @@ public struct AgentSessionSummary: Equatable, Identifiable {
         if let startedAt = raw["startedAt"]?.stringValue { object["startedAt"] = .string(startedAt) }
         if let supportsImagePrompts = raw["supportsImagePrompts"]?.boolValue { object["supportsImagePrompts"] = .bool(supportsImagePrompts) }
         if let connectedClients = raw["connectedClients"]?.numberValue { object["connectedClients"] = .number(connectedClients) }
+        if let activityStatus = raw["activityStatus"]?.stringValue { object["activityStatus"] = .string(activityStatus) }
         if let updatedAtISO { object["updatedAt"] = .string(updatedAtISO) }
         else if let updatedAt = raw["updatedAt"]?.stringValue { object["updatedAt"] = .string(updatedAt) }
         return AgentSessionSummary(raw: .object(object))

--- a/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
+++ b/clients/RookKit/Sources/RookKit/Models/ApiTypes.swift
@@ -43,12 +43,7 @@ public struct AgentSessionSummary: Equatable, Identifiable {
     public var name: String { raw["title"]?.stringValue ?? "session" }
     public var running: Bool { raw["running"]?.boolValue ?? false }
     public var activityStatus: SessionSelectionStatus {
-        if let value = raw["activityStatus"]?.stringValue, let status = SessionSelectionStatus(rawValue: value) {
-            return status
-        }
-        // THIS IS FOR BACKWARDS COMPATIBILITY
-        // Older servers only expose running, so retain their non-selection-derived fallback during rollout.
-        return running ? .on : .off
+        SessionSelectionStatus(rawValue: raw["activityStatus"]?.stringValue ?? "") ?? .off
     }
     public var connectedClients: Int { Int(raw["connectedClients"]?.numberValue ?? 0) }
     public var updatedAtISO: String? { raw["updatedAt"]?.stringValue }

--- a/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
+++ b/clients/RookKit/Sources/RookKit/Net/RookAPI.swift
@@ -138,6 +138,10 @@ public struct RookAPI {
         AgentSessionSummary(raw: try await postJSON(path: "api/sessions/\(sessionId)/touch", payload: .object([:])) )
     }
 
+    public func unviewSession(sessionId: String) async throws -> AgentSessionSummary {
+        AgentSessionSummary(raw: try await postJSON(path: "api/sessions/\(sessionId)/unview", payload: .object([:])) )
+    }
+
     public func deleteSession(sessionId: String) async throws {
         _ = try await deleteJSON(path: "api/sessions/\(sessionId)")
     }

--- a/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
+++ b/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
@@ -46,11 +46,6 @@ final class ApiTypesTests: XCTestCase {
         }
     }
 
-    func testAgentSessionSummaryActivityStatusFallsBackForOlderServer() {
-        XCTAssertEqual(AgentSessionSummary(raw: .object(["running": .bool(true)])).activityStatus, .on)
-        XCTAssertEqual(AgentSessionSummary(raw: .object(["running": .bool(false)])).activityStatus, .off)
-    }
-
     func testAgentSessionSummaryFieldsAreCanonical() {
         let raw = JSONValue.object([
             "sessionId": .string("s2"),

--- a/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
+++ b/clients/RookKit/Tests/RookKitTests/ApiTypesTests.swift
@@ -38,6 +38,19 @@ final class ApiTypesTests: XCTestCase {
         XCTAssertEqual(summary.connectedClients, 2)
     }
 
+    func testAgentSessionSummaryActivityStatusUsesServerValue() {
+        for (rawValue, expected) in [("active", SessionSelectionStatus.active), ("ready", .ready), ("error", .error), ("on", .on), ("off", .off)] {
+            let summary = AgentSessionSummary(raw: .object(["activityStatus": .string(rawValue)]))
+            XCTAssertEqual(summary.activityStatus, expected)
+            XCTAssertEqual(summary.activityStatus.label, rawValue.capitalized)
+        }
+    }
+
+    func testAgentSessionSummaryActivityStatusFallsBackForOlderServer() {
+        XCTAssertEqual(AgentSessionSummary(raw: .object(["running": .bool(true)])).activityStatus, .on)
+        XCTAssertEqual(AgentSessionSummary(raw: .object(["running": .bool(false)])).activityStatus, .off)
+    }
+
     func testAgentSessionSummaryFieldsAreCanonical() {
         let raw = JSONValue.object([
             "sessionId": .string("s2"),

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -2,7 +2,9 @@
 
 A native Android client at feature parity with the iOS/Mac apps — the fourth
 [Rook](../../README.md) client, speaking the same REST + ACP-over-WebSocket
-contract. No server changes required. Ported from the Swift clients in
+contract. The main session-selection list quietly polls every five seconds
+for the server-authoritative Active/Ready/Error/On/Off activity state; chat
+status remains local to the chat experience. Ported from the Swift clients in
 `clients/RookKit/` and `clients/iphone/`.
 
 ## Getting it running

--- a/clients/android/app/src/main/java/com/rookkeeper/rook/RookViewModel.kt
+++ b/clients/android/app/src/main/java/com/rookkeeper/rook/RookViewModel.kt
@@ -195,6 +195,7 @@ class RookViewModel(
     private var autoResumeAttempted = false
     private var reconnectJob: Job? = null
     private var environmentListAutoRefreshJob: Job? = null
+    private var sessionListPollingJob: Job? = null
     private var userCancelledRun = false
     // Set on any content-bearing event during the in-flight turn; checked on RunCompleted.
     // Upstream provider failures (e.g. billing/auth rejections) can come back from the
@@ -278,7 +279,7 @@ class RookViewModel(
                     _sessions.value = api.sessions().map(::AgentSessionSummary)
                 }
                 val recent = _sessions.value.firstOrNull() ?: return@launch
-                resumeSession(recent)
+                resumeSession(recent, acknowledge = false)
             } catch (_: Exception) {
             }
         }
@@ -286,18 +287,33 @@ class RookViewModel(
 
     // MARK: - Session lifecycle
 
-    fun loadSessions(agentId: String) {
+    fun loadSessions(agentId: String, showLoading: Boolean = true) {
         scope.launch {
-            _sessionsLoading.value = true
+            if (showLoading) _sessionsLoading.value = true
             try {
                 _sessions.value = api.sessions().map(::AgentSessionSummary)
                 _sessionsError.value = ""
             } catch (e: Exception) {
                 _sessionsError.value = e.message ?: "Failed to load sessions"
             } finally {
-                _sessionsLoading.value = false
+                if (showLoading) _sessionsLoading.value = false
             }
         }
+    }
+
+    fun startSessionListPolling() {
+        if (sessionListPollingJob != null) return
+        sessionListPollingJob = scope.launch {
+            while (true) {
+                delay(5_000)
+                loadSessions("", showLoading = false)
+            }
+        }
+    }
+
+    fun stopSessionListPolling() {
+        sessionListPollingJob?.cancel()
+        sessionListPollingJob = null
     }
 
     fun startNewSession(agentId: String, name: String) {
@@ -330,7 +346,7 @@ class RookViewModel(
         }
     }
 
-    fun resumeSession(session: AgentSessionSummary) {
+    fun resumeSession(session: AgentSessionSummary, acknowledge: Boolean = true) {
         scope.launch {
             _startingSession.value = true
             try {
@@ -341,8 +357,9 @@ class RookViewModel(
                 } else {
                     socket.loadSession(session.id)
                 }
-                val touched = AgentSessionSummary(api.touchSession(session.id))
-                _currentSession.value = touched
+                if (acknowledge) {
+                    _currentSession.value = AgentSessionSummary(api.touchSession(session.id))
+                }
                 _sessions.value = api.sessions().map(::AgentSessionSummary)
                 _sessions.value.firstOrNull { it.id == session.id }?.let { _currentSession.value = it }
             } catch (e: Exception) {
@@ -475,6 +492,7 @@ class RookViewModel(
     }
 
     fun leaveChat() {
+        _currentSession.value?.id?.let { sessionId -> scope.launch { runCatching { api.unviewSession(sessionId) } } }
         socket.disconnect()
         connectedSocketSessionId = null
         reconnectJob?.cancel()

--- a/clients/android/app/src/main/java/com/rookkeeper/rook/model/ApiTypes.kt
+++ b/clients/android/app/src/main/java/com/rookkeeper/rook/model/ApiTypes.kt
@@ -18,6 +18,8 @@ data class AgentDefinition(
 
 enum class SessionSelectionStatus(val label: String) {
     ACTIVE("Active"),
+    READY("Ready"),
+    ERROR("Error"),
     ON("On"),
     OFF("Off")
 }
@@ -27,13 +29,13 @@ data class AgentSessionSummary(val raw: JsonObject) {
     val agent: String get() = raw["runtimeId"]?.stringValue ?: ""
     val name: String get() = raw["title"]?.stringValue ?: "session"
     val running: Boolean get() = raw["running"]?.boolValue ?: false
+    val activityStatus: SessionSelectionStatus
+        get() = raw["activityStatus"]?.stringValue?.let { value -> SessionSelectionStatus.values().firstOrNull { it.name.lowercase() == value } }
+            // THIS IS FOR BACKWARDS COMPATIBILITY
+            // Older servers only expose running, so retain a non-selection-derived fallback during rollout.
+            ?: if (running) SessionSelectionStatus.ON else SessionSelectionStatus.OFF
     val connectedClients: Int get() = (raw["connectedClients"]?.numberValue ?: 0.0).toInt()
 
-    fun selectionStatus(currentSessionId: String?): SessionSelectionStatus = when {
-        running && currentSessionId == id -> SessionSelectionStatus.ACTIVE
-        running -> SessionSelectionStatus.ON
-        else -> SessionSelectionStatus.OFF
-    }
 
     val createdAt: Instant?
         get() = parseInstant(raw["startedAt"]?.stringValue)

--- a/clients/android/app/src/main/java/com/rookkeeper/rook/model/ApiTypes.kt
+++ b/clients/android/app/src/main/java/com/rookkeeper/rook/model/ApiTypes.kt
@@ -31,9 +31,7 @@ data class AgentSessionSummary(val raw: JsonObject) {
     val running: Boolean get() = raw["running"]?.boolValue ?: false
     val activityStatus: SessionSelectionStatus
         get() = raw["activityStatus"]?.stringValue?.let { value -> SessionSelectionStatus.values().firstOrNull { it.name.lowercase() == value } }
-            // THIS IS FOR BACKWARDS COMPATIBILITY
-            // Older servers only expose running, so retain a non-selection-derived fallback during rollout.
-            ?: if (running) SessionSelectionStatus.ON else SessionSelectionStatus.OFF
+            ?: SessionSelectionStatus.OFF
     val connectedClients: Int get() = (raw["connectedClients"]?.numberValue ?: 0.0).toInt()
 
 

--- a/clients/android/app/src/main/java/com/rookkeeper/rook/net/RookApi.kt
+++ b/clients/android/app/src/main/java/com/rookkeeper/rook/net/RookApi.kt
@@ -115,6 +115,9 @@ class RookApi(
     suspend fun touchSession(sessionId: String): JsonObject =
         postJson("api/sessions/$sessionId/touch", buildJsonObject { }).jsonObject
 
+    suspend fun unviewSession(sessionId: String): JsonObject =
+        postJson("api/sessions/$sessionId/unview", buildJsonObject { }).jsonObject
+
     suspend fun deleteSession(sessionId: String) {
         deleteJson("api/sessions/$sessionId")
     }

--- a/clients/android/app/src/main/java/com/rookkeeper/rook/ui/AgentPickerScreen.kt
+++ b/clients/android/app/src/main/java/com/rookkeeper/rook/ui/AgentPickerScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -79,6 +80,10 @@ fun SessionsHomeScreen(viewModel: RookViewModel) {
     val isRunning by viewModel.isRunning.collectAsState()
     val startingSession by viewModel.startingSession.collectAsState()
     val agentTree = remember(agents) { buildAgentTree(agents) }
+    DisposableEffect(Unit) {
+        viewModel.startSessionListPolling()
+        onDispose { viewModel.stopSessionListPolling() }
+    }
     var newSessionName by remember { mutableStateOf("") }
     var selectedRuntimeId by remember(agents) { mutableStateOf(agents.firstOrNull()?.id ?: "") }
     var sessionToRename by remember { mutableStateOf<AgentSessionSummary?>(null) }
@@ -140,7 +145,6 @@ fun SessionsHomeScreen(viewModel: RookViewModel) {
                         sessions.forEachIndexed { index, session ->
                             SessionRow(
                                 session = session,
-                                currentSessionId = currentSession?.id,
                                 enabled = !startingSession,
                                 onClick = { viewModel.resumeSession(session) },
                                 onRename = {
@@ -266,10 +270,12 @@ private fun NewChatNameField(value: String, onValueChange: (String) -> Unit, onS
 }
 
 @Composable
-private fun SessionRow(session: AgentSessionSummary, currentSessionId: String?, enabled: Boolean, onClick: () -> Unit, onRename: () -> Unit, onDelete: () -> Unit) {
-    val status = session.selectionStatus(currentSessionId)
+private fun SessionRow(session: AgentSessionSummary, enabled: Boolean, onClick: () -> Unit, onRename: () -> Unit, onDelete: () -> Unit) {
+    val status = session.activityStatus
     val statusTint = when (status) {
         SessionSelectionStatus.ACTIVE -> PanelPalette.warning
+        SessionSelectionStatus.READY -> PanelPalette.info
+        SessionSelectionStatus.ERROR -> PanelPalette.danger
         SessionSelectionStatus.ON -> PanelPalette.success
         SessionSelectionStatus.OFF -> PanelPalette.textMuted
     }

--- a/clients/iphone/README.md
+++ b/clients/iphone/README.md
@@ -40,6 +40,7 @@ binding, and bearer-token auth, start with [docs/setup.md](../../docs/setup.md).
   `AVSpeechSynthesizer` speaks the reply once the turn completes. The shared
   `VoiceController` adds an iOS `AVAudioSession` (`.playAndRecord`,
   `.spokenAudio`) so capture and playback coexist.
+- **Session activity selection pill.** The main session list quietly polls every five seconds and displays the server-authoritative Active/Ready/Error/On/Off state; per-agent session lists and chat keep their existing presentation.
 - **Live Activity / Dynamic Island.** The lock screen and Dynamic Island show
   the current place, whether skills are loaded, and the agent's status
   (idle/working) — for an active chat *or* ambiently when you're at a

--- a/clients/iphone/Sources/RookModel.swift
+++ b/clients/iphone/Sources/RookModel.swift
@@ -90,6 +90,7 @@ final class RookModel: ObservableObject {
     private var handles: [String: SessionHandle] = [:]
     private var healthTimer: Timer?
     private var environmentListAutoRefreshTask: Task<Void, Never>?
+    private var sessionListPollingTask: Task<Void, Never>?
     private var autoResumeAttempted = false
     private var blockCounter = 0
     private var enteredEnvironments: Set<String> = []
@@ -537,7 +538,7 @@ final class RookModel: ObservableObject {
         do {
             if sessions.isEmpty { sessions = try await api.sessions() }
             guard let recent = sessions.first else { return }
-            resumeSession(recent)
+            resumeSession(recent, acknowledge: false)
         } catch {
             sessionsError = error.localizedDescription
         }
@@ -546,15 +547,15 @@ final class RookModel: ObservableObject {
     func openAgentSessions(_ agentId: String) {}
     func closeAgentSessions() { selectedAgentId = nil }
 
-    func loadSessions(agentId _: String = "") async {
-        sessionsLoading = true
+    func loadSessions(agentId _: String = "", showLoading: Bool = true) async {
+        if showLoading { sessionsLoading = true }
         let timed = RookPerformance.begin(
             "iPhoneLoadSessions",
             operation: "iphone-load-sessions",
             logger: Self.logger,
             signposter: RookLog.sessionSignposter
         )
-        defer { sessionsLoading = false }
+        defer { if showLoading { sessionsLoading = false } }
         do {
             sessions = try await api.sessions()
             sessionsError = ""
@@ -622,7 +623,7 @@ final class RookModel: ObservableObject {
         }
     }
 
-    func resumeSession(_ session: AgentSessionSummary) {
+    func resumeSession(_ session: AgentSessionSummary, acknowledge: Bool = true) {
         Self.logger.info("iphone resume session=\(session.id, privacy: .public) runtime=\(session.agent, privacy: .public) running=\(session.running, privacy: .public)")
         startingSession = true
         Task {
@@ -639,8 +640,10 @@ final class RookModel: ObservableObject {
                 } else {
                     try await handle.load()
                 }
-                let touched = try await api.touchSession(sessionId: session.id)
-                currentSession = touched
+                if acknowledge {
+                    let touched = try await api.touchSession(sessionId: session.id)
+                    currentSession = touched
+                }
                 await loadSessions()
                 if let refreshed = sessions.first(where: { $0.id == session.id }) {
                     currentSession = refreshed
@@ -729,7 +732,26 @@ final class RookModel: ObservableObject {
         chatVisible = true
     }
 
+    func startSessionListPolling() {
+        guard sessionListPollingTask == nil else { return }
+        sessionListPollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                guard !Task.isCancelled, let self else { return }
+                await self.loadSessions(showLoading: false)
+            }
+        }
+    }
+
+    func stopSessionListPolling() {
+        sessionListPollingTask?.cancel()
+        sessionListPollingTask = nil
+    }
+
     func leaveChat() {
+        if let sessionId = currentSession?.id {
+            Task { try? await api.unviewSession(sessionId: sessionId) }
+        }
         for handle in handles.values { handle.close() }
         handles = [:]
         currentSession = nil

--- a/clients/iphone/Sources/Views/AgentPickerScreen.swift
+++ b/clients/iphone/Sources/Views/AgentPickerScreen.swift
@@ -73,6 +73,8 @@ struct SessionsHomeScreen: View {
         .onAppear {
             if selectedRuntimeID.isEmpty { selectedRuntimeID = model.agents.first?.id ?? "" }
         }
+        .onAppear { model.startSessionListPolling() }
+        .onDisappear { model.stopSessionListPolling() }
         .onChange(of: model.agents) { _, newValue in
             if selectedRuntimeID.isEmpty || !newValue.contains(where: { $0.id == selectedRuntimeID }) {
                 selectedRuntimeID = newValue.first?.id ?? ""
@@ -151,7 +153,7 @@ struct SessionsHomeScreen: View {
                     ForEach(Array(model.sessions.enumerated()), id: \.element.id) { index, session in
                         HStack(spacing: 8) {
                             Button { model.resumeSession(session) } label: {
-                                SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                                SessionRow(session: session)
                             }
                             .buttonStyle(.plain)
                             .disabled(model.startingSession)
@@ -241,7 +243,6 @@ struct SessionsHomeScreen: View {
 
 private struct SessionRow: View {
     let session: AgentSessionSummary
-    let currentSessionId: String?
 
     var body: some View {
         HStack(spacing: 10) {
@@ -286,12 +287,14 @@ private struct SessionRow: View {
     }
 
     private var status: SessionSelectionStatus {
-        session.selectionStatus(currentSessionId: currentSessionId)
+        session.activityStatus
     }
 
     private var statusTint: Color {
         switch status {
         case .active: return PanelPalette.warning
+        case .ready: return PanelPalette.info
+        case .error: return PanelPalette.danger
         case .on: return PanelPalette.success
         case .off: return PanelPalette.textMuted
         }
@@ -300,6 +303,8 @@ private struct SessionRow: View {
     private var statusIcon: String {
         switch status {
         case .active: return "waveform.and.mic"
+        case .ready: return "checkmark.circle.fill"
+        case .error: return "exclamationmark.circle.fill"
         case .on: return "bolt.fill"
         case .off: return "moon.zzz"
         }

--- a/clients/iphone/Sources/Views/SessionsScreen.swift
+++ b/clients/iphone/Sources/Views/SessionsScreen.swift
@@ -163,7 +163,7 @@ struct SessionsScreen: View {
                             Button {
                                 model.resumeSession(session)
                             } label: {
-                                SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                                SessionRow(session: session, showsStatus: false)
                             }
                             .buttonStyle(.plain)
                             .disabled(model.startingSession)
@@ -199,13 +199,13 @@ struct SessionsScreen: View {
 
 private struct SessionRow: View {
     let session: AgentSessionSummary
-    let currentSessionId: String?
+    var showsStatus = true
 
     var body: some View {
         HStack(spacing: 10) {
-            Image(systemName: statusIcon)
+            Image(systemName: showsStatus ? statusIcon : "bubble.left.and.bubble.right")
                 .font(.system(size: 12, weight: .bold))
-                .foregroundStyle(statusTint)
+                .foregroundStyle(showsStatus ? statusTint : PanelPalette.info)
                 .frame(width: 30, height: 30)
                 .background(
                     Circle().fill(statusTint.opacity(0.14))
@@ -227,14 +227,16 @@ private struct SessionRow: View {
 
             Spacer(minLength: 4)
 
-            Text(statusLabel)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(.white.opacity(0.95))
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(
-                    Capsule().fill(statusTint.opacity(0.25))
-                )
+            if showsStatus {
+                Text(statusLabel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.white.opacity(0.95))
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(
+                        Capsule().fill(statusTint.opacity(0.25))
+                    )
+            }
 
             Image(systemName: "chevron.right")
                 .font(.system(size: 12, weight: .bold))
@@ -245,12 +247,14 @@ private struct SessionRow: View {
     }
 
     private var status: SessionSelectionStatus {
-        session.selectionStatus(currentSessionId: currentSessionId)
+        session.activityStatus
     }
 
     private var statusTint: Color {
         switch status {
         case .active: return PanelPalette.warning
+        case .ready: return PanelPalette.info
+        case .error: return PanelPalette.danger
         case .on: return PanelPalette.success
         case .off: return PanelPalette.textMuted
         }
@@ -259,6 +263,8 @@ private struct SessionRow: View {
     private var statusIcon: String {
         switch status {
         case .active: return "waveform.and.mic"
+        case .ready: return "checkmark.circle.fill"
+        case .error: return "exclamationmark.circle.fill"
         case .on: return "bolt.fill"
         case .off: return "moon.zzz"
         }

--- a/clients/mac/README.md
+++ b/clients/mac/README.md
@@ -169,6 +169,8 @@ every 5 minutes. If it is not brought back into user-visible focus within
 4m45s, it simply falls out of the Mac cache; the server ages it out on its
 own.
 
+The main session-selection list quietly polls `GET /api/sessions` every five seconds for the server-authoritative Active/Ready/Error/On/Off pill. Per-agent session lists and chat views do not poll for or render this activity pill.
+
 Non-user timers/polls do **not** discover new environments. They are used only
 for:
 

--- a/clients/mac/Sources/Models/RookMacChatSessionController.swift
+++ b/clients/mac/Sources/Models/RookMacChatSessionController.swift
@@ -65,15 +65,15 @@ final class ChatSessionController {
         handles = [:]
     }
 
-    func loadSessions() async {
-        sessionsLoading = true
+    func loadSessions(showLoading: Bool = true) async {
+        if showLoading { sessionsLoading = true }
         let timed = RookPerformance.begin(
             "MacLoadSessions",
             operation: "mac-load-sessions",
             logger: Self.logger,
             signposter: RookLog.sessionSignposter
         )
-        defer { sessionsLoading = false }
+        defer { if showLoading { sessionsLoading = false } }
         do {
             sessions = try await api.sessions()
             sessionsError = ""
@@ -90,7 +90,7 @@ final class ChatSessionController {
         do {
             if sessions.isEmpty { sessions = try await api.sessions() }
             guard let recent = sessions.first else { return }
-            resumeSession(recent)
+            resumeSession(recent, acknowledge: false)
         } catch {
             sessionsError = error.localizedDescription
         }
@@ -143,7 +143,7 @@ final class ChatSessionController {
         }
     }
 
-    func resumeSession(_ session: AgentSessionSummary, completion: (() -> Void)? = nil) {
+    func resumeSession(_ session: AgentSessionSummary, acknowledge: Bool = true, completion: (() -> Void)? = nil) {
         Self.logger.info("chat session controller resume session=\(session.id, privacy: .public) runtime=\(session.agent, privacy: .public) running=\(session.running, privacy: .public)")
         startingSession = true
         Task {
@@ -160,8 +160,10 @@ final class ChatSessionController {
                 } else {
                     try await handle.load()
                 }
-                let touched = try await api.touchSession(sessionId: session.id)
-                currentSession = touched
+                if acknowledge {
+                    let touched = try await api.touchSession(sessionId: session.id)
+                    currentSession = touched
+                }
                 await loadSessions()
                 if let refreshed = sessions.first(where: { $0.id == session.id }) {
                     currentSession = refreshed

--- a/clients/mac/Sources/Models/RookMacModel.swift
+++ b/clients/mac/Sources/Models/RookMacModel.swift
@@ -86,6 +86,7 @@ final class RookMacModel: ObservableObject {
     private let appEnvironmentProvider: AppEnvironmentProvider
     private let environmentOfferController: EnvironmentOfferController
     private let environmentListController: EnvironmentListController
+    private var sessionListPollingTask: Task<Void, Never>?
 
     init(environmentFocusDelay: TimeInterval = 1) {
         let envBaseURL = ProcessInfo.processInfo.environment["ROOK_SERVER_BASE_URL"]?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -408,6 +409,7 @@ final class RookMacModel: ObservableObject {
         appEnvironmentProvider.stop()
         serverStateController.stop()
         environmentListController.stopAutoRefresh()
+        stopSessionListPolling()
         MacStallWatchdog.shared.stop()
         Task {
             if managedServerRunning {
@@ -421,7 +423,35 @@ final class RookMacModel: ObservableObject {
 
     func goHome() {
         stopEnvironmentListAutoRefresh()
+        unviewCurrentSession()
         panelMode = .home
+    }
+
+    func updateSessionListPolling() {
+        if panelMode == .home { startSessionListPolling() }
+        else { stopSessionListPolling() }
+    }
+
+    func startSessionListPolling() {
+        guard sessionListPollingTask == nil else { return }
+        sessionListPollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                guard !Task.isCancelled, let self else { return }
+                await self.chatSessionController.loadSessions(showLoading: false)
+                self.syncChatState()
+            }
+        }
+    }
+
+    func stopSessionListPolling() {
+        sessionListPollingTask?.cancel()
+        sessionListPollingTask = nil
+    }
+
+    private func unviewCurrentSession() {
+        guard let sessionId = currentSession?.id else { return }
+        Task { try? await api.unviewSession(sessionId: sessionId) }
     }
 
     func openEnvironments() {

--- a/clients/mac/Sources/Views/RookView.swift
+++ b/clients/mac/Sources/Views/RookView.swift
@@ -36,6 +36,7 @@ struct RookView: View {
         .environment(\.colorScheme, .dark)
         .onAppear {
             model.refreshNow()
+            model.updateSessionListPolling()
             applyWindowSizing(hostingWindow)
         }
         .onPreferenceChange(PanelContentHeightKey.self) { height in
@@ -45,6 +46,7 @@ struct RookView: View {
             applyWindowSizing(hostingWindow)
         }
         .onChange(of: model.panelMode) { _, _ in
+            model.updateSessionListPolling()
             applyWindowSizing(hostingWindow)
         }
     }
@@ -568,7 +570,7 @@ private struct HomeContent: View {
                                 Button {
                                     model.resumeSession(session)
                                 } label: {
-                                    SessionHomeRow(session: session, currentSessionId: model.currentSession?.id)
+                                    SessionHomeRow(session: session)
                                 }
                                 .buttonStyle(.plain)
                                 .pointingHandOnHover()
@@ -659,7 +661,6 @@ private struct HomeContent: View {
 
 private struct SessionHomeRow: View {
     var session: AgentSessionSummary
-    var currentSessionId: String?
 
     var body: some View {
         HStack(spacing: 9) {
@@ -707,12 +708,14 @@ private struct SessionHomeRow: View {
     }
 
     private var status: SessionSelectionStatus {
-        session.selectionStatus(currentSessionId: currentSessionId)
+        session.activityStatus
     }
 
     private var statusTint: Color {
         switch status {
         case .active: return PanelPalette.warning
+        case .ready: return PanelPalette.info
+        case .error: return PanelPalette.danger
         case .on: return PanelPalette.success
         case .off: return PanelPalette.secondaryText
         }
@@ -855,7 +858,7 @@ private struct SessionsDetail: View {
                                 Button {
                                     model.resumeSession(session)
                                 } label: {
-                                    SessionRow(session: session, currentSessionId: model.currentSession?.id)
+                                    SessionRow(session: session, showsStatus: false)
                                 }
                                 .buttonStyle(.plain)
                                 .help("Resume this session")
@@ -896,13 +899,13 @@ private struct SessionsDetail: View {
 
 private struct SessionRow: View {
     var session: AgentSessionSummary
-    var currentSessionId: String?
+    var showsStatus = true
 
     var body: some View {
         HStack(alignment: .center, spacing: 9) {
-            Image(systemName: statusIcon)
+            Image(systemName: showsStatus ? statusIcon : "bubble.left.and.bubble.right")
                 .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(statusTint)
+                .foregroundStyle(showsStatus ? statusTint : PanelPalette.info)
                 .frame(width: 22, height: 22)
                 .background(
                     Circle()
@@ -924,16 +927,18 @@ private struct SessionRow: View {
 
             Spacer(minLength: 4)
 
-            Text(statusLabel)
-                .font(.caption2)
-                .fontWeight(.semibold)
-                .foregroundColor(.white.opacity(0.96))
-                .padding(.horizontal, 6)
-                .padding(.vertical, 2)
-                .background(
-                    Capsule()
-                        .fill(statusTint.opacity(0.25))
-                )
+            if showsStatus {
+                Text(statusLabel)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white.opacity(0.96))
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(statusTint.opacity(0.25))
+                    )
+            }
         }
         .padding(.vertical, 7)
         .padding(.horizontal, 6)
@@ -942,12 +947,14 @@ private struct SessionRow: View {
     }
 
     private var status: SessionSelectionStatus {
-        session.selectionStatus(currentSessionId: currentSessionId)
+        session.activityStatus
     }
 
     private var statusTint: Color {
         switch status {
         case .active: return PanelPalette.warning
+        case .ready: return PanelPalette.info
+        case .error: return PanelPalette.danger
         case .on: return PanelPalette.success
         case .off: return PanelPalette.secondaryText
         }
@@ -956,6 +963,8 @@ private struct SessionRow: View {
     private var statusIcon: String {
         switch status {
         case .active: return "waveform.and.mic"
+        case .ready: return "checkmark.circle.fill"
+        case .error: return "exclamationmark.circle.fill"
         case .on: return "bolt.fill"
         case .off: return "moon.zzz"
         }

--- a/server/README.md
+++ b/server/README.md
@@ -84,7 +84,7 @@ For current SQLite tables and persistence ownership, see [../AS-BUILT-ARCHITECTU
 
 - `GET /api/health` — service health
 - `GET /api/agent_runtimes` — configured runtime catalog (only explicitly declared entries)
-- `GET /api/sessions` — session list + running state
+- `GET /api/sessions` — session list + running state + server-authoritative activity status (`Active`, `Ready`, `Error`, `On`, or `Off`)
 - `GET /api/sessions/:sessionId/transcript` — coalesced logical server-owned transcript hydration
 - `POST /api/session/environments` — enter/leave environments for a session
 - `POST /api/environments/register` — mark an environment available
@@ -109,7 +109,8 @@ It implements:
 - `session/set_mode`, `session/set_config_option` — ACP controls
 - `session/close` — closes a session
 - `PATCH /api/sessions/:id` — rename a session without changing its recency ordering
-- `POST /api/sessions/:id/touch` — mark a session as recently viewed so it moves to the top of the recents list even without a prompt
+- `POST /api/sessions/:id/touch` — acknowledge pending attention and mark a session as recently viewed
+- `POST /api/sessions/:id/unview` — leave the viewed session so later turn results can become pending attention
 - `DELETE /api/sessions/:id` — delete a session, its transcript, and its workspace state
 - `session/request_permission` — permission request relay
 - `_com.rookkeeper/environment_offer*` — negotiated env-offer extension
@@ -120,6 +121,7 @@ It implements:
 - Each session maps to `runtimeId` + runtime-local `runtimeSessionId` in SQLite
 - Sessions are a unified cross-runtime list ordered by `updatedAt` desc
 - `updatedAt` now represents both prompt activity and explicit client-side "viewed" touches, so opening/resuming a session moves it to the top
+- `attention_status` durably stores `clear`, `ready`, or `error`; live turn/liveness state is combined into `activityStatus` with precedence `Active` > `Ready` > `Error` > `On` > `Off`
 - Session-to-environment membership persists in `session_environments`
 - Logical transcript history persists in `session_transcript_events` so later viewers can hydrate from server state instead of forcing runtime replay; ACP chunks are merged and in-progress records are updated in place.
 

--- a/server/src/runtime/SessionRuntime.ts
+++ b/server/src/runtime/SessionRuntime.ts
@@ -54,6 +54,14 @@ export class SessionRuntime {
     private readonly logger: { info: (obj: Record<string, unknown>, msg?: string) => void; error?: (obj: Record<string, unknown>, msg?: string) => void } = console,
   ) {}
 
+  get isAlive(): boolean {
+    return this.child !== null;
+  }
+
+  get isStarted(): boolean {
+    return this.child !== null || this.started !== null;
+  }
+
   /** Builds an unstarted replacement carrying new session-only environment state. */
   replacement(configuration: SessionRuntimeConfiguration): SessionRuntime {
     return new SessionRuntime(this.profile, this.repoRoot, this.launchPlanner, configuration, this.logger);

--- a/server/src/runtime/acpFacade.test.ts
+++ b/server/src/runtime/acpFacade.test.ts
@@ -251,6 +251,25 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
   });
 
 
+  it("moves a prompted session to the front of the recency-sorted list", async () => {
+    const olderWs = await connect();
+    const newerWs = await connect();
+    await request(olderWs, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "older" } });
+    await request(newerWs, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "newer" } });
+    const older = await request(olderWs, 2, "session/new", { cwd: "/tmp", mcpServers: [], _meta: { runtimeId: "MockAcpAgent", title: "older" } });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const newer = await request(newerWs, 2, "session/new", { cwd: "/tmp", mcpServers: [], _meta: { runtimeId: "MockAcpAgent", title: "newer" } });
+
+    await request(olderWs, 3, "session/prompt", { sessionId: older.sessionId, prompt: [{ type: "text", text: "tell me a joke" }] });
+    const list = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((response) => response.json()) as { sessions: Array<Record<string, unknown>> };
+    expect(list.sessions[0]?.sessionId).toBe(older.sessionId);
+
+    await request(olderWs, 4, "session/close", { sessionId: older.sessionId });
+    await request(newerWs, 3, "session/close", { sessionId: newer.sessionId });
+    olderWs.close();
+    newerWs.close();
+  });
+
   it("materializes approved environment skills during an environment restart", async () => {
     const ws = await connect();
     await request(ws, 1, "initialize", { protocolVersion: 1, clientCapabilities: {}, clientInfo: { name: "materializer-test" } });

--- a/server/src/runtime/acpFacade.test.ts
+++ b/server/src/runtime/acpFacade.test.ts
@@ -213,7 +213,38 @@ describe("ACP facade integration", { timeout: 30000 }, () => {
 
     const listResponse = await fetch(`http://127.0.0.1:${PORT}/api/sessions`);
     const list = await listResponse.json() as { sessions: Array<Record<string, unknown>> };
-    expect(list.sessions.some((session) => session.sessionId === sessionId)).toBe(true);
+    const listed = list.sessions.find((session) => session.sessionId === sessionId);
+    expect(listed?.activityStatus).toBe("ready");
+
+    const touched = await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionId}/touch`, { method: "POST" }).then((response) => response.json()) as Record<string, unknown>;
+    expect(touched.activityStatus).toBe("on");
+
+    send(ws, 5, "session/prompt", {
+      sessionId,
+      prompt: [{ type: "text", text: "long task" }],
+    });
+    let activeStatus = "";
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const activeList = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((response) => response.json()) as { sessions: Array<Record<string, unknown>> };
+      activeStatus = String(activeList.sessions.find((session) => session.sessionId === sessionId)?.activityStatus ?? "");
+      if (activeStatus === "active") break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(activeStatus).toBe("active");
+    while (true) {
+      const message = await recv(ws);
+      if (message.id === "5") break;
+    }
+
+    const unviewed = await fetch(`http://127.0.0.1:${PORT}/api/sessions/${sessionId}/unview`, { method: "POST" }).then((response) => response.json()) as Record<string, unknown>;
+    expect(unviewed.activityStatus).toBe("on");
+
+    await expect(request(ws, 5, "session/prompt", {
+      sessionId,
+      prompt: [{ type: "text", text: "boom" }],
+    })).rejects.toThrow("boom");
+    const failedList = await fetch(`http://127.0.0.1:${PORT}/api/sessions`).then((response) => response.json()) as { sessions: Array<Record<string, unknown>> };
+    expect(failedList.sessions.find((session) => session.sessionId === sessionId)?.activityStatus).toBe("error");
 
     await request(ws, 6, "session/close", { sessionId });
     ws.close();

--- a/server/src/runtime/services/AgentRuntimeManager.ts
+++ b/server/src/runtime/services/AgentRuntimeManager.ts
@@ -1,12 +1,14 @@
 import type { AgentRuntimeProfile } from "../../infrastructure/config/agentRuntimes.js";
 import type { EnvironmentManager } from "../../environments/services/EnvironmentManager.js";
 import type { EnvironmentBundleOffer, EnvironmentEventListener, EnvironmentResolution } from "../../environments/support/types.js";
-import type { SessionRecord, SessionRepository } from "../../sessions/repositories/SessionRepository.js";
+import type { SessionAttentionStatus, SessionRecord, SessionRepository } from "../../sessions/repositories/SessionRepository.js";
 import { SessionRuntime, type JsonObject, type JsonRpcMessage, type RuntimeNotification, type SessionRuntimeConfiguration } from "../SessionRuntime.js";
 import { runtimeLaunchPlan, runtimeSessionParams } from "../runtimeLaunchPlan.js";
 import { SessionTranscriptRepository } from "../../sessions/repositories/SessionTranscriptRepository.js";
 import { normalizedEventsFromRuntimeMessage, runCompletedEvent, runFailedEvent } from "../../sessions/services/sessionTranscriptEvents.js";
 import { CapabilityWorkspaceManager, type CapabilityWorkspaceResult } from "../CapabilityWorkspaceManager.js";
+
+export type SessionActivityStatus = "active" | "ready" | "error" | "on" | "off";
 
 /**
  * Owns the configured runtime catalog and lazily creates one isolated
@@ -16,6 +18,8 @@ import { CapabilityWorkspaceManager, type CapabilityWorkspaceResult } from "../C
 export class AgentRuntimeManager {
   private readonly profilesById: Map<string, AgentRuntimeProfile>;
   private readonly sessionRuntimes = new Map<string, SessionRuntime>();
+  private readonly activeTurns = new Map<string, number>();
+  private readonly viewedSessions = new Set<string>();
   private readonly subscribers = new Map<string, Map<RuntimeNotification, { environmentOffers: boolean }>>();
   private readonly unresolvedOffers = new Map<string, Map<string, EnvironmentBundleOffer>>();
   private readonly runtimeSubscriptions = new Map<string, () => void>();
@@ -91,7 +95,21 @@ export class AgentRuntimeManager {
     await this.requireSession(sessionId);
     const updatedAt = new Date().toISOString();
     await this.sessions.touch(sessionId, updatedAt);
+    await this.sessions.setAttentionStatus(sessionId, "clear");
+    this.viewedSessions.add(sessionId);
     return await this.requireSession(sessionId);
+  }
+
+  async unviewSession(sessionId: string): Promise<void> {
+    await this.requireSession(sessionId);
+    this.viewedSessions.delete(sessionId);
+  }
+
+  activityStatus(sessionId: string, record?: SessionRecord): SessionActivityStatus {
+    if ((this.activeTurns.get(sessionId) ?? 0) > 0) return "active";
+    const attentionStatus = record?.attentionStatus ?? "clear";
+    if (attentionStatus === "ready" || attentionStatus === "error") return attentionStatus;
+    return this.sessionHasRuntime(sessionId) ? "on" : "off";
   }
 
   async createSession(runtimeId: string, params: JsonObject, title: string): Promise<SessionRecord> {
@@ -114,6 +132,7 @@ export class AgentRuntimeManager {
       cwd: workspace.root,
       startedAt: now,
       updatedAt: now,
+      attentionStatus: "clear",
     };
     await this.sessions.save(record);
     this.attachSessionRuntime(record.sessionId, runtime);
@@ -138,13 +157,17 @@ export class AgentRuntimeManager {
         ? { cwd: record.cwd, mcpServers: [], ...params, sessionId: record.runtimeSessionId }
         : { ...params, sessionId: record.runtimeSessionId };
     const privateReplay = method === "session/load" && options.privateReplayListener;
+    const isPrompt = method === "session/prompt";
     if (privateReplay) this.beginPrivateReplay(sessionId, options.privateReplayListener!);
+    if (isPrompt) this.beginTurn(sessionId);
+    let promptOutcome: SessionAttentionStatus | undefined;
     try {
       const result = await runtime.request(method, runtimeSessionParams(runtime.profile, runtimeParams, runtime.configuration));
       if (method === "session/prompt") {
         const stopReason = typeof (result as JsonObject | undefined)?.stopReason === "string" ? String((result as JsonObject).stopReason) : "end_turn";
         await this.transcriptRepository?.append(sessionId, runCompletedEvent(stopReason));
         await this.workspaceManager.assessAndFlush();
+        promptOutcome = "ready";
       }
       await this.sessions.touch(sessionId);
       this.timingLog("request_complete", {
@@ -155,8 +178,9 @@ export class AgentRuntimeManager {
       });
       return rewriteResultSessionId(record, result);
     } catch (error) {
-      if (method === "session/prompt") {
+      if (isPrompt) {
         await this.transcriptRepository?.append(sessionId, runFailedEvent(error instanceof Error ? error.message : String(error)));
+        promptOutcome = "error";
       }
       this.timingLog("request_failed", {
         method,
@@ -167,6 +191,7 @@ export class AgentRuntimeManager {
       });
       throw error;
     } finally {
+      if (isPrompt) await this.finishTurn(sessionId, promptOutcome ?? "error");
       if (privateReplay) await this.endPrivateReplayAfterQuiet(sessionId);
     }
   }
@@ -276,7 +301,7 @@ export class AgentRuntimeManager {
   }
 
   sessionHasRuntime(sessionId: string): boolean {
-    return this.sessionRuntimes.has(sessionId);
+    return this.sessionRuntimes.get(sessionId)?.isAlive === true;
   }
 
   async close(): Promise<void> {
@@ -286,6 +311,8 @@ export class AgentRuntimeManager {
     await Promise.all([...this.sessionRuntimes.values()].map((runtime) => runtime.close()));
     await Promise.all([...this.workspaceResults.keys()].map((sessionId) => this.workspaceManager.removeSession(sessionId)));
     this.sessionRuntimes.clear();
+    this.activeTurns.clear();
+    this.viewedSessions.clear();
     this.inboundRequestRoutes.clear();
     if (this.environmentManager) {
       for (const sessionId of this.environmentSubscriptions) this.environmentManager.unsubscribe(sessionId);
@@ -299,13 +326,14 @@ export class AgentRuntimeManager {
 
   private runtimeFor(record: SessionRecord): SessionRuntime {
     const existing = this.sessionRuntimes.get(record.sessionId);
-    if (existing) return existing;
+    if (existing?.isStarted) return existing;
     const workspace = this.workspaceResults.get(record.sessionId);
     const runtime = this.createSessionRuntime(this.requireProfile(record.runtimeId), {
       ...this.baseRuntimeConfiguration(),
       ...(workspace ? { workspaceRoot: workspace.root } : {}),
     });
-    this.attachSessionRuntime(record.sessionId, runtime);
+    if (existing) this.replaceSessionRuntime(record.sessionId, runtime);
+    else this.attachSessionRuntime(record.sessionId, runtime);
     this.subscribeToEnvironments(record.sessionId);
     return runtime;
   }
@@ -355,6 +383,8 @@ export class AgentRuntimeManager {
     this.runtimeSubscriptions.get(sessionId)?.();
     this.runtimeSubscriptions.delete(sessionId);
     this.sessionRuntimes.delete(sessionId);
+    this.activeTurns.delete(sessionId);
+    this.viewedSessions.delete(sessionId);
     this.subscribers.delete(sessionId);
     this.privateReplayTargets.delete(sessionId);
     const timer = this.privateReplayIdleTimers.get(sessionId);
@@ -478,6 +508,20 @@ export class AgentRuntimeManager {
       }
       this.bumpPrivateReplayIdle(sessionId);
     });
+  }
+
+  private beginTurn(sessionId: string): void {
+    this.activeTurns.set(sessionId, (this.activeTurns.get(sessionId) ?? 0) + 1);
+  }
+
+  private async finishTurn(sessionId: string, outcome: SessionAttentionStatus): Promise<void> {
+    const remaining = (this.activeTurns.get(sessionId) ?? 1) - 1;
+    if (remaining > 0) {
+      this.activeTurns.set(sessionId, remaining);
+      return;
+    }
+    this.activeTurns.delete(sessionId);
+    await this.sessions.setAttentionStatus(sessionId, this.viewedSessions.has(sessionId) ? "clear" : outcome);
   }
 
   private async captureTranscriptEvents(sessionId: string, message: JsonRpcMessage): Promise<void> {

--- a/server/src/runtime/services/AgentRuntimeManager.ts
+++ b/server/src/runtime/services/AgentRuntimeManager.ts
@@ -159,7 +159,10 @@ export class AgentRuntimeManager {
     const privateReplay = method === "session/load" && options.privateReplayListener;
     const isPrompt = method === "session/prompt";
     if (privateReplay) this.beginPrivateReplay(sessionId, options.privateReplayListener!);
-    if (isPrompt) this.beginTurn(sessionId);
+    if (isPrompt) {
+      await this.sessions.touch(sessionId);
+      this.beginTurn(sessionId);
+    }
     let promptOutcome: SessionAttentionStatus | undefined;
     try {
       const result = await runtime.request(method, runtimeSessionParams(runtime.profile, runtimeParams, runtime.configuration));

--- a/server/src/sessions/repositories/SessionRepository.ts
+++ b/server/src/sessions/repositories/SessionRepository.ts
@@ -1,3 +1,5 @@
+export type SessionAttentionStatus = "clear" | "ready" | "error";
+
 export interface SessionRecord {
   sessionId: string;
   runtimeId: string;
@@ -6,6 +8,7 @@ export interface SessionRecord {
   cwd: string;
   startedAt: string;
   updatedAt: string;
+  attentionStatus: SessionAttentionStatus;
 }
 
 export interface SessionRepository {
@@ -14,6 +17,7 @@ export interface SessionRepository {
   save(record: SessionRecord): Promise<void>;
   rename(sessionId: string, title: string): Promise<void>;
   touch(sessionId: string, updatedAt?: string): Promise<void>;
+  setAttentionStatus(sessionId: string, status: SessionAttentionStatus): Promise<void>;
   delete(sessionId: string): Promise<void>;
   environmentIds(sessionId: string): Promise<string[]>;
   replaceEnvironmentIds(sessionId: string, environmentIds: string[]): Promise<void>;

--- a/server/src/sessions/repositories/SessionTranscriptRepository.test.ts
+++ b/server/src/sessions/repositories/SessionTranscriptRepository.test.ts
@@ -21,6 +21,7 @@ async function makeRepository(): Promise<SessionTranscriptRepository> {
     cwd: "/tmp",
     startedAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
+    attentionStatus: "clear",
   });
   transcripts = new SessionTranscriptRepository(datastore);
   return transcripts;

--- a/server/src/sessions/repositories/SqliteSessionRepository.test.ts
+++ b/server/src/sessions/repositories/SqliteSessionRepository.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { RookDatastore } from "../../infrastructure/datastores/RookDatastore.js";
 import { SqliteSessionRepository } from "./SqliteSessionRepository.js";
 
 describe("SqliteSessionRepository", () => {
   it("persists and orders the unified public session space by update time", async () => {
-    const repository = new SqliteSessionRepository(":memory:");
+    const datastore = new RookDatastore(":memory:");
+    const repository = new SqliteSessionRepository(datastore);
     await repository.save({
       sessionId: "Pi:pi-1",
       runtimeId: "Pi",
@@ -12,6 +14,7 @@ describe("SqliteSessionRepository", () => {
       cwd: "/tmp",
       startedAt: "2026-01-01T00:00:00.000Z",
       updatedAt: "2026-01-01T00:00:00.000Z",
+      attentionStatus: "clear",
     });
     await repository.save({
       sessionId: "Claude:claude-1",
@@ -21,6 +24,7 @@ describe("SqliteSessionRepository", () => {
       cwd: "/tmp",
       startedAt: "2026-01-02T00:00:00.000Z",
       updatedAt: "2026-01-03T00:00:00.000Z",
+      attentionStatus: "clear",
     });
 
     expect((await repository.list()).map((session) => session.sessionId)).toEqual(["Claude:claude-1", "Pi:pi-1"]);
@@ -35,9 +39,14 @@ describe("SqliteSessionRepository", () => {
     await repository.replaceEnvironmentIds("Pi:pi-1", ["web:example.com", "location:target"]);
     expect(new Set(await repository.environmentIds("Pi:pi-1"))).toEqual(new Set(["web:example.com", "location:target"]));
 
+    await repository.setAttentionStatus("Pi:pi-1", "ready");
+    expect((await repository.get("Pi:pi-1"))?.attentionStatus).toBe("ready");
+    expect(() => datastore.db.prepare("UPDATE sessions SET attention_status = 'invalid'").run()).toThrow();
+
     await repository.delete("Pi:pi-1");
     expect(await repository.get("Pi:pi-1")).toBeUndefined();
     expect(await repository.environmentIds("Pi:pi-1")).toEqual([]);
     repository.close();
+    datastore.close();
   });
 });

--- a/server/src/sessions/repositories/SqliteSessionRepository.ts
+++ b/server/src/sessions/repositories/SqliteSessionRepository.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
-import type { SessionRecord, SessionRepository } from "./SessionRepository.js";
+import type { SessionAttentionStatus, SessionRecord, SessionRepository } from "./SessionRepository.js";
 import { RookDatastore } from "../../infrastructure/datastores/RookDatastore.js";
 
 /** SQLite repository for the unified public session space. */
@@ -24,6 +24,7 @@ export class SqliteSessionRepository implements SessionRepository {
         cwd TEXT NOT NULL,
         started_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
+        attention_status TEXT NOT NULL DEFAULT 'clear' CHECK (attention_status IN ('clear', 'ready', 'error')),
         UNIQUE(runtime_id, runtime_session_id)
       );
       CREATE INDEX IF NOT EXISTS sessions_updated_at_idx ON sessions(updated_at DESC);
@@ -34,18 +35,19 @@ export class SqliteSessionRepository implements SessionRepository {
         PRIMARY KEY (session_id, environment_id)
       );
     `);
+    this.ensureAttentionStatusColumn();
   }
 
   async list(): Promise<SessionRecord[]> {
     return this.db.prepare(`
-      SELECT session_id, runtime_id, runtime_session_id, title, cwd, started_at, updated_at
+      SELECT session_id, runtime_id, runtime_session_id, title, cwd, started_at, updated_at, attention_status
       FROM sessions ORDER BY updated_at DESC, started_at DESC, session_id DESC
     `).all().map(rowToRecord);
   }
 
   async get(sessionId: string): Promise<SessionRecord | undefined> {
     const row = this.db.prepare(`
-      SELECT session_id, runtime_id, runtime_session_id, title, cwd, started_at, updated_at
+      SELECT session_id, runtime_id, runtime_session_id, title, cwd, started_at, updated_at, attention_status
       FROM sessions WHERE session_id = ?
     `).get(sessionId);
     return row ? rowToRecord(row) : undefined;
@@ -53,8 +55,8 @@ export class SqliteSessionRepository implements SessionRepository {
 
   async save(record: SessionRecord): Promise<void> {
     this.db.prepare(`
-      INSERT INTO sessions (session_id, runtime_id, runtime_session_id, title, cwd, started_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO sessions (session_id, runtime_id, runtime_session_id, title, cwd, started_at, updated_at, attention_status)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(session_id) DO UPDATE SET
         runtime_id = excluded.runtime_id,
         runtime_session_id = excluded.runtime_session_id,
@@ -62,7 +64,7 @@ export class SqliteSessionRepository implements SessionRepository {
         cwd = excluded.cwd,
         started_at = excluded.started_at,
         updated_at = excluded.updated_at
-    `).run(record.sessionId, record.runtimeId, record.runtimeSessionId, record.title, record.cwd, record.startedAt, record.updatedAt);
+    `).run(record.sessionId, record.runtimeId, record.runtimeSessionId, record.title, record.cwd, record.startedAt, record.updatedAt, record.attentionStatus ?? "clear");
   }
 
   async rename(sessionId: string, title: string): Promise<void> {
@@ -71,6 +73,10 @@ export class SqliteSessionRepository implements SessionRepository {
 
   async touch(sessionId: string, updatedAt = new Date().toISOString()): Promise<void> {
     this.db.prepare("UPDATE sessions SET updated_at = ? WHERE session_id = ?").run(updatedAt, sessionId);
+  }
+
+  async setAttentionStatus(sessionId: string, status: SessionAttentionStatus): Promise<void> {
+    this.db.prepare("UPDATE sessions SET attention_status = ? WHERE session_id = ?").run(status, sessionId);
   }
 
   async delete(sessionId: string): Promise<void> {
@@ -102,6 +108,14 @@ export class SqliteSessionRepository implements SessionRepository {
   close(): void {
     this.ownedDatastore?.close();
   }
+
+  private ensureAttentionStatusColumn(): void {
+    // THIS IS FOR BACKWARDS COMPATIBILITY
+    // Existing application databases predate attention_status and receive the clear default in place.
+    const columns = this.db.prepare("PRAGMA table_info(sessions)").all() as Array<Record<string, unknown>>;
+    if (columns.some((column) => column.name === "attention_status")) return;
+    this.db.exec("ALTER TABLE sessions ADD COLUMN attention_status TEXT NOT NULL DEFAULT 'clear' CHECK (attention_status IN ('clear', 'ready', 'error'))");
+  }
 }
 
 function rowToRecord(row: unknown): SessionRecord {
@@ -114,5 +128,10 @@ function rowToRecord(row: unknown): SessionRecord {
     cwd: String(value.cwd),
     startedAt: String(value.started_at),
     updatedAt: String(value.updated_at),
+    attentionStatus: normalizeAttentionStatus(value.attention_status),
   };
+}
+
+function normalizeAttentionStatus(value: unknown): SessionAttentionStatus {
+  return value === "ready" || value === "error" ? value : "clear";
 }

--- a/server/src/sessions/repositories/SqliteSessionRepository.ts
+++ b/server/src/sessions/repositories/SqliteSessionRepository.ts
@@ -64,7 +64,7 @@ export class SqliteSessionRepository implements SessionRepository {
         cwd = excluded.cwd,
         started_at = excluded.started_at,
         updated_at = excluded.updated_at
-    `).run(record.sessionId, record.runtimeId, record.runtimeSessionId, record.title, record.cwd, record.startedAt, record.updatedAt, record.attentionStatus ?? "clear");
+    `).run(record.sessionId, record.runtimeId, record.runtimeSessionId, record.title, record.cwd, record.startedAt, record.updatedAt, record.attentionStatus);
   }
 
   async rename(sessionId: string, title: string): Promise<void> {
@@ -110,8 +110,6 @@ export class SqliteSessionRepository implements SessionRepository {
   }
 
   private ensureAttentionStatusColumn(): void {
-    // THIS IS FOR BACKWARDS COMPATIBILITY
-    // Existing application databases predate attention_status and receive the clear default in place.
     const columns = this.db.prepare("PRAGMA table_info(sessions)").all() as Array<Record<string, unknown>>;
     if (columns.some((column) => column.name === "attention_status")) return;
     this.db.exec("ALTER TABLE sessions ADD COLUMN attention_status TEXT NOT NULL DEFAULT 'clear' CHECK (attention_status IN ('clear', 'ready', 'error'))");

--- a/server/src/sessions/routes/sessionRoutes.ts
+++ b/server/src/sessions/routes/sessionRoutes.ts
@@ -46,8 +46,6 @@ export async function registerSessionRoutes(app: FastifyInstance, runtimeManager
     const events = await transcriptRepository.list(sessionId);
     return {
       sessionId,
-      // THIS IS FOR BACKWARDS COMPATIBILITY
-      // Keep the legacy transcript liveness field alongside activityStatus.
       running: runtimeManager.sessionHasRuntime(sessionId),
       activityStatus: runtimeManager.activityStatus(sessionId, record),
       events: events.map((item) => ({ sequence: item.sequence, createdAt: item.createdAt, ...item.event })),
@@ -73,8 +71,6 @@ function serializeSession(record: SessionRecord, runtimeManager: AgentRuntimeMan
     runtimeId: record.runtimeId,
     startedAt: record.startedAt,
     updatedAt: record.updatedAt,
-    // THIS IS FOR BACKWARDS COMPATIBILITY
-    // Keep the legacy liveness boolean while clients migrate to activityStatus.
     running: runtimeManager.sessionHasRuntime(record.sessionId),
     activityStatus: runtimeManager.activityStatus(record.sessionId, record),
     supportsImagePrompts: runtimeManager.supportsImagePrompts(record.runtimeId),

--- a/server/src/sessions/routes/sessionRoutes.ts
+++ b/server/src/sessions/routes/sessionRoutes.ts
@@ -22,6 +22,13 @@ export async function registerSessionRoutes(app: FastifyInstance, runtimeManager
     return serializeSession(record, runtimeManager);
   });
 
+  app.post<{ Params: { sessionId: string } }>("/api/sessions/:sessionId/unview", async (request, reply) => {
+    if (!await ensureSessionExists(runtimeManager, request.params.sessionId, reply)) return;
+    await runtimeManager.unviewSession(request.params.sessionId);
+    const record = await runtimeManager.getSession(request.params.sessionId);
+    return serializeSession(record, runtimeManager);
+  });
+
   app.delete<{ Params: { sessionId: string } }>("/api/sessions/:sessionId", async (request, reply) => {
     if (!await ensureSessionExists(runtimeManager, request.params.sessionId, reply)) return;
     await runtimeManager.deleteSession(request.params.sessionId);
@@ -39,7 +46,10 @@ export async function registerSessionRoutes(app: FastifyInstance, runtimeManager
     const events = await transcriptRepository.list(sessionId);
     return {
       sessionId,
+      // THIS IS FOR BACKWARDS COMPATIBILITY
+      // Keep the legacy transcript liveness field alongside activityStatus.
       running: runtimeManager.sessionHasRuntime(sessionId),
+      activityStatus: runtimeManager.activityStatus(sessionId, record),
       events: events.map((item) => ({ sequence: item.sequence, createdAt: item.createdAt, ...item.event })),
     };
   });
@@ -63,7 +73,10 @@ function serializeSession(record: SessionRecord, runtimeManager: AgentRuntimeMan
     runtimeId: record.runtimeId,
     startedAt: record.startedAt,
     updatedAt: record.updatedAt,
+    // THIS IS FOR BACKWARDS COMPATIBILITY
+    // Keep the legacy liveness boolean while clients migrate to activityStatus.
     running: runtimeManager.sessionHasRuntime(record.sessionId),
+    activityStatus: runtimeManager.activityStatus(record.sessionId, record),
     supportsImagePrompts: runtimeManager.supportsImagePrompts(record.runtimeId),
   };
 }


### PR DESCRIPTION
## Summary
- add server-authoritative session activity states: Active, Ready, Error, On, and Off
- persist pending session attention in SQLite and acknowledge it when a session is opened
- show activity pills and quietly refresh only the main session-selection page
- update prompt recency before processing so externally triggered sessions sort correctly
- update Mac, iPhone, Android, RookKit, architecture, product, and package documentation

## Validation
- `server`: typecheck and focused/full Vitest validation passed
- `clients/RookKit`: `swift test` passed
- Mac app build passed
- iPhone simulator build passed
- Android validation was unavailable because Java was not installed
