### PR TITLE
Fix Mac session pinning drop feedback

### DIFF
--- a/CHANGES/2026-08-19-session-pinning-drop-targets/TODO.md
+++ b/CHANGES/2026-08-19-session-pinning-drop-targets/TODO.md
@@ -13,7 +13,7 @@ Make dragging the first session into an empty Pinned section easy to target and 
 
 ## Work checklist
 
-- [ ] Expand the empty Pinned section drop target.
-- [ ] Clear stale insertion indicators after pinning/reordering.
-- [ ] Update relevant Mac documentation if needed.
-- [ ] Build and validate the Mac client and inspect the final diff.
+- [x] Expand the empty Pinned section drop target.
+- [x] Clear stale insertion indicators after pinning/reordering.
+- [x] Review relevant Mac documentation; existing drag/drop behavior documentation remains accurate.
+- [x] Build and validate the Mac client and inspect the final diff.

--- a/CHANGES/2026-08-19-session-pinning-drop-targets/TODO.md
+++ b/CHANGES/2026-08-19-session-pinning-drop-targets/TODO.md
@@ -7,7 +7,7 @@ Make dragging the first session into an empty Pinned section easy to target and 
 ## Decision details
 
 - Treat the whole empty Pinned section, including its header and empty-state area, as the drop target for pinning.
-- Clear the Mac drag/drop target state whenever a drag establishes a pin or completes a pinned reorder.
+- Clear the Mac drag/drop target state whenever a drag establishes a pin or completes a pinned reorder, and ignore late hover updates after the drag source state is cleared.
 - Keep existing insertion-line behavior while a drag is active and preserve current Recent/unpin behavior.
 - This is a focused Mac UI fix; no changes to server ordering semantics or mobile clients.
 

--- a/CHANGES/2026-08-19-session-pinning-drop-targets/WORKSTEPS.md
+++ b/CHANGES/2026-08-19-session-pinning-drop-targets/WORKSTEPS.md
@@ -12,6 +12,6 @@
 - [x] Maintain product and architecture documentation — existing Mac drag/drop documentation remains accurate; no product or architecture change
 - [x] Run final validation — Mac build passed and final diff is whitespace-clean
 - [x] Synchronize with main before submitting — fetched origin and merged origin/main; branch is up to date
-- [ ] Open and validate the PR
+- [x] Open and validate the PR — PR #165 is mergeable and required checks pass
 - [ ] Merge with approval
 - [ ] Record outcomes and clean up

--- a/CHANGES/2026-08-19-session-pinning-drop-targets/WORKSTEPS.md
+++ b/CHANGES/2026-08-19-session-pinning-drop-targets/WORKSTEPS.md
@@ -11,7 +11,7 @@
 - [x] Mark compatibility surfaces — no compatibility surface retained by this focused UI change
 - [x] Maintain product and architecture documentation — existing Mac drag/drop documentation remains accurate; no product or architecture change
 - [x] Run final validation — Mac build passed and final diff is whitespace-clean
-- [ ] Synchronize with main before submitting
+- [x] Synchronize with main before submitting — fetched origin and merged origin/main; branch is up to date
 - [ ] Open and validate the PR
 - [ ] Merge with approval
 - [ ] Record outcomes and clean up

--- a/CHANGES/2026-08-19-session-pinning-drop-targets/WORKSTEPS.md
+++ b/CHANGES/2026-08-19-session-pinning-drop-targets/WORKSTEPS.md
@@ -6,11 +6,11 @@
 - [x] Create the change directory and lifecycle record
 - [x] Brainstorm bypassed because this is a focused, obvious UI regression fix confirmed by the developer
 - [x] Record the agreed decision and TODO after the explicit decision gate
-- [ ] Prepare the implementation workspace after the planning commit
-- [ ] Implement and test
-- [ ] Mark compatibility surfaces
-- [ ] Maintain product and architecture documentation
-- [ ] Run final validation
+- [x] Prepare the implementation workspace after the planning commit
+- [x] Implement and test — expanded the empty Pinned drop target and clear drag state after pin/reorder
+- [x] Mark compatibility surfaces — no compatibility surface retained by this focused UI change
+- [x] Maintain product and architecture documentation — existing Mac drag/drop documentation remains accurate; no product or architecture change
+- [x] Run final validation — Mac build passed and final diff is whitespace-clean
 - [ ] Synchronize with main before submitting
 - [ ] Open and validate the PR
 - [ ] Merge with approval

--- a/clients/mac/Sources/Views/RookView.swift
+++ b/clients/mac/Sources/Views/RookView.swift
@@ -663,17 +663,22 @@ private struct MacSessionSections: View {
     var body: some View {
         ScrollView(.vertical) {
             VStack(alignment: .leading, spacing: 6) {
-                sectionHeader("Pinned", systemImage: "pin.fill")
                 if pinned.isEmpty {
-                    Text("Pin a session to keep it here.")
-                        .font(.caption)
-                        .foregroundStyle(PanelPalette.textMuted)
-                        .frame(maxWidth: .infinity, minHeight: 42)
-                        .background(RoundedRectangle(cornerRadius: 8).fill(PanelPalette.backgroundPrimary.opacity(0.35)))
-                        .onDrop(of: [.text], delegate: SessionDropDelegate(onTargetChanged: { _, _ in clearDropTarget() }) { id, _ in
-                            pin(id, moveToRecent: false)
-                        })
+                    VStack(alignment: .leading, spacing: 6) {
+                        sectionHeader("Pinned", systemImage: "pin.fill")
+                        Text("Pin a session to keep it here.")
+                            .font(.caption)
+                            .foregroundStyle(PanelPalette.textMuted)
+                            .frame(maxWidth: .infinity, minHeight: 72)
+                            .background(RoundedRectangle(cornerRadius: 8).fill(PanelPalette.backgroundPrimary.opacity(0.35)))
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contentShape(Rectangle())
+                    .onDrop(of: [.text], delegate: SessionDropDelegate(onTargetChanged: { _, _ in clearDropTarget() }) { id, _ in
+                        pin(id, moveToRecent: false)
+                    })
                 } else {
+                    sectionHeader("Pinned", systemImage: "pin.fill")
                     sessionRows(pinned, allowsReordering: true)
                 }
                 sectionHeader("Recent", systemImage: "clock.arrow.circlepath")
@@ -770,16 +775,20 @@ private struct MacSessionSections: View {
         dropTarget = nil
     }
 
+    private func clearDragState() {
+        draggedSessionID = nil
+        dropTarget = nil
+    }
+
     private func pin(_ id: String, moveToRecent: Bool) {
         model.setSessionPinned(model.sessions.first { $0.id == id } ?? AgentSessionSummary(raw: .object(["sessionId": .string(id)])), pinned: !moveToRecent, moveToRecent: moveToRecent)
-        draggedSessionID = nil
+        clearDragState()
     }
 
     private func unpinIfPinned(_ id: String) {
         guard let session = model.sessions.first(where: { $0.id == id }), session.pinned else { return }
         model.setSessionPinned(session, pinned: false, moveToRecent: true)
-        draggedSessionID = nil
-        dropTarget = nil
+        clearDragState()
     }
 
     private func handlePinnedDrop(_ id: String, before targetID: String?, after: Bool) {
@@ -793,7 +802,7 @@ private struct MacSessionSections: View {
                 nextID = targetID
             }
             model.pinSessionInPinned(source, before: nextID)
-            draggedSessionID = nil
+            clearDragState()
         }
     }
 
@@ -806,7 +815,7 @@ private struct MacSessionSections: View {
             reordered.append(source)
         }
         model.reorderPinnedSessions(reordered)
-        draggedSessionID = nil
+        clearDragState()
     }
 }
 

--- a/clients/mac/Sources/Views/RookView.swift
+++ b/clients/mac/Sources/Views/RookView.swift
@@ -764,6 +764,7 @@ private struct MacSessionSections: View {
     }
 
     private func updateDropTarget(_ sessionID: String?, after: Bool) {
+        guard draggedSessionID != nil else { return }
         guard let sessionID else {
             dropTarget = nil
             return


### PR DESCRIPTION
## Summary

- Expand the empty Pinned section into a full-width, larger drop target that includes the section header and empty-state card.
- Clear the drag/drop state immediately when a session is pinned, unpinned, or reordered so insertion indicators cannot remain after the drop completes.
- Preserve existing pinned insertion-line behavior while dragging.

## Validation

- Mac client build passed via `./scripts/run-rook.sh server mac`.
- `git diff --check` passed.

## Scope

Mac UI only; no server, mobile, or ordering-semantics changes.
